### PR TITLE
fixed drawer scroll

### DIFF
--- a/src/components/Content.svelte
+++ b/src/components/Content.svelte
@@ -96,7 +96,7 @@
           </TabBar>
         </Header>
         <Content style="padding-right: 15px; overflow: visible;">
-          <div hidden={activeTab !== TabNames.LOAD_DATA} style="overflow-y: auto; max-height: calc(100vh - 145px);">
+          <div hidden={activeTab !== TabNames.LOAD_DATA}>
             <TreeView />
           </div>
           <div hidden={activeTab !== TabNames.LAYERS}>
@@ -181,10 +181,13 @@
     flex-grow: 1;
 
     .drawer-container {
+      position: relative;
       display: flex;
       height: $height;
+      overflow: hidden;
 
       .drawer-content {
+        overflow: auto;
         display: flex;
         flex-direction: column;
         flex-basis: 100%;


### PR DESCRIPTION
@foochris Fixed scrolling of contents on the drawer.

This commit's change fixed scroll of 'load data' tab, however, layer tab still has an issue of scrolling.
https://github.com/UNDP-Data/geohub/blob/acd5bd7aabfc33f381ba78da0199b41e02d66db4/src/components/Content.svelte#L99

There is an example of drawer container in the below website.
https://sveltematerialui.com/demo/drawer/

`.drawer-container` class should be set `style:height` and other parameters.