### PR TITLE
Fix/1022 restore colormap name

### DIFF
--- a/sites/geohub/src/components/LayerList.svelte
+++ b/sites/geohub/src/components/LayerList.svelte
@@ -7,7 +7,7 @@
   import VectorLayer from '$components/VectorLayer.svelte'
   import { map, layerList, indicatorProgress } from '$stores'
   import { ClassificationMethodTypes, LayerTypes, TabNames } from '$lib/constants'
-  import { getLayerStyle } from '$lib/helper'
+  import { getLayerStyle, getRandomColormap } from '$lib/helper'
   import Notification from './controls/Notification.svelte'
   import LayerOrder from './LayerOrder.svelte'
 
@@ -55,13 +55,25 @@
   const getClassificationMethod = (layerId: string) => {
     const layerStyle = restoredStyle?.layers.find((l) => l.id === layerId)
     let classificationMethod = ClassificationMethodTypes.EQUIDISTANT
-    if (['fill', 'symbol'].includes(layerStyle.type)) {
+    if (['fill', 'symbol'].includes(layerStyle?.type)) {
       classificationMethod = ClassificationMethodTypes.NATURAL_BREAK
     }
     if (layerStyle && layerStyle['classification']) {
       classificationMethod = layerStyle['classification']
     }
     return classificationMethod
+  }
+
+  const getColormapName = (layerId: string) => {
+    const layerStyle = restoredStyle?.layers.find((l) => l.id === layerId)
+    let colorMapName: string
+    if (layerStyle && layerStyle['colormap']) {
+      colorMapName = layerStyle['colormap']
+    }
+    if (!colorMapName) {
+      colorMapName = getRandomColormap()
+    }
+    return colorMapName
   }
 </script>
 
@@ -96,7 +108,8 @@
       {:else}
         <VectorLayer
           {layer}
-          classificationMethod={getClassificationMethod(layer.id)} />
+          classificationMethod={getClassificationMethod(layer.id)}
+          colorMapName={getColormapName(layer.id)} />
       {/if}
     </div>
   {/each}

--- a/sites/geohub/src/components/StyleShare.svelte
+++ b/sites/geohub/src/components/StyleShare.svelte
@@ -20,11 +20,15 @@
   let exportedStyleJSON: StyleSpecification
 
   let layerClassification: { [key: string]: string } = {}
-
+  let layerColormap: { [key: string]: string } = {}
   $: {
     if ($map) {
       $map.on('classification:changed', (e: { layerId: string; classification: string }) => {
         layerClassification[e.layerId] = e.classification
+      })
+
+      $map.on('colormap:changed', (e: { layerId: string; colorMapName: string }) => {
+        layerColormap[e.layerId] = e.colorMapName
       })
     }
   }
@@ -73,6 +77,19 @@
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         l.classification = layerClassification[l.id]
+      }
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (l.colormap) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        delete l.colormap
+      }
+      if (layerColormap[l.id]) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        l.colormap = layerColormap[l.id]
       }
     })
 

--- a/sites/geohub/src/components/VectorLayer.svelte
+++ b/sites/geohub/src/components/VectorLayer.svelte
@@ -11,8 +11,8 @@
   import { Tabs } from '@undp-data/svelte-undp-design'
 
   export let layer: Layer
-  let colorMapName = getRandomColormap()
   export let classificationMethod: ClassificationMethodTypes
+  export let colorMapName: string = getRandomColormap()
   let applyToOption: string
   let legendType: string
   let defaultColor: string = undefined

--- a/sites/geohub/src/components/controls/RasterLegendContainer.svelte
+++ b/sites/geohub/src/components/controls/RasterLegendContainer.svelte
@@ -142,7 +142,7 @@
     updateParamsInURL(layerStyle, layerURL, updatedParams)
 
     colorPickerVisibleIndex = -1
-    const nlayer = { ...layer, colorMapName: colorMapName }
+    const nlayer = { ...layer }
     const layers = $layerList.map((lyr) => {
       return layer.id !== lyr.id ? lyr : nlayer
     })

--- a/sites/geohub/src/components/controls/VectorLineContainer.svelte
+++ b/sites/geohub/src/components/controls/VectorLineContainer.svelte
@@ -102,6 +102,12 @@
     const layerClone = cloneDeep(layer)
     layer = layerClone
     colorPickerVisibleIndex = -1
+
+    // fire event for style sharing
+    $map?.fire('colormap:changed', {
+      layerId: layer.id,
+      colorMapName: colorMapName,
+    })
   }
 
   const handleClosePopup = () => {

--- a/sites/geohub/src/components/controls/VectorPolygonContainer.svelte
+++ b/sites/geohub/src/components/controls/VectorPolygonContainer.svelte
@@ -103,6 +103,12 @@
     const layerClone = cloneDeep(layer)
     layer = layerClone
     colorPickerVisibleIndex = -1
+
+    // fire event for style sharing
+    $map?.fire('colormap:changed', {
+      layerId: layer.id,
+      colorMapName: colorMapName,
+    })
   }
 
   const handleClosePopup = () => {

--- a/sites/geohub/src/components/controls/VectorSymbolAdvanced.svelte
+++ b/sites/geohub/src/components/controls/VectorSymbolAdvanced.svelte
@@ -235,6 +235,9 @@
           hasUniqueValues = false
 
           if (stat) {
+            layerMax = stat.max
+            layerMin = stat.min
+
             const propertySelectValues = []
 
             if (stat['values'] !== undefined) {
@@ -287,8 +290,6 @@
                 }
                 propertySelectValues.push(row)
               }
-              layerMax = stat.max
-              layerMin = stat.min
             }
 
             colorMapRows = propertySelectValues

--- a/sites/geohub/src/components/controls/VectorSymbolContainer.svelte
+++ b/sites/geohub/src/components/controls/VectorSymbolContainer.svelte
@@ -96,6 +96,12 @@
     const layerClone = cloneDeep(layer)
     layer = layerClone
     colorPickerVisibleIndex = -1
+
+    // fire event for style sharing
+    $map?.fire('colormap:changed', {
+      layerId: layer.id,
+      colorMapName: colorMapName,
+    })
   }
 
   const handleClosePopup = () => {

--- a/sites/geohub/src/routes/api/style/+server.ts
+++ b/sites/geohub/src/routes/api/style/+server.ts
@@ -33,7 +33,7 @@ export const GET: RequestHandler = async ({ url }) => {
     if (offset) options['offset'] = offset
 
     const query = {
-      text: `SELECT id, name, createdat, updatedat, layers FROM geohub.style ORDER BY id ${Object.keys(options)
+      text: `SELECT id, name, createdat, updatedat FROM geohub.style ORDER BY id ${Object.keys(options)
         .map((key, index) => `${key} $${index + 1}`)
         .join(' ')}`,
       values: [...Object.keys(options).map((key) => options[key])],

--- a/sites/geohub/static/api/docs/swagger.yaml
+++ b/sites/geohub/static/api/docs/swagger.yaml
@@ -765,11 +765,6 @@ paths:
                           type: string
                         updatedat:
                           type: string
-                        layers:
-                          type: array
-                          description: $layerList object
-                          items:
-                            type: object
                       required:
                         - id
                         - createdat


### PR DESCRIPTION
fixes #1003 and #1022

- store `colormap` property for saved style.json (only vector layer)
- restotre colormap of vector layer from saved style.json
- deleted `layers` property from response of `/api/style` GET endpoint