### PR TITLE
fix: fixed tile sources instead of using tilejson.

### DIFF
--- a/src/components/controls/AddLayerModal.svelte
+++ b/src/components/controls/AddLayerModal.svelte
@@ -24,7 +24,7 @@
   let layerIdList: string[]
   let layerType = LayerTypes.LINE
   let layerTypes = [LayerTypes.LINE, LayerTypes.FILL, LayerTypes.SYMBOL, LayerTypes.HEATMAP]
-  let selectedLayerId: string | undefined = treeNode?.label
+  let selectedLayerId: string | undefined = treeNode.isMartin ? treeNode?.path : treeNode?.label
   let tileSourceId = treeNode?.path
 
   $: {
@@ -80,9 +80,14 @@
     let layerSource: VectorSourceSpecification
     if (!$map.getSource(tileSourceId)) {
       if (treeNode.isMartin) {
+        const tilejson = await fetchUrl(treeNode.url)
+        // URL of tiles inside tileJSON from martin is http, hence we cannot use tileJSON directly because of CORS issue.
         layerSource = {
           type: LayerTypes.VECTOR,
-          url: treeNode.url,
+          scheme: tilejson.scheme,
+          tiles: tilejson.tiles.map((url) => url.replace('http', 'https')),
+          minzoom: tilejson.minzoom,
+          maxzoom: tilejson.maxzoom,
         }
       } else {
         layerSource = {


### PR DESCRIPTION
I found martin returns http URL inside tilejson. So, I changed from tileJSON to pbf format by changing http to https manually. 

https://martin.undpgeohub.org/zambia.poverty.json

```json
{
   "tilejson":"2.2.0",
   "name":"zambia.poverty",
   "version":"1.0.0",
   "scheme":"xyz",
   "tiles":[
      "http://martin.undpgeohub.org/zambia.poverty/{z}/{x}/{y}.pbf"
   ],
   "minzoom":0,
   "maxzoom":30,
   "bounds":[
      21.99937,
      -18.079473,
      33.705708,
      -8.2243595
   ]
}
```