### PR TITLE
fix: bug of restoring state of visilibity button in interval legend

### DIFF
--- a/sites/geohub/src/components/controls/IntervalsLegendColorMapRow.svelte
+++ b/sites/geohub/src/components/controls/IntervalsLegendColorMapRow.svelte
@@ -2,7 +2,6 @@
   import { createEventDispatcher } from 'svelte'
   import { fade } from 'svelte/transition'
   import chroma from 'chroma-js'
-  import { abs } from 'mathjs'
   import { clickOutside } from 'svelte-use-click-outside'
   import ColorPicker from '$components/controls/ColorPicker.svelte'
   import Popper from '$lib/popper'
@@ -54,7 +53,7 @@
       g,
       b,
       a,
-      hex: chroma([r, g, b]).hex('rgba'),
+      hex: chroma([r, g, b, a]).hex('rgba'),
       h: isNaN(chroma([r, g, b]).hsv()[0]) ? 0 : chroma([r, g, b]).hsv()[0],
       s: chroma([r, g, b]).hsv()[1],
       v: chroma([r, g, b]).hsv()[2],
@@ -62,12 +61,13 @@
   }
 
   const getColorPickerStyle = () => {
-    const rowColor: number[] = colorMapRow.color
-    const r = rowColor[0]
-    const g = rowColor[1]
-    const b = rowColor[2]
-    const a = rowColor[3]
-    const rgba = `rgba(${r}, ${g}, ${b}, ${a})`
+    if (!color) return
+    let rgba = chroma(color.r, color.g, color.b, color.a).css()
+    const rgba2 = chroma(colorMapRow.color).css()
+    if (rgba !== rgba2) {
+      rgba = rgba2
+      setColorFromProp()
+    }
     colorPickerStyle = `caret-color:${rgba}; background-color: ${rgba}`
     return colorPickerStyle
   }
@@ -76,7 +76,9 @@
   const handleVisibilityChanged = () => {
     if (isVisible) {
       color.a = 1
-    } else [(color.a = 0)]
+    } else {
+      ;[(color.a = 0)]
+    }
     updateColorMap(color)
   }
 
@@ -111,8 +113,6 @@
   }
 
   const handleColorChanged = () => {
-    colorMapRow.color = [color.r, color.g, color.b, color.a]
-    colorPickerStyle = getColorPickerStyle()
     updateColorMap(color)
     dispatch('changeColorMap', {
       color,

--- a/sites/geohub/src/components/controls/VectorLegendAdvanced.svelte
+++ b/sites/geohub/src/components/controls/VectorLegendAdvanced.svelte
@@ -70,7 +70,6 @@
   let numberOfClasses: number
   let colorMapRows: IntervalLegendColorMapRow[]
   let defaultOutlineColor: string
-  let showTooltip = false
 
   let applyToOptions: Radio[] = [
     {
@@ -91,7 +90,6 @@
       getPropertySelectValue()
       setCssIconFilter()
       getColorMapRows()
-      setIntervalValues()
 
       if (layerType === 'line') {
         if (highlySkewed) {
@@ -195,7 +193,11 @@
       (l) => l.layer === getLayerStyle($map, layer.id)['source-layer'],
     )
     const stat = stats?.attributes.find((val) => val.attribute === propertySelectValue)
-
+    if (!layerMax) {
+      if (stat?.max) {
+        layerMax = stat.max
+      }
+    }
     stops?.forEach((stop, index: number) => {
       const value: number = stop[0]
       const color: string = stop[1]
@@ -292,8 +294,6 @@
               for (let i = 0; i < stat.values.length; i++) {
                 const row: IntervalLegendColorMapRow = {
                   index: i,
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore:next-line
                   color: [...scaleColorList(i).rgb(), 1],
                   start: stat.values[i],
                   end: '',
@@ -322,8 +322,6 @@
               for (let i = 0; i < intervalList.length - 1; i++) {
                 const row: IntervalLegendColorMapRow = {
                   index: i,
-                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                  // @ts-ignore:next-line
                   color: [...scaleColorList(intervalList[i]).rgb(), 1],
                   start: intervalList[i],
                   end: intervalList[i + 1],
@@ -343,6 +341,9 @@
 
   const updateMap = () => {
     if (!propertySelectValue) return
+    if (!(colorMapRows && colorMapRows.length > 0)) {
+      setIntervalValues()
+    }
     if (layerType === 'fill') {
       let stops = colorMapRows.map((row, index) => {
         const rgb = `rgba(${row.color[0]}, ${row.color[1]}, ${row.color[2]}, ${row.color[3]})`

--- a/sites/geohub/src/lib/helper/generateColorMap.ts
+++ b/sites/geohub/src/lib/helper/generateColorMap.ts
@@ -22,9 +22,7 @@ export const generateColorMap = (
     for (let i = 0; i <= numberOfClasses - 2; i++) {
       const row: IntervalLegendColorMapRow = {
         index: i,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore:next-line
-        color: [...scaleColorList(intervalList[i]).rgb(), 255],
+        color: [...scaleColorList(intervalList[i]).rgb(), 1],
         start:
           isClassificationMethodEdited == false && colorMapRows.length > 0 && colorMapRows[i]?.start
             ? colorMapRows[i].start
@@ -38,9 +36,7 @@ export const generateColorMap = (
     }
     const lastRow: IntervalLegendColorMapRow = {
       index: numberOfClasses - 1,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore:next-line
-      color: [...scaleColorList(intervalList[numberOfClasses - 1]).rgb(), 255],
+      color: [...scaleColorList(intervalList[numberOfClasses - 1]).rgb(), 1],
       start: Math.floor(percentile98),
       end: Math.ceil(layerMax),
     }
@@ -56,9 +52,7 @@ export const generateColorMap = (
     for (let i = 0; i <= numberOfClasses - 1; i++) {
       const row: IntervalLegendColorMapRow = {
         index: i,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore:next-line
-        color: [...scaleColorList(intervalList[i]).rgb(), 255],
+        color: [...scaleColorList(intervalList[i]).rgb(), 1],
         start:
           isClassificationMethodEdited == false && colorMapRows.length > 0 && colorMapRows[i]?.start
             ? colorMapRows[i].start


### PR DESCRIPTION
fixes #1185 

## Description

- fixed bug of restoring visibility button state for vector interval legend
- fixed bug of `generateColormap` function to set opacity=1 instead of 255 for raster.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [ ] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
