### PR TITLE
fix: changed visibility icons oppositely

### DIFF
--- a/src/components/controls/VisibilityButton.svelte
+++ b/src/components/controls/VisibilityButton.svelte
@@ -33,7 +33,7 @@
 
 <Wrapper>
   <div class="icon-selected" on:click={() => toggleVisibility()}>
-    <Fa icon={visibility === 'none' ? faEyeSlash : faEye} size="sm" />
+    <Fa icon={visibility === 'none' ? faEye : faEyeSlash} size="sm" />
   </div>
   <Tooltip showDelay={300} hideDelay={100} yPos="above">{isLayerVisible ? 'Show Layer' : 'Hide Layer'}</Tooltip>
 </Wrapper>


### PR DESCRIPTION
I changed visibility icons oppositely.

In [Maputnik editor](https://maputnik.github.io/editor), icon uses `eye` when the layer is visible, and it uses `eyeslash` when it is invisible. Using the same behaviour with other GIS editor can be better. Mapbox Studio also use the same behaviour with maputnik editor.

![image](https://user-images.githubusercontent.com/2639701/168037147-6e367756-8594-4ae7-bbe9-6d6e7ec08881.png)
