### PR TITLE
fix: disabled optimizeDeps since there is an issue of dashboard page when pnpm dev is run

### DIFF
--- a/sites/geohub/vite.config.ts
+++ b/sites/geohub/vite.config.ts
@@ -13,9 +13,9 @@ const config: UserConfig = {
       $stores: resolve('./src/stores/index.ts'),
     },
   },
-  optimizeDeps: {
-    include: ['lodash.get', 'lodash.isequal', 'lodash.clonedeep'],
-  },
+  // optimizeDeps: {
+  //   include: ['lodash.get', 'lodash.isequal', 'lodash.clonedeep'],
+  // },
   server: {
     fs: {
       // Allow serving files from one level up to the project root


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Disabled optimizeDeps in vite.config.ts. 
There was an issue of showing 500 error in my environment for dashboard page (and it works in production, only for dev command).
I found it works if we disabled optimizeDeps option in vite.config.ts.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
