### PR TITLE
Refactor/delete intervals

### DIFF
--- a/src/components/BucketTreeItemRaster.svelte
+++ b/src/components/BucketTreeItemRaster.svelte
@@ -12,7 +12,6 @@
   import { map, layerList, bannerMessages, indicatorProgress } from '$stores'
   import { fetchUrl, getActiveBandIndex, getBase64EncodedUrl, paramsToQueryString } from '$lib/helper'
   import {
-    ClassificationMethodTypes,
     COLOR_CLASS_COUNT,
     COLOR_CLASS_COUNT_MAXIMUM,
     DEFAULT_COLORMAP,
@@ -132,7 +131,6 @@
         name: layerName,
         info: layerInfo,
         intervals: {
-          classification: ClassificationMethodTypes.EQUIDISTANT,
           numberOfClasses: COLOR_CLASS_COUNT,
           colorMapRows: [],
         },
@@ -260,7 +258,6 @@
         name: layerName,
         info: layerInfo,
         intervals: {
-          classification: ClassificationMethodTypes.EQUIDISTANT,
           numberOfClasses: COLOR_CLASS_COUNT,
           colorMapRows: [],
         },

--- a/src/components/RasterLayer.svelte
+++ b/src/components/RasterLayer.svelte
@@ -9,7 +9,7 @@
   import RasterExpression from '$components/controls/RasterExpression.svelte'
   import LayerNameGroup from '$components/control-groups/LayerNameGroup.svelte'
   import OpacityPanel from '$components/controls/OpacityPanel.svelte'
-  import { DEFAULT_COLORMAP, LayerInitialValues, TabNames } from '$lib/constants'
+  import { ClassificationMethodTypes, DEFAULT_COLORMAP, LayerInitialValues, TabNames } from '$lib/constants'
   import type { Layer, RasterSimpleExpression } from '$lib/types'
   import { faChartColumn } from '@fortawesome/free-solid-svg-icons/faChartColumn'
   import RasterHistogram from '$components/controls/RasterHistogram.svelte'
@@ -24,6 +24,7 @@
   let isOpacityPanelVisible = false
   let isHistogramPanelVisible = false
   let colorMapName = DEFAULT_COLORMAP
+  let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.EQUIDISTANT
 
   $: {
     isLegendPanelVisible = false
@@ -140,7 +141,8 @@
       {#if isLegendPanelVisible === true}
         <RasterLegendContainer
           bind:layer
-          bind:colorMapName />
+          bind:colorMapName
+          bind:classificationMethod />
       {/if}
       {#if isHistogramPanelVisible}
         <RasterHistogram bind:layer />

--- a/src/components/VectorLayer.svelte
+++ b/src/components/VectorLayer.svelte
@@ -8,13 +8,14 @@
   import OpacityPanel from '$components/controls/OpacityPanel.svelte'
   import VectorLegendPanel from '$components/controls/VectorLegendPanel.svelte'
   import VectorLabelPanel from '$components/controls/VectorLabelPanel.svelte'
-  import { DEFAULT_COLORMAP, LayerInitialValues, TabNames } from '$lib/constants'
+  import { ClassificationMethodTypes, DEFAULT_COLORMAP, LayerInitialValues, TabNames } from '$lib/constants'
   import type { Layer } from '$lib/types'
   import { faFilter } from '@fortawesome/free-solid-svg-icons/faFilter'
   import VectorFilterPanelWizard from './controls/VectorFilterPanelWizard.svelte'
 
   export let layer: Layer = LayerInitialValues
   let colorMapName = DEFAULT_COLORMAP
+  let classificationMethod: ClassificationMethodTypes
 
   let activeTab = ''
   let isLabelPanelVisible: boolean
@@ -125,7 +126,8 @@
       <VectorLegendPanel
         {layer}
         {isLegendPanelVisible}
-        bind:colorMapName />
+        bind:colorMapName
+        bind:classificationMethod />
       <VectorFilterPanelWizard
         {layer}
         {isFilterPanelVisible} />

--- a/src/components/VectorLayer.svelte
+++ b/src/components/VectorLayer.svelte
@@ -16,6 +16,7 @@
   export let layer: Layer = LayerInitialValues
   let colorMapName = DEFAULT_COLORMAP
   let classificationMethod: ClassificationMethodTypes
+  let applyToOption: string
 
   let activeTab = ''
   let isLabelPanelVisible: boolean
@@ -127,7 +128,8 @@
         {layer}
         {isLegendPanelVisible}
         bind:colorMapName
-        bind:classificationMethod />
+        bind:classificationMethod
+        bind:applyToOption />
       <VectorFilterPanelWizard
         {layer}
         {isFilterPanelVisible} />

--- a/src/components/__tests__/_layer.json
+++ b/src/components/__tests__/_layer.json
@@ -115,7 +115,6 @@
   "url":"https://undpngddlsgeohubdev01.blob.core.windows.net/climate-action/Volcanic_Hazard_Level_for_Proximal_Volcanic_Hazards.tif?c3Y9MjAyMS0wNC0xMCZzZT0yMDIyLTA1LTExVDAzJTNBMDElM0E1M1omc3I9YiZzcD1yJnNpZz1WTjRSYm5peUFxSU50SWMlMkY3cTRZWnNjYXBQSkN2VnNSZ0o0VzNLdFEzbnclM0Q=",
   "colorMapName":"viridis",
   "intervals":{
-     "classification":"e",
      "numberOfClasses":5,
      "colorMapRows":[
         {

--- a/src/components/controls/RasterIntervalsLegend.svelte
+++ b/src/components/controls/RasterIntervalsLegend.svelte
@@ -41,7 +41,7 @@
     layerMax = Number(bandMetaStats['STATISTICS_MAXIMUM'])
   }
 
-  let classificationMethod = layerConfig.intervals.classification || ClassificationMethodTypes.EQUIDISTANT
+  export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.EQUIDISTANT
   let percentile98: number = info.stats[Object.keys(info.stats)[bandIndex]]['percentile_98']
   let classificationMethods = [
     { name: ClassificationMethodNames.NATURAL_BREAK, code: ClassificationMethodTypes.NATURAL_BREAK },
@@ -61,16 +61,12 @@
     const band = info.active_band_no
     percentile98 = info.stats[band]['percentile_98']
     const skewness = 3 * ((info.stats[band].mean - info.stats[band].median) / info.stats[band].std)
-    if (layerConfig.intervals.classification !== ClassificationMethodTypes.LOGARITHMIC) {
-      //pass
-    } else {
+    if (classificationMethod === ClassificationMethodTypes.LOGARITHMIC) {
       if (skewness > 1 && skewness > -1) {
         // Layer isn't higly skewed.
         classificationMethod = ClassificationMethodTypes.EQUIDISTANT // Default classification method
-        layerConfig.intervals.classification = classificationMethod
       } else {
         classificationMethod = ClassificationMethodTypes.LOGARITHMIC
-        layerConfig.intervals.classification = classificationMethod
       }
     }
     layerConfig = { ...layerConfig, info: info }
@@ -99,7 +95,6 @@
       isClassificationMethodEdited,
       percentile98,
     )
-    layerConfig.intervals.classification = classificationMethod
     handleParamsUpdate()
   }
   // encode colormap and update url parameters

--- a/src/components/controls/RasterLegendContainer.svelte
+++ b/src/components/controls/RasterLegendContainer.svelte
@@ -11,7 +11,7 @@
   import RasterContinuousLegend from '$components/controls/RasterContinuousLegend.svelte'
   import RasterIntervalsLegend from '$components/controls/RasterIntervalsLegend.svelte'
   import RasterUniqueValuesLegend from '$components/controls/RasterUniqueValuesLegend.svelte'
-  import { DynamicLayerLegendTypes, COLOR_CLASS_COUNT_MAXIMUM } from '$lib/constants'
+  import { DynamicLayerLegendTypes, COLOR_CLASS_COUNT_MAXIMUM, ClassificationMethodTypes } from '$lib/constants'
   import Popper from '$lib/popper'
   import type { Layer } from '$lib/types'
   import { layerList, map } from '$stores'
@@ -26,6 +26,8 @@
   import type { RasterTileSource } from 'maplibre-gl'
 
   export let layer: Layer
+  export let colorMapName: string
+  export let classificationMethod: ClassificationMethodTypes
 
   let info
   ;({ info } = layer)
@@ -36,7 +38,6 @@
   let layerHasUniqueValues = false
   let layerListCount = $layerList.length
   let showTooltip = false
-  export let colorMapName: string
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -169,7 +170,8 @@
         <RasterIntervalsLegend
           bind:layerConfig={layer}
           bind:colorPickerVisibleIndex
-          bind:colorMapName />
+          bind:colorMapName
+          bind:classificationMethod />
       </div>
     {:else if layer.legendType === DynamicLayerLegendTypes.UNIQUE}
       <div transition:slide>

--- a/src/components/controls/VectorLegendPanel.svelte
+++ b/src/components/controls/VectorLegendPanel.svelte
@@ -8,13 +8,14 @@
   import HeatmapIntensity from '$components/controls/vector-styles/HeatmapIntensity.svelte'
   import HeatmapRadius from '$components/controls/vector-styles/HeatmapRadius.svelte'
   import HeatmapWeight from '$components/controls/vector-styles/HeatmapWeight.svelte'
-  import { LayerInitialValues, LayerTypes } from '$lib/constants'
+  import { ClassificationMethodTypes, LayerInitialValues, LayerTypes } from '$lib/constants'
   import type { Layer } from '$lib/types'
   import { map } from '$stores'
 
   export let isLegendPanelVisible = false
   export let layer: Layer = LayerInitialValues
   export let colorMapName: string
+  export let classificationMethod: ClassificationMethodTypes
 
   const layerId = layer.id
   const style: LayerSpecification = $map
@@ -29,15 +30,18 @@
     {#if style.type === LayerTypes.LINE}
       <VectorLineContainer
         bind:layer
-        bind:colorMapName />
+        bind:colorMapName
+        bind:classificationMethod />
     {:else if style.type === LayerTypes.FILL}
       <VectorPolygonContainer
         bind:layer
-        bind:colorMapName />
+        bind:colorMapName
+        bind:classificationMethod />
     {:else if style.type === LayerTypes.SYMBOL}
       <VectorSymbolContainer
         bind:layer
-        bind:colorMapName />
+        bind:colorMapName
+        bind:classificationMethod />
     {:else if style.type === LayerTypes.HEATMAP}
       <div class="columns">
         <div class="column">

--- a/src/components/controls/VectorLegendPanel.svelte
+++ b/src/components/controls/VectorLegendPanel.svelte
@@ -8,7 +8,13 @@
   import HeatmapIntensity from '$components/controls/vector-styles/HeatmapIntensity.svelte'
   import HeatmapRadius from '$components/controls/vector-styles/HeatmapRadius.svelte'
   import HeatmapWeight from '$components/controls/vector-styles/HeatmapWeight.svelte'
-  import { ClassificationMethodTypes, LayerInitialValues, LayerTypes } from '$lib/constants'
+  import {
+    ClassificationMethodTypes,
+    LayerInitialValues,
+    LayerTypes,
+    VectorLayerLineLegendApplyToTypes,
+    VectorLayerSymbolLegendApplyToTypes,
+  } from '$lib/constants'
   import type { Layer } from '$lib/types'
   import { map } from '$stores'
 
@@ -16,6 +22,7 @@
   export let layer: Layer = LayerInitialValues
   export let colorMapName: string
   export let classificationMethod: ClassificationMethodTypes
+  export let applyToOption: string
 
   const layerId = layer.id
   const style: LayerSpecification = $map
@@ -31,7 +38,8 @@
       <VectorLineContainer
         bind:layer
         bind:colorMapName
-        bind:classificationMethod />
+        bind:classificationMethod
+        bind:applyToOption />
     {:else if style.type === LayerTypes.FILL}
       <VectorPolygonContainer
         bind:layer
@@ -41,7 +49,8 @@
       <VectorSymbolContainer
         bind:layer
         bind:colorMapName
-        bind:classificationMethod />
+        bind:classificationMethod
+        bind:applyToOption />
     {:else if style.type === LayerTypes.HEATMAP}
       <div class="columns">
         <div class="column">

--- a/src/components/controls/VectorLineAdvanced.svelte
+++ b/src/components/controls/VectorLineAdvanced.svelte
@@ -56,10 +56,7 @@
   let sizeArray: number[]
   let highlySkewed: boolean
   // update layer store upon change of apply to option
-  $: if (applyToOption !== layer.intervals.applyToOption) {
-    layer.intervals.applyToOption = applyToOption
-    updateMap()
-  }
+  $: applyToOption, updateMap()
 
   // update color intervals upon change of color map name
   $: colorMapName, setIntervalValues()
@@ -232,21 +229,21 @@
     const stops = layer.intervals.colorMapRows.map((row) => {
       return [
         row.start,
-        hasUniqueValues === true || layer.intervals.applyToOption === VectorLayerLineLegendApplyToTypes.LINE_COLOR
+        hasUniqueValues === true || applyToOption === VectorLayerLineLegendApplyToTypes.LINE_COLOR
           ? chroma([row.color[0], row.color[1], row.color[2]]).hex('rgb')
           : remapInputValue(Number(row.end), layerMin, layerMax, 0.5, 10),
       ]
     })
 
     if (stops.length > 0) {
-      if (hasUniqueValues === true || layer.intervals.applyToOption === VectorLayerLineLegendApplyToTypes.LINE_COLOR) {
+      if (hasUniqueValues === true || applyToOption === VectorLayerLineLegendApplyToTypes.LINE_COLOR) {
         $map.setPaintProperty(layer.id, 'line-width', getLineWidth($map, layer.id))
         $map.setPaintProperty(layer.id, 'line-color', {
           property: layer.intervals.propertyName,
           type: 'interval',
           stops,
         })
-      } else if (layer.intervals.applyToOption === VectorLayerLineLegendApplyToTypes.LINE_WIDTH) {
+      } else if (applyToOption === VectorLayerLineLegendApplyToTypes.LINE_WIDTH) {
         // generate remapped stops based on the zoom level
         const newStops = stops.map((item) => [item[0] as number, (item[1] as number) / $map.getZoom()])
 

--- a/src/components/controls/VectorLineAdvanced.svelte
+++ b/src/components/controls/VectorLineAdvanced.svelte
@@ -46,7 +46,7 @@
     { name: ClassificationMethodNames.QUANTILE, code: ClassificationMethodTypes.QUANTILE },
   ]
 
-  let classificationMethod
+  export let classificationMethod: ClassificationMethodTypes
   let classificationMethods = classificationMethodsDefault
   let colorPickerVisibleIndex: number
   let cssIconFilter: string
@@ -105,7 +105,6 @@
   }
 
   const handleClassificationChange = () => {
-    layer.intervals.classification = classificationMethod
     setIntervalValues()
   }
 

--- a/src/components/controls/VectorLineContainer.svelte
+++ b/src/components/controls/VectorLineContainer.svelte
@@ -26,9 +26,7 @@
   export let colorMapName
   export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.NATURAL_BREAK
 
-  let applyToOption = layer?.intervals?.applyToOption
-    ? layer.intervals.applyToOption
-    : VectorLayerLineLegendApplyToTypes.LINE_COLOR
+  export let applyToOption: string = VectorLayerLineLegendApplyToTypes.LINE_COLOR
   let colorPickerVisibleIndex: number
   let isLegendSwitchAnimate = false
   let layerListCount = $layerList.length

--- a/src/components/controls/VectorLineContainer.svelte
+++ b/src/components/controls/VectorLineContainer.svelte
@@ -63,8 +63,6 @@
       layer.intervals = {
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
-        propertyName: '',
-        applyToOption: VectorLayerLineLegendApplyToTypes.LINE_COLOR,
       }
     }
 

--- a/src/components/controls/VectorLineContainer.svelte
+++ b/src/components/controls/VectorLineContainer.svelte
@@ -24,6 +24,7 @@
 
   export let layer: Layer
   export let colorMapName
+  export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.NATURAL_BREAK
 
   let applyToOption = layer?.intervals?.applyToOption
     ? layer.intervals.applyToOption
@@ -62,7 +63,6 @@
 
     if (layer?.intervals === undefined) {
       layer.intervals = {
-        classification: ClassificationMethodTypes.NATURAL_BREAK,
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
         propertyName: '',
@@ -127,7 +127,8 @@
           bind:applyToOption
           bind:layerMin
           bind:layerMax
-          bind:colorMapName />
+          bind:colorMapName
+          bind:classificationMethod />
       </div>
     {/if}
   </div>

--- a/src/components/controls/VectorPolygonAdvanced.svelte
+++ b/src/components/controls/VectorPolygonAdvanced.svelte
@@ -42,7 +42,7 @@
     { name: ClassificationMethodNames.QUANTILE, code: ClassificationMethodTypes.QUANTILE },
   ]
 
-  let classificationMethod = layer.intervals.classification
+  export let classificationMethod: ClassificationMethodTypes
   let classificationMethods = classificationMethodsDefault
   let colorPickerVisibleIndex: number
   let defaultFillOutlineColor = getFillOutlineColor($map, layer.id)
@@ -79,7 +79,6 @@
   }
 
   const handleClassificationChange = () => {
-    layer.intervals.classification = classificationMethod
     setIntervalValues()
   }
 

--- a/src/components/controls/VectorPolygonAdvanced.svelte
+++ b/src/components/controls/VectorPolygonAdvanced.svelte
@@ -25,6 +25,7 @@
   import {
     getFillOutlineColor,
     getIntervalList,
+    getLayerNumberProperties,
     getLayerStyle,
     getSampleFromInterval,
     remapInputValue,
@@ -48,13 +49,14 @@
   let defaultFillOutlineColor = getFillOutlineColor($map, layer.id)
   let hasUniqueValues = false
   let numberOfClasses = layer.intervals.numberOfClasses
-  let propertySelectValue: string = layer.intervals.propertyName
+  let propertySelectValue: string
   let inLegend = true
 
   // update color intervals upon change of color map name
   $: colorMapName, setIntervalValues()
 
   onMount(() => {
+    getPropertySelectValue()
     setIntervalValues()
     $map.on('zoom', updateMap)
   })
@@ -64,17 +66,26 @@
     $map.off('zoom', updateMap)
   })
 
+  const getPropertySelectValue = () => {
+    const vectorLayerMeta = getLayerNumberProperties($map, layer)
+    const selectOptions = Object.keys(vectorLayerMeta.fields)
+
+    propertySelectValue = selectOptions[0]
+
+    const fillColorValue = $map.getPaintProperty(layer.id, 'fill-color')
+    if (fillColorValue && Object.prototype.hasOwnProperty.call(fillColorValue, 'property')) {
+      propertySelectValue = fillColorValue['property']
+    }
+  }
+
   const setDefaultProperty = (selectOptions: string[]) => {
     if (selectOptions.length === 0) return ''
-    const defaultValue = layer.intervals.propertyName === '' ? selectOptions[0] : layer.intervals.propertyName
-    layer.intervals.propertyName = defaultValue
     setIntervalValues()
-    return defaultValue
+    return propertySelectValue
   }
 
   const handlePropertyChange = (e) => {
     propertySelectValue = e.detail.prop
-    layer.intervals.propertyName = propertySelectValue
     setIntervalValues()
   }
 
@@ -125,7 +136,7 @@
 
       if (tileStatLayer) {
         const tileStatLayerAttribute = tileStatLayer.attributes.find(
-          (val: VectorLayerTileStatAttribute) => val.attribute === layer.intervals.propertyName,
+          (val: VectorLayerTileStatAttribute) => val.attribute === propertySelectValue,
         )
         if (tileStatLayerAttribute) {
           const stats = layer.info.stats as VectorLayerTileStatAttribute[]
@@ -218,7 +229,7 @@
     // console.log(stops)
     $map.setPaintProperty(layer.id, 'fill-outline-color', defaultFillOutlineColor)
     $map.setPaintProperty(layer.id, 'fill-color', {
-      property: layer.intervals.propertyName,
+      property: propertySelectValue,
       type: 'interval',
       stops: stops,
     })

--- a/src/components/controls/VectorPolygonContainer.svelte
+++ b/src/components/controls/VectorPolygonContainer.svelte
@@ -57,7 +57,6 @@
       layer.intervals = {
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
-        propertyName: '',
       }
     }
 

--- a/src/components/controls/VectorPolygonContainer.svelte
+++ b/src/components/controls/VectorPolygonContainer.svelte
@@ -19,6 +19,7 @@
 
   export let layer: Layer
   export let colorMapName
+  export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.NATURAL_BREAK
 
   let colorPickerVisibleIndex: number
   let isLegendSwitchAnimate = false
@@ -54,7 +55,6 @@
 
     if (layer?.intervals === undefined) {
       layer.intervals = {
-        classification: ClassificationMethodTypes.NATURAL_BREAK,
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
         propertyName: '',
@@ -117,7 +117,8 @@
           bind:layer
           bind:layerMin
           bind:layerMax
-          bind:colorMapName />
+          bind:colorMapName
+          bind:classificationMethod />
       </div>
     {/if}
   </div>

--- a/src/components/controls/VectorSymbolAdvanced.svelte
+++ b/src/components/controls/VectorSymbolAdvanced.svelte
@@ -193,7 +193,7 @@
                   // @ts-ignore:next-line
                   color: [...scaleColorList(i).rgb(), 255],
                   start: stat.values[i],
-                  end: '',
+                  end: stat.values[i],
                 }
                 propertySelectValues.push(row)
               }

--- a/src/components/controls/VectorSymbolAdvanced.svelte
+++ b/src/components/controls/VectorSymbolAdvanced.svelte
@@ -39,7 +39,7 @@
     { name: ClassificationMethodNames.QUANTILE, code: ClassificationMethodTypes.QUANTILE },
   ]
   let hasUniqueValues = false
-  let classificationMethod = layer.intervals.classification
+  export let classificationMethod: ClassificationMethodTypes
   let classificationMethods = classificationMethodsDefault
   let colorPickerVisibleIndex: number
   let cssIconFilter: string
@@ -94,7 +94,6 @@
   }
 
   const handleClassificationChange = () => {
-    layer.intervals.classification = classificationMethod
     setIntervalValues()
   }
 

--- a/src/components/controls/VectorSymbolAdvanced.svelte
+++ b/src/components/controls/VectorSymbolAdvanced.svelte
@@ -47,10 +47,7 @@
   let numberOfClasses = layer.intervals.numberOfClasses
   let propertySelectValue: string = null
   // update layer store upon change of apply to option
-  $: if (applyToOption !== layer.intervals.applyToOption) {
-    layer.intervals.applyToOption = applyToOption
-    updateMap()
-  }
+  $: applyToOption, updateMap()
 
   // update color intervals upon change of color map name
   $: colorMapName, setIntervalValues()
@@ -216,13 +213,13 @@
     const stops = layer.intervals.colorMapRows.map((row) => {
       return [
         row.start,
-        layer.intervals.applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_COLOR
+        applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_COLOR
           ? chroma([row.color[0], row.color[1], row.color[2]]).hex('rgb')
           : remapInputValue(Number(row.end), layerMin, layerMax, 0.5, 10),
       ]
     })
 
-    if (layer.intervals.applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_COLOR && stops.length > 0) {
+    if (applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_COLOR && stops.length > 0) {
       const iconSize = $map.getLayoutProperty(layer.id, 'icon-size')
       if (!iconSize || (iconSize && iconSize.type === 'interval')) {
         $map.setLayoutProperty(layer.id, 'icon-size', 1)
@@ -234,7 +231,7 @@
       })
     }
 
-    if (layer.intervals.applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_SIZE && stops.length > 0) {
+    if (applyToOption === VectorLayerSymbolLegendApplyToTypes.ICON_SIZE && stops.length > 0) {
       // Generate new stops based on the zoomLevel
 
       // Ends are the

--- a/src/components/controls/VectorSymbolContainer.svelte
+++ b/src/components/controls/VectorSymbolContainer.svelte
@@ -60,8 +60,6 @@
       layer.intervals = {
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
-        propertyName: '',
-        applyToOption: VectorLayerSymbolLegendApplyToTypes.ICON_COLOR,
       }
     }
   })

--- a/src/components/controls/VectorSymbolContainer.svelte
+++ b/src/components/controls/VectorSymbolContainer.svelte
@@ -23,6 +23,7 @@
 
   export let layer: Layer
   export let colorMapName: string
+  export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.NATURAL_BREAK
 
   let applyToOption = layer?.intervals?.applyToOption
     ? layer.intervals.applyToOption
@@ -59,7 +60,6 @@
 
     if (layer?.intervals === undefined) {
       layer.intervals = {
-        classification: ClassificationMethodTypes.NATURAL_BREAK,
         numberOfClasses: COLOR_CLASS_COUNT,
         colorMapRows: [],
         propertyName: '',
@@ -117,7 +117,8 @@
           bind:applyToOption
           bind:layerMin
           bind:layerMax
-          bind:colorMapName />
+          bind:colorMapName
+          bind:classificationMethod />
       </div>
     {/if}
   </div>

--- a/src/components/controls/VectorSymbolContainer.svelte
+++ b/src/components/controls/VectorSymbolContainer.svelte
@@ -25,9 +25,7 @@
   export let colorMapName: string
   export let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.NATURAL_BREAK
 
-  let applyToOption = layer?.intervals?.applyToOption
-    ? layer.intervals.applyToOption
-    : VectorLayerSymbolLegendApplyToTypes.ICON_COLOR
+  export let applyToOption: string = VectorLayerSymbolLegendApplyToTypes.ICON_COLOR
   let colorPickerVisibleIndex: number
   let isLegendSwitchAnimate = false
   let layerListCount = $layerList.length

--- a/src/components/controls/vector-styles/PropertySelect.svelte
+++ b/src/components/controls/vector-styles/PropertySelect.svelte
@@ -10,7 +10,7 @@
   export let showOnlyNumberFields = false
   export let inLegend = false
 
-  let propertySelectOptions = inLegend ? layer.intervals.propertyOptions : undefined
+  let propertySelectOptions: string[]
 
   const dispatch = createEventDispatcher()
 
@@ -25,7 +25,6 @@
     if (showEmptyFields === true) {
       propertySelectOptions = ['', ...propertySelectOptions]
     }
-    inLegend ? (layer.intervals.propertyOptions = propertySelectOptions) : null
     propertySelectValue = setDefaultProperty(propertySelectOptions)
     propertyChanged()
   }

--- a/src/components/controls/vector-styles/PropertySelectButtons.svelte
+++ b/src/components/controls/vector-styles/PropertySelectButtons.svelte
@@ -7,7 +7,7 @@
   export let showEmptyFields = false //this needs to be removed TODO
   export let showOnlyNumberFields = false
   export let inLegend = false
-  let propertySelectOptions = inLegend ? layer.intervals.propertyOptions : undefined
+  let propertySelectOptions: string[]
 
   const dispatch = createEventDispatcher()
 
@@ -27,8 +27,6 @@
         }
       })
     }
-
-    inLegend ? (layer.intervals.propertyOptions = propertySelectOptions) : null
 
     propertyChanged()
   }

--- a/src/components/controls/vector-styles/ValueInput.svelte
+++ b/src/components/controls/vector-styles/ValueInput.svelte
@@ -82,7 +82,7 @@
       const layerStyle = getLayerStyle($map, layer.id)
       features = $map.querySourceFeatures(layerStyle.source, {
         sourceLayer: layerStyle['source-layer'],
-        filter: [],
+        filter: undefined,
       })
     }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -61,7 +61,6 @@ export const LayerInitialValues: Layer = {
   name: 'GeoHub',
   info: {},
   intervals: {
-    classification: ClassificationMethodTypes.EQUIDISTANT,
     numberOfClasses: COLOR_CLASS_COUNT,
   },
   legendType: '',

--- a/src/lib/types/IntervalLegend.ts
+++ b/src/lib/types/IntervalLegend.ts
@@ -5,6 +5,5 @@ export interface IntervalLegend {
   numberOfClasses?: number
   colorMapRows?: IntervalLegendColorMapRow[]
   propertyName?: string
-  applyToOption?: string
   propertyOptions?: string[]
 }

--- a/src/lib/types/IntervalLegend.ts
+++ b/src/lib/types/IntervalLegend.ts
@@ -3,5 +3,4 @@ import type { IntervalLegendColorMapRow } from './IntervalLegendColorMapRow'
 export interface IntervalLegend {
   numberOfClasses?: number
   colorMapRows?: IntervalLegendColorMapRow[]
-  propertyName?: string
 }

--- a/src/lib/types/IntervalLegend.ts
+++ b/src/lib/types/IntervalLegend.ts
@@ -2,7 +2,6 @@ import type { ClassificationMethodTypes } from '$lib/constants'
 import type { IntervalLegendColorMapRow } from './IntervalLegendColorMapRow'
 
 export interface IntervalLegend {
-  classification?: ClassificationMethodTypes
   numberOfClasses?: number
   colorMapRows?: IntervalLegendColorMapRow[]
   propertyName?: string

--- a/src/lib/types/IntervalLegend.ts
+++ b/src/lib/types/IntervalLegend.ts
@@ -1,9 +1,7 @@
-import type { ClassificationMethodTypes } from '$lib/constants'
 import type { IntervalLegendColorMapRow } from './IntervalLegendColorMapRow'
 
 export interface IntervalLegend {
   numberOfClasses?: number
   colorMapRows?: IntervalLegendColorMapRow[]
   propertyName?: string
-  propertyOptions?: string[]
 }


### PR DESCRIPTION
Apart from `numberOfClasses` and `colorMapRows` in `IntervalLegend` interface, other properties were deleted now. Let me merge it to develop before starting the heaviest properties in `IntervalLegend`