### PR TITLE
fix: fixed propertyselect. get field list from vector_layers

### DIFF
--- a/src/components/controls/vector-styles/PropertySelect.svelte
+++ b/src/components/controls/vector-styles/PropertySelect.svelte
@@ -4,9 +4,9 @@
   export let layer
 
   const metadata = layer.info
-  const layerI = metadata.json.tilestats.layers.find((l) => l.layer === layer.definition['source-layer'])
+  const vectorLayerMeta = metadata.json.vector_layers.find((l) => l.id === layer.definition['source-layer'])
 
-  const propertySelectOptions = layerI['attributes'].map((attr) => attr.attribute)
+  const propertySelectOptions = Object.keys(vectorLayerMeta.fields)
   const dispatch = createEventDispatcher()
   let propertySelectValue: string = null
 


### PR DESCRIPTION
tilestats is not mandetory property, it is an optional attributes. So, it is better to get field list from vector_layers property. Also, there is not tilestats infomation in martin vector tiles.