### PR TITLE
fixed a bug of resetting number of classes after changing colormap

### DIFF
--- a/sites/geohub/src/components/controls/RasterContinuousLegend.svelte
+++ b/sites/geohub/src/components/controls/RasterContinuousLegend.svelte
@@ -28,8 +28,6 @@
     layerMax = Number(bandMetaStats['STATISTICS_MAXIMUM'])
   }
 
-  export let numberOfClasses = COLOR_CLASS_COUNT
-
   const rescale = getValueFromRasterTileUrl($map, layerConfig.id, 'rescale') as number[]
 
   // this ensures the slider state is set to layer min max
@@ -99,7 +97,7 @@
       colorMapType={ColorMapTypes.SEQUENTIAL}
       {layerMax}
       {layerMin}
-      {numberOfClasses}
+      numberOfClasses={COLOR_CLASS_COUNT}
       isSelected={false}
       isCardStyle={false} />
   </div>

--- a/sites/geohub/src/components/controls/RasterIntervalsLegend.svelte
+++ b/sites/geohub/src/components/controls/RasterIntervalsLegend.svelte
@@ -33,7 +33,6 @@
   $: colorMapName, colorManNameChanged()
 
   const colorManNameChanged = () => {
-    getColorMapRows()
     reclassifyImage()
   }
 
@@ -68,6 +67,7 @@
     const rasterInfo = info as RasterTileMetadata
     if (!rasterInfo?.isMosaicJson) {
       const layerSrc: RasterTileSource = $map.getSource(getLayerStyle($map, layerConfig.id).source) as RasterTileSource
+      if (!(layerSrc.tiles && layerSrc.tiles.length > 0)) return
       const layerURL = new URL(layerSrc.tiles[0])
       const statsURL = `${PUBLIC_TITILER_ENDPOINT}/statistics?url=${layerURL.searchParams.get('url')}&histogram_bins=20`
       const layerStats: RasterLayerStats = await fetchUrl(statsURL)

--- a/sites/geohub/src/components/controls/RasterLegendContainer.svelte
+++ b/sites/geohub/src/components/controls/RasterLegendContainer.svelte
@@ -196,8 +196,7 @@
       <div transition:slide>
         <RasterContinuousLegend
           bind:layerConfig={layer}
-          bind:colorMapName
-          bind:numberOfClasses />
+          bind:colorMapName />
       </div>
     {:else if legendType === DynamicLayerLegendTypes.INTERVALS}
       <div transition:slide>


### PR DESCRIPTION
fixes #1039 partially.

There is an issue when we change the tab from Legend. It will be reset to 5 if we go back to legend tab from others. But now number of classes is remained after changing colormap
