### PR TITLE
fix: only deploy node_modules for Dependencies

### DIFF
--- a/.github/workflows/main_undpgeohub.yml
+++ b/.github/workflows/main_undpgeohub.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Copy package.json / lock files to build folder
         if: ${{ (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/develop') }}
         run: |
+          rm -rf node_modules
+          pnpm install --prod
           cp package.json build/.
           cp pnpm-lock.yaml build/.
           mv node_modules build/.


### PR DESCRIPTION
I think sveltekit will bundle devDependencies packages, so we don't need to deploy them to the server.

I added `pnpm install --prod` to only deploy dependencies to the server. Folder size was reduced from 370MB to 200MB