### PR TITLE
updated heatmap style

### DIFF
--- a/src/dashboards/components/Content.svelte
+++ b/src/dashboards/components/Content.svelte
@@ -204,6 +204,7 @@
       const layerSource: GeoJSONSourceSpecification = {
         type: 'geojson',
         data: RWI_URL,
+        maxzoom: 9,
       }
       $map.addSource(RWI_ID, layerSource)
     }
@@ -213,8 +214,6 @@
         id: RWI_ID,
         type: LayerTypes.HEATMAP,
         source: RWI_ID,
-        minzoom: 0,
-        maxzoom: 22,
         layout: { visibility: 'none' },
         paint: {
           'heatmap-weight': {
@@ -223,6 +222,61 @@
             stops: [
               [-0.855, 0],
               [1.06009, 1],
+            ],
+          },
+          // use sequential color palette to use exponentially as the weight increases
+          'heatmap-color': [
+            'interpolate',
+            ['linear'],
+            ['heatmap-density'],
+            0,
+            'rgba(0,140,0,0)',
+            0.1,
+            'rgb(104,255,0)',
+            0.2,
+            'rgb(150,255,0)',
+            0.3,
+            'rgb(195,255,0)',
+            0.4,
+            'rgb(255,255,0)',
+            0.5,
+            'rgb(255,222,0)',
+            0.6,
+            'rgb(255,208,0)',
+            0.7,
+            'rgb(255,180,0)',
+            0.8,
+            'rgb(255,132,0)',
+            0.9,
+            'rgb(255,80,0)',
+            1.0,
+            'rgb(255,0,0)',
+          ],
+          // increase intensity as zoom level increases
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          'heatmap-intensity': {
+            stops: [
+              [2, 1],
+              [4, 3],
+              [6, 5],
+            ],
+          },
+          // increase radius as zoom increases
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          'heatmap-radius': {
+            stops: [
+              [0, 5],
+              [1, 15],
+              [2, 30],
+              [3, 40],
+              [4, 50],
+              [5, 60],
+              [6, 70],
+              [7, 100],
+              [8, 120],
+              [9, 140],
             ],
           },
         },


### PR DESCRIPTION
- increase `heatmap-intensity` and `heatmap-radius` when zoom level is up
- change different color map to visualise poverty. Uses color map from green, yellow to red like traffic signal.
- I found some papers use green to red color map to visualise povery in heatmap
    - https://www.mdpi.com/2220-9964/9/6/345
 
Some example of screenshots
- Z0
<img width="639" alt="image" src="https://user-images.githubusercontent.com/2639701/166945444-678a64a3-e3f5-4bd0-bcec-737cfa89ac61.png">
- Z3
<img width="639" alt="image" src="https://user-images.githubusercontent.com/2639701/166945521-b4adb304-bcc5-4979-bd05-889a84d305d3.png">
-Z5
<img width="750" alt="image" src="https://user-images.githubusercontent.com/2639701/166945584-7d14e80b-1691-42b7-b512-73e25722a9d5.png">
-Z7
<img width="750" alt="image" src="https://user-images.githubusercontent.com/2639701/166945658-9ee79ed5-5151-4a94-b9a4-a19dfb6d75e3.png">
-Z9
<img width="750" alt="image" src="https://user-images.githubusercontent.com/2639701/166945750-e7afcac9-05b0-4eeb-93e4-4b84d51d00eb.png">

The style settings will be changed up to Z9, style after Z10 will not be changed.