### PR TITLE
fix: set classification from restored style.json fro vector and raster layer

### DIFF
--- a/sites/geohub/src/components/Content.svelte
+++ b/sites/geohub/src/components/Content.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
-  import { page } from '$app/stores'
   import DataView from '$components/DataView.svelte'
   import LayerList from '$components/LayerList.svelte'
   import { TabNames } from '$lib/constants'
-  import { map, layerList, indicatorProgress } from '$stores'
+  import { map, layerList } from '$stores'
   import BannerMessageControl from '$components/BannerMessageControl.svelte'
   import { Tabs } from '@undp-data/svelte-undp-design'
   import type { Tab } from '@undp-data/svelte-undp-design/interfaces'
   import ContentSidebar from './ContentSidebar.svelte'
-  import { onMount } from 'svelte'
-  import type { StyleSpecification } from 'maplibre-gl'
 
   export let drawerOpen = false
   export let headerHeight: number = undefined
@@ -34,35 +30,6 @@
     },
   ]
   let activeTab: string = tabs[0].label
-
-  onMount(async () => {
-    try {
-      $indicatorProgress = true
-      const styleId = $page.url.searchParams.get('style')
-      if (!(styleId && $layerList.length === 0)) return
-      const res = await fetch(`/api/style/${styleId}`)
-      if (!res.ok) {
-        $page.url.searchParams.delete('style')
-        goto(`?${$page.url.searchParams.toString()}`)
-        return
-      }
-      const styleInfo = await res.json()
-      if (styleInfo.layers) {
-        $layerList = styleInfo.layers
-        const style: StyleSpecification = styleInfo.style
-        $map.setStyle(style)
-        $map.flyTo({
-          center: [style.center[0], style.center[1]],
-          zoom: style.zoom,
-          bearing: style.bearing,
-          pitch: style.pitch,
-        })
-        activeTab = TabNames.LAYERS
-      }
-    } finally {
-      $indicatorProgress = false
-    }
-  })
 </script>
 
 <ContentSidebar
@@ -86,7 +53,8 @@
         <div hidden={activeTab !== TabNames.LAYERS}>
           <LayerList
             bind:headerHeight
-            bind:tabsHeight />
+            bind:tabsHeight
+            bind:activeTab />
         </div>
       </div>
     </div>

--- a/sites/geohub/src/components/LayerList.svelte
+++ b/sites/geohub/src/components/LayerList.svelte
@@ -1,16 +1,68 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
+  import type { StyleSpecification } from 'maplibre-gl'
+  import { goto } from '$app/navigation'
+  import { page } from '$app/stores'
   import RasterLayer from '$components/RasterLayer.svelte'
   import VectorLayer from '$components/VectorLayer.svelte'
-  import { map, layerList } from '$stores'
-  import { LayerTypes, TabNames } from '$lib/constants'
+  import { map, layerList, indicatorProgress } from '$stores'
+  import { ClassificationMethodTypes, LayerTypes, TabNames } from '$lib/constants'
   import { getLayerStyle } from '$lib/helper'
   import Notification from './controls/Notification.svelte'
   import LayerOrder from './LayerOrder.svelte'
 
   export let headerHeight: number = undefined
   export let tabsHeight: number = undefined
+  export let activeTab: string
   let marginTop = 5
   let layerHeaderHeight = 39
+
+  let restoredStyle: StyleSpecification
+
+  onMount(async () => {
+    try {
+      $indicatorProgress = true
+      const styleId = $page.url.searchParams.get('style')
+      if (!(styleId && $layerList.length === 0)) return
+      const res = await fetch(`/api/style/${styleId}`)
+      if (!res.ok) {
+        $page.url.searchParams.delete('style')
+        goto(`?${$page.url.searchParams.toString()}`)
+        return
+      }
+      const styleInfo = await res.json()
+      restoredStyle = styleInfo.style
+      if (styleInfo.layers) {
+        $layerList = styleInfo.layers
+        const style: StyleSpecification = styleInfo.style
+        $map.setStyle(style)
+        $map.flyTo({
+          center: [style.center[0], style.center[1]],
+          zoom: style.zoom,
+          bearing: style.bearing,
+          pitch: style.pitch,
+        })
+        activeTab = TabNames.LAYERS
+      } else {
+        $page.url.searchParams.delete('style')
+        goto(`?${$page.url.searchParams.toString()}`)
+      }
+    } finally {
+      $indicatorProgress = false
+    }
+  })
+
+  const getClassificationMethod = (layerId: string) => {
+    const layerStyle = restoredStyle?.layers.find((l) => l.id === layerId)
+    let classificationMethod = ClassificationMethodTypes.EQUIDISTANT
+    if (['fill', 'symbol'].includes(layerStyle.type)) {
+      classificationMethod = ClassificationMethodTypes.NATURAL_BREAK
+    }
+    if (layerStyle && layerStyle['classification']) {
+      classificationMethod = layerStyle['classification']
+    }
+    return classificationMethod
+  }
 </script>
 
 {#if $layerList?.length > 0}
@@ -38,9 +90,13 @@
   {#each $layerList as layer (layer.id)}
     <div class="box p-0 mx-1 my-3">
       {#if getLayerStyle($map, layer.id).type === LayerTypes.RASTER}
-        <RasterLayer {layer} />
+        <RasterLayer
+          {layer}
+          classificationMethod={getClassificationMethod(layer.id)} />
       {:else}
-        <VectorLayer {layer} />
+        <VectorLayer
+          {layer}
+          classificationMethod={getClassificationMethod(layer.id)} />
       {/if}
     </div>
   {/each}

--- a/sites/geohub/src/components/RasterLayer.svelte
+++ b/sites/geohub/src/components/RasterLayer.svelte
@@ -10,6 +10,8 @@
   import { Tabs } from '@undp-data/svelte-undp-design'
 
   export let layer: Layer
+  export let classificationMethod: ClassificationMethodTypes
+
   let expressions: RasterSimpleExpression[]
 
   let activeTab = ''
@@ -18,7 +20,6 @@
   let isOpacityPanelVisible = false
   let isHistogramPanelVisible = false
   let colorMapName: string = undefined
-  let classificationMethod: ClassificationMethodTypes = ClassificationMethodTypes.EQUIDISTANT
   let legendType: DynamicLayerLegendTypes
 
   $: {

--- a/sites/geohub/src/components/VectorLayer.svelte
+++ b/sites/geohub/src/components/VectorLayer.svelte
@@ -12,7 +12,7 @@
 
   export let layer: Layer
   let colorMapName = getRandomColormap()
-  let classificationMethod: ClassificationMethodTypes
+  export let classificationMethod: ClassificationMethodTypes
   let applyToOption: string
   let legendType: string
   let defaultColor: string = undefined


### PR DESCRIPTION
fixes #1020

- moved style loading codes from Content.svelte to LayerList.svelte
- exposed `classificationMethod` from vectorLayer and rasterLayer
- set classification method from restored style.json