### PR TITLE
show raster tile's metadata in accordion

### DIFF
--- a/src/components/DataCard.svelte
+++ b/src/components/DataCard.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { RasterTileData } from '$lib/RasterTileData'
-  import type { BannerMessage, StacAsset, StacItemFeature, StacItemFeatureCollection } from '$lib/types'
+  import type {
+    BannerMessage,
+    RasterTileMetadata,
+    StacAsset,
+    StacItemFeature,
+    StacItemFeatureCollection,
+    VectorTileMetadata,
+  } from '$lib/types'
   import { VectorTileData } from '$lib/VectorTileData'
   import type { GeoJSONFeature } from 'maplibre-gl'
   import Accordion from './controls/Accordion.svelte'
@@ -10,6 +17,7 @@
   import { MosaicJsonData } from '$lib/MosaicJsonData'
   import { StatusTypes } from '$lib/constants'
   import { assets } from '$app/paths'
+  import { hasOwnProperty } from 'vega'
 
   interface AssetOptions {
     url: string
@@ -25,6 +33,8 @@
   let isFullDescription = false
 
   let assetList: AssetOptions[] = []
+
+  let metadata: RasterTileMetadata | VectorTileMetadata
 
   const tags: [{ key: string; value: string }] = feature.properties.tags as unknown as [{ key: string; value: string }]
   const stacType = tags?.find((tag) => tag.key === 'stac')
@@ -155,7 +165,8 @@
           bind:feature
           width={'100%'}
           height={'150px'}
-          bind:isLoadMap={isExpanded} />
+          bind:isLoadMap={isExpanded}
+          bind:metadata />
       </div>
       <div class="description">
         {#if !isFullDescription}
@@ -177,7 +188,37 @@
             <i />
           </a>
         {:else}
-          <p><b>Description: </b>{feature.properties.description}</p>
+          {#if feature.properties.description}
+            <p><b>Description: </b>{feature.properties.description}</p>
+          {/if}
+          {#if metadata}
+            {#if metadata['band_metadata']}
+              {#if metadata['band_metadata'][0][1]?.RepresentationType}
+                <p><b>Representation Type: </b> {metadata['band_metadata'][0][1].RepresentationType}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.Unit}
+                <p><b>unit: </b> {metadata['band_metadata'][0][1].Unit}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MINIMUM}
+                <p><b>Minimum value: </b> {metadata['band_metadata'][0][1].STATISTICS_MINIMUM}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MAXIMUM}
+                <p><b>Maximum value: </b> {metadata['band_metadata'][0][1].STATISTICS_MAXIMUM}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MAXIMUM}
+                <p><b>Mean value: </b> {metadata['band_metadata'][0][1].STATISTICS_MEAN}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MAXIMUM}
+                <p><b>Median value: </b> {metadata['band_metadata'][0][1].STATISTICS_MEDIAN}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MAXIMUM}
+                <p><b>STDDev value: </b> {metadata['band_metadata'][0][1].STATISTICS_STDDEV}</p>
+              {/if}
+              {#if metadata['band_metadata'][0][1]?.STATISTICS_MAXIMUM}
+                <p><b>Valid percent: </b> {metadata['band_metadata'][0][1].STATISTICS_VALID_PERCENT}</p>
+              {/if}
+            {/if}
+          {/if}
           <p><b>Source: </b> {feature.properties.source}</p>
           <p><b>Updated at: </b> {feature.properties.updatedat}</p>
         {/if}

--- a/src/components/MiniMap.svelte
+++ b/src/components/MiniMap.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { Map, NavigationControl } from 'maplibre-gl'
   import { styles } from '$lib/constants'
-  import type { StacCollection, StacItemFeature, StacItemFeatureCollection } from '$lib/types'
+  import type {
+    RasterTileMetadata,
+    StacCollection,
+    StacItemFeature,
+    StacItemFeatureCollection,
+    VectorTileMetadata,
+  } from '$lib/types'
   import { RasterTileData } from '$lib/RasterTileData'
   import { VectorTileData } from '$lib/VectorTileData'
 
@@ -14,6 +20,8 @@
   let map: Map
   let previewImageUrl: string
   let isLoading = false
+
+  export let metadata: RasterTileMetadata | VectorTileMetadata
 
   $: if (isLoadMap === true) {
     if (!map) {
@@ -58,9 +66,11 @@
         if (is_raster === true) {
           const rasterTile = new RasterTileData(map, feature)
           await rasterTile.add()
+          metadata = rasterTile.metadata
         } else {
           const vectorTile = new VectorTileData(map, feature)
           await vectorTile.add()
+          metadata = vectorTile.metadata
         }
       } finally {
         isLoading = false

--- a/src/lib/MosaicJsonData.ts
+++ b/src/lib/MosaicJsonData.ts
@@ -10,6 +10,8 @@ export class MosaicJsonData {
   private map: Map
   private url: string
   private assetName: string
+  public metadata: RasterTileMetadata
+
   constructor(map: Map, feature: StacItemFeature, assetUrl: string, assetName: string) {
     this.map = map
     this.feature = feature
@@ -40,12 +42,14 @@ export class MosaicJsonData {
         data.active_band_no = Object.keys(layerStats)[0]
       }
       data.isMosaicJson = true
+      this.metadata = data
       return data
     } else {
       const data: RasterTileMetadata = {
         bounds: tilejson.bounds,
       }
       data.isMosaicJson = true
+      this.metadata = data
       return data
     }
   }
@@ -133,12 +137,14 @@ export class MosaicJsonData {
       }
     })
 
+    const maxzoom = Number(tilejson.maxzoom && tilejson.maxzoom <= 24 ? tilejson.maxzoom : 24)
+
     const source: RasterSourceSpecification = {
       type: 'raster',
       // convert http to https because titiler's /mosaicjson/tilejson.json does not return https protocol currently
       tiles: tilejson.tiles,
       minzoom: 0,
-      maxzoom: tilejson.maxzoom | 22,
+      maxzoom: maxzoom ?? 22,
       bounds: tilejson.bounds,
       attribution:
         'Map tiles by <a target="_top" rel="noopener" href="http://undp.org">UNDP</a>, under <a target="_top" rel="noopener" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.\
@@ -157,7 +163,7 @@ export class MosaicJsonData {
       id: layerId,
       type: 'raster',
       source: sourceId,
-      minzoom: 0,
+      minzoom: source.minzoom,
       maxzoom: source.maxzoom,
       layout: {
         visibility: 'visible',

--- a/src/lib/VectorTileData.ts
+++ b/src/lib/VectorTileData.ts
@@ -14,6 +14,8 @@ export class VectorTileData {
   private feature: StacItemFeature
   private map: Map
   private url: string
+  public metadata: VectorTileMetadata
+
   constructor(map: Map, feature: StacItemFeature) {
     this.map = map
     this.feature = feature
@@ -42,6 +44,7 @@ export class VectorTileData {
     }
     const res = await fetch(metadataUrl)
     const data: VectorTileMetadata = await res.json()
+    this.metadata = data
     return {
       metadata: data,
       type: type,
@@ -55,6 +58,10 @@ export class VectorTileData {
     const tileSourceId = this.feature.properties.id
     const selectedLayerId = vectorInfo.metadata.json.vector_layers[0].id
 
+    const maxzoom = Number(
+      vectorInfo.metadata.maxzoom && vectorInfo.metadata.maxzoom <= 24 ? vectorInfo.metadata.maxzoom : 24,
+    )
+
     let source: VectorSourceSpecification
     if (vectorInfo.type) {
       source = {
@@ -66,7 +73,7 @@ export class VectorTileData {
         type: 'vector',
         tiles: [this.url],
         minzoom: 0,
-        maxzoom: vectorInfo.metadata.maxzoom | 24,
+        maxzoom: maxzoom,
       }
     }
     this.map.addSource(tileSourceId, source)
@@ -129,9 +136,7 @@ export class VectorTileData {
         return
     }
     layer.minzoom = 0
-    layer.maxzoom = Number(
-      vectorInfo.metadata.maxzoom && vectorInfo.metadata.maxzoom <= 24 ? vectorInfo.metadata.maxzoom : 24,
-    )
+    layer.maxzoom = maxzoom
 
     this.map.addLayer(layer)
     const bounds = vectorInfo.metadata.bounds.split(',').map((val) => Number(val))


### PR DESCRIPTION
fix #830 

also fixed bug of min max zoom

<img width="393" alt="image" src="https://user-images.githubusercontent.com/2639701/203867540-f2488a9c-9fa3-4d0b-85a9-8d0bad32478e.png">
