### PR TITLE
changed mosaicjson api from GET to POST.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 yarn-error.log
 static/docs
 static/smui*.css
+tmp/

--- a/src/routes/stac/+server.ts
+++ b/src/routes/stac/+server.ts
@@ -11,8 +11,8 @@ export const GET: RequestHandler = async ({ url }) => {
   const catalogIds = url.searchParams.get('id')
   const containerPath = url.searchParams.get('path')
 
-  // because of limitation of URL length, set 15 as limit of COGs
-  const LIMIT = 10
+  // because of limitation of URL length, set 50 as limit of COGs
+  const LIMIT = 50
 
   const catalogId = catalogIds.split('_')[0]
   const collectionId = catalogIds.split('_')[1]


### PR DESCRIPTION
Now it uses POST method to create mosaicjson from titiler, then store it in Azure Blob Container. Svelte API returns tilejson URL which contains mosaicjson's Blob URL

- create mosaic json by the following API (POST /mosaicjson/create)
https://titiler.undpgeohub.org/docs#/MosaicJSON/create_mosaicJSON_post_mosaicjson_create_post
- store mosaicjson in Azure Blob container. URL should be like below
  - https://undpngddlsgeohubdev01.blob.core.windows.net/mosaicjson/480415c8-fd01-48c1-9ee8-ca6a8c0626de.json?{SAS token}
- create tilejson URL of titiler with Blob mosaicjson.
  - https://titiler.undpgeohub.org/docs#/MosaicJSON/tilejson_mosaicjson_tilejson_json_get

