### PR TITLE
move docs to prerender folder after building

### DIFF
--- a/.github/workflows/main_undpgeohub.yml
+++ b/.github/workflows/main_undpgeohub.yml
@@ -119,6 +119,7 @@ jobs:
           cp package.json build/.
           cp pnpm-lock.yaml build/.
           mv node_modules build/.
+          mv build/client/docs build/prerendered/docs
 
       - name: "Deploy to Azure Web App for undpgeohub-dev"
         id: deploy-to-webapp-dev


### PR DESCRIPTION
fixes #1161 

I found it works if docs folder is moved from `build/client` folder to `build/prerender`. Hope it will work in Azure App Service