### PR TITLE
updated layout.server.ts that only set session property in __data.json when there is session info

### DIFF
--- a/sites/geohub/src/routes/+layout.server.ts
+++ b/sites/geohub/src/routes/+layout.server.ts
@@ -1,7 +1,10 @@
 import type { LayoutServerLoad } from './$types'
 
 export const load: LayoutServerLoad = async (event) => {
-  return {
-    session: await event.locals.getSession(),
+  const data = {}
+  const session = await event.locals.getSession()
+  if (session) {
+    data['session'] = session
   }
+  return data
 }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Since there is error of __data.json, I updated +layout.server.ts not to set `session` property if there is no login info. Hope it will work...

<img width="1415" alt="image" src="https://user-images.githubusercontent.com/2639701/213817283-fc30e7aa-3c0e-4b54-8222-eab7e3baf23c.png">

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
