### PR TITLE
fix: fix the bug where the stats is undefined in the VectorFilterExpression Creator

### DIFF
--- a/src/components/controls/vector-styles/VectorFilterExpressionCreator.svelte
+++ b/src/components/controls/vector-styles/VectorFilterExpressionCreator.svelte
@@ -107,9 +107,9 @@
           <div class="stats message is-info is-normal has-background-white mt-5 is-size-8 has-text-weight-semibold">
             <div id="stats-title" class="stats-content message-header">Statistics</div>
             <div class="stats-content">Min:</div>
-            <div class="stats-content">{propertyStats[0]}</div>
+            <div class="stats-content">{propertyStats[0] !== undefined ? propertyStats[0] : ''}</div>
             <div class="stats-content">Max:</div>
-            <div class="stats-content">{propertyStats[1]}</div>
+            <div class="stats-content">{propertyStats[1] !== undefined ? propertyStats[1] : ''}</div>
           </div>
           {#if activeOperatorsTab === 'Numbers'}
             <NumberButtons on:valueclicked={numberSelected} />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45137948/180886265-1201775a-bc11-471d-b6e2-45712b5ac048.png)

If there isn't a selection in the PropertySelect.svelte, the min and max will be empty and not `undefined`