### PR TITLE
Use name property from metadata.json or pmtiles's metadata instead of using file name if name property is present.

### DIFF
--- a/.changeset/fluffy-teachers-develop.md
+++ b/.changeset/fluffy-teachers-develop.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/geohub-cli": patch
+---
+
+Use name property from metadata.json or pmtiles's metadata instead of using file name if name property is present.


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

For vector tiles, previously we used file name as `name` field of dataset table, but it should be retrieved from `name` property of metadata.json or metadata on pmtiles if `name` is present.

If `name` does not exist in metadata, file name will be used as `name` field as the same with current API.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
