### PR TITLE
fix: update filloutline color with new transparency of fill color in vector advanced legend

### DIFF
--- a/sites/geohub/src/components/controls/VectorLegendAdvanced.svelte
+++ b/sites/geohub/src/components/controls/VectorLegendAdvanced.svelte
@@ -69,7 +69,6 @@
   let propertySelectValue
   let numberOfClasses: number
   let colorMapRows: IntervalLegendColorMapRow[]
-  let defaultOutlineColor: string
 
   let applyToOptions: Radio[] = [
     {
@@ -347,17 +346,23 @@
     if (layerType === 'fill') {
       let stops = colorMapRows.map((row, index) => {
         const rgb = `rgba(${row.color[0]}, ${row.color[1]}, ${row.color[2]}, ${row.color[3]})`
-        const hex = chroma([row.color[0], row.color[1], row.color[2]]).hex()
-
-        // set default line color to be middle of colors
-        if (index === Math.floor(colorMapRows.length / 2)) {
-          defaultOutlineColor = chroma(hex).darken(2.6).hex()
-        }
-
         return [row.start, rgb]
       })
       stops = sortStops(stops)
-      $map.setPaintProperty(layer.id, 'fill-outline-color', defaultOutlineColor)
+
+      let outlineStops = colorMapRows.map((row) => {
+        const hex = chroma([row.color[0], row.color[1], row.color[2], row.color[3]]).hex()
+        const rgb = chroma(hex).darken(2.6).rgb(true)
+        const cssColor = `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${row.color[3]})`
+        return [row.start, cssColor]
+      })
+      outlineStops = sortStops(outlineStops)
+
+      $map.setPaintProperty(layer.id, 'fill-outline-color', {
+        property: propertySelectValue,
+        type: 'interval',
+        stops: outlineStops,
+      })
       $map.setPaintProperty(layer.id, 'fill-color', {
         property: propertySelectValue,
         type: 'interval',


### PR DESCRIPTION
fixes #1190 

## Description

Fix bug of not setting transparency of fill outline color in advanced legend

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
