### PR TITLE
fix: close user profile menu when click user icon again

### DIFF
--- a/sites/geohub/src/components/UserAccount.svelte
+++ b/sites/geohub/src/components/UserAccount.svelte
@@ -42,6 +42,7 @@
     tabindex="0"
     on:click={togglePanel}
     on:keydown={handleKeyDown}
+    use:clickOutside={() => (isPanelOpen = false)}
     use:popperRef>
     {#if $page.data.session.user?.image}
       <span
@@ -68,7 +69,6 @@
       data-testid="tooltip"
       style="max-width: {panelWidth};"
       use:popperContent={popperOptions}
-      use:clickOutside={() => (isPanelOpen = false)}
       transition:slide>
       <div class="panel container p-4">
         <button


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixed bug not to close user menu when user icon is clicked

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
