### PR TITLE
Fix/issue 748

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,6 +12,7 @@ export const STRING_COMPARE_THRESHOLD = 0.25
 export const STAC_PAGINATION_PREV = 'prev'
 export const STAC_PAGINATION_NEXT = 'next'
 export const STAC_PAGINATION_LIMIT = 5
+export const TOKEN_EXPIRY_PERIOD_MSEC = 86400000 * 365 // for 1 year
 
 export enum TabNames {
   ANALYZE = 'Analyze',

--- a/src/routes/azstorage.json/+server.ts
+++ b/src/routes/azstorage.json/+server.ts
@@ -10,6 +10,7 @@ import {
 import type { Tree, TreeNode } from '$lib/types'
 import { AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY } from '$lib/variables/private'
 import { fetchUrl } from '$lib/helper'
+import { TOKEN_EXPIRY_PERIOD_MSEC } from '$lib/constants'
 
 const sharedKeyCredential = new StorageSharedKeyCredential(AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY)
 
@@ -33,7 +34,7 @@ const listContainer = async (containerName: string, relPath: string) => {
   // adding a vector tile to mapbox requires adding a template/pattern not one file and reading many more files as well.
 
   const ACCOUNT_SAS_TOKEN_URI = blobServiceClient.generateAccountSasUrl(
-    new Date(new Date().valueOf() + 86400000),
+    new Date(new Date().valueOf() + TOKEN_EXPIRY_PERIOD_MSEC),
     AccountSASPermissions.parse('r'),
     'o',
   )

--- a/src/routes/stac/mosaicjson/+server.ts
+++ b/src/routes/stac/mosaicjson/+server.ts
@@ -174,7 +174,7 @@ const storeMosaicJson2Blob = async (mosaicjson: JSON, filter: string) => {
 
   const containerClient = blobServiceClient.getContainerClient(containerName)
 
-  const blobName = `${uuidv4()}.json`
+  const blobName = `mosaicjson_${uuidv4()}.json`
   const blockBlobClient = await containerClient.getBlockBlobClient(blobName)
 
   const tmpDir = path.resolve(`${__dirname}/tmp/`)

--- a/src/routes/stac/mosaicjson/+server.ts
+++ b/src/routes/stac/mosaicjson/+server.ts
@@ -5,7 +5,7 @@ import { PUBLIC_TITILER_ENDPOINT } from '$lib/variables/public'
 const TITILER_MOSAIC_ENDPOINT = PUBLIC_TITILER_ENDPOINT.replace('cog', 'mosaicjson')
 
 import { v4 as uuidv4 } from 'uuid'
-import { AccountSASPermissions, BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob'
+import { BlobServiceClient, StorageSharedKeyCredential } from '@azure/storage-blob'
 import { AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY } from '$lib/variables/private'
 const sharedKeyCredential = new StorageSharedKeyCredential(AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY)
 
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async ({ url }) => {
   const searchUrl = url.searchParams.get('url')
   const bbox: number[] = JSON.parse(url.searchParams.get('bbox'))
   const asset = url.searchParams.get('asset')
-  console.log(new URL(searchUrl), asset)
+  // console.log(new URL(searchUrl), asset)
   const searchResult = await searchStacItemUrls(searchUrl, bbox, asset)
   const mosaicJsonUrl = await createTitilerMosaicJsonEndpoint(searchResult.urls, searchResult.filter)
   const tileJsonUrl = createMosaicTileJson(mosaicJsonUrl)
@@ -26,7 +26,7 @@ export const GET: RequestHandler = async ({ url }) => {
   const searchUrlObj = new URL(searchUrl)
   const collectionUrl = `${searchUrlObj.origin}${searchUrlObj.pathname.replace('search', 'collections')}`
   const classmap = await getClassmap(collectionUrl, searchUrlObj.searchParams.get('collections'), asset)
-  console.log(classmap)
+  // console.log(classmap)
   return new Response(
     JSON.stringify({
       tilejson: tileJsonUrl,
@@ -110,7 +110,6 @@ const searchStacItemUrls = async (url: string, bbox: number[], targetAsset: stri
   const itemUrls: string[] = []
 
   const sasToken = await getMsStacToken(url)
-
   fc.features.forEach((f) => {
     itemUrls.push(`${f.assets[targetAsset].href}?${sasToken}`)
   })

--- a/src/routes/tags-search.json/+server.ts
+++ b/src/routes/tags-search.json/+server.ts
@@ -10,7 +10,7 @@ import {
   StorageSharedKeyCredential,
 } from '@azure/storage-blob'
 import { AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCESS_KEY } from '$lib/variables/private'
-import { TagKeys } from '$lib/constants'
+import { TagKeys, TOKEN_EXPIRY_PERIOD_MSEC } from '$lib/constants'
 import { fetchUrl } from '$lib/helper'
 import type { TagLayer } from '$lib/types'
 
@@ -30,7 +30,7 @@ export const GET: RequestHandler = async ({ url }) => {
   const blobs = []
   let tagsFilteredParam = []
   const accountSasTokenUri = blobServiceClient.generateAccountSasUrl(
-    new Date(new Date().valueOf() + 86400000),
+    new Date(new Date().valueOf() + TOKEN_EXPIRY_PERIOD_MSEC),
     AccountSASPermissions.parse('r'),
     'o',
   )


### PR DESCRIPTION
fixed #748 

- set 365 days of expiry for SAS token of geohub blob container.
- created a constant variable for expiry period : `TOKEN_EXPIRY_PERIOD_MSEC`

for mosaicjson container, since we cannot request a token of more than a day from microsoft planetary, mosaicjson will be deleted after 24 hours generated.
This PR is going to put `mosaicjson_` prefix for each json file, and I added prefix filter in lifecycle management rule.

![image](https://user-images.githubusercontent.com/2639701/199024439-560ecdcb-f750-46de-b0f7-2f4bd787379d.png)

![image](https://user-images.githubusercontent.com/2639701/199024508-5f0e46b4-2f04-49bf-a172-8ce96757937f.png)
