### PR TITLE
add asset header font size options

### DIFF
--- a/packages/svelte-undp-design/src/lib/Accordion/Accordion.stories.ts
+++ b/packages/svelte-undp-design/src/lib/Accordion/Accordion.stories.ts
@@ -28,6 +28,9 @@ const meta = {
 	parameters: {
 		isExpanded: {
 			values: [true, false]
+		},
+		fontSize: {
+			values: ['small', 'medium']
 		}
 	}
 } satisfies Meta<Accordion>;

--- a/packages/svelte-undp-design/src/lib/Accordion/Accordion.stories.ts
+++ b/packages/svelte-undp-design/src/lib/Accordion/Accordion.stories.ts
@@ -17,7 +17,13 @@ const meta = {
 			type: 'boolean',
 			description: 'State of whether accordion is opened or closed.',
 			defaultValue: false
+		},
+		fontSize: {
+			type: 'string',
+			description: 'Font size of the accordion header title.',
+			defaultValue: 'medium'
 		}
+
 	},
 	parameters: {
 		isExpanded: {

--- a/packages/svelte-undp-design/src/lib/Accordion/Accordion.svelte
+++ b/packages/svelte-undp-design/src/lib/Accordion/Accordion.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	export let headerTitle: string;
 	export let isExpanded = false;
+	export let fontSize : "small" | "medium" = "medium";
 </script>
 
 <ul class="accordion" aria-label="accordion">
@@ -14,9 +15,9 @@
 					isExpanded = !isExpanded;
 				}}
 			>
-				<p class="accordion-header">
-					{headerTitle}
-				</p>
+			<p class="accordion-header" style="font-size:{fontSize === 'small' ? 1 : 1.5 }rem">
+				{headerTitle}
+			</p>
 			</button>
 
 			<slot name="button" />
@@ -36,9 +37,7 @@
 	@use '../css/accordion.min.css';
 
 	.accordion {
-		padding: 5px;
-		padding-right: 10px;
-
+		padding: 5px 10px 5px 5px;
 		.accordion-title {
 			display: flex;
 			flex-direction: row;
@@ -53,7 +52,7 @@
 
 			.accordion-header {
 				padding-left: 2rem;
-				padding-right: 0rem;
+				padding-right: 0;
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;

--- a/sites/geohub/src/components/data-view/DataStacAssetCard.svelte
+++ b/sites/geohub/src/components/data-view/DataStacAssetCard.svelte
@@ -42,7 +42,8 @@
 
 <Accordion
   headerTitle={asset.title}
-  bind:isExpanded>
+  bind:isExpanded
+  fontSize="small">
   <div slot="button">
     {#if !isExpanded}
       <AddLayerButton


### PR DESCRIPTION
Asset header is now different from the main dataset accordion title
![image](https://user-images.githubusercontent.com/45137948/210100517-d229dc3a-2c80-40c1-8740-d2b1f48079da.png)
