### PR TITLE
fix: use css flex instead of bulma tile

### DIFF
--- a/sites/geohub/src/components/maps/MapStyleCardList.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCardList.svelte
@@ -159,10 +159,16 @@
         setPageUrl()
       }
       const res = await fetch(apiUrl.toString())
-      const json = await res.json()
-      styleList = json.styles
-      links = json.links
-      pages = json.pages
+      if (res.ok) {
+        const json = await res.json()
+        styleList = [...json.styles]
+        links = json.links
+        pages = json.pages
+      } else {
+        styleList = []
+        links = []
+        pages = undefined
+      }
     } finally {
       isLoading = false
     }

--- a/sites/geohub/src/routes/maps/+page.svelte
+++ b/sites/geohub/src/routes/maps/+page.svelte
@@ -42,9 +42,7 @@
   class="main-section mb-4"
   style="margin-top: {headerHeight}px">
   {#if stats}
-    <div
-      class="grid"
-      style={isMobile ? '' : `grid-template-columns: repeat(4, 1fr);`}>
+    <div class="grid is-flex {isMobile ? 'is-flex-direction-column' : 'is-flex-direction-row'}">
       {#each stats as card}
         <Stats
           bind:card
@@ -78,10 +76,5 @@
     padding-top: 1rem;
     padding-left: 1.5rem;
     padding-right: 1.5rem;
-
-    .grid {
-      display: grid;
-      grid-gap: 5px;
-    }
   }
 </style>

--- a/sites/geohub/src/routes/maps/+page.svelte
+++ b/sites/geohub/src/routes/maps/+page.svelte
@@ -42,13 +42,13 @@
   class="main-section mb-4"
   style="margin-top: {headerHeight}px">
   {#if stats}
-    <div class="tile">
+    <div
+      class="grid"
+      style={isMobile ? '' : `grid-template-columns: repeat(4, 1fr);`}>
       {#each stats as card}
-        <div class="tile">
-          <Stats
-            bind:card
-            size={isMobile ? 'large' : 'small'} />
-        </div>
+        <Stats
+          bind:card
+          size={isMobile ? 'medium' : 'small'} />
       {/each}
     </div>
     <div class="is-divider" />
@@ -78,5 +78,10 @@
     padding-top: 1rem;
     padding-left: 1.5rem;
     padding-right: 1.5rem;
+
+    .grid {
+      display: grid;
+      grid-gap: 5px;
+    }
   }
 </style>

--- a/sites/geohub/src/routes/maps/+page.svelte
+++ b/sites/geohub/src/routes/maps/+page.svelte
@@ -76,5 +76,14 @@
     padding-top: 1rem;
     padding-left: 1.5rem;
     padding-right: 1.5rem;
+
+    .grid {
+      margin: 0 auto;
+      width: fit-content;
+
+      :global(.stats-card) {
+        margin: 5px;
+      }
+    }
   }
 </style>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixed a design layout of map stats. Use css flex instead of using bulma tile. Removed some gaps between cards

<img width="910" alt="image" src="https://user-images.githubusercontent.com/2639701/215847984-0dd34095-d03f-4566-8d91-2faa35b6b309.png">

<img width="910" alt="image" src="https://user-images.githubusercontent.com/2639701/215848039-2a55f99d-2e22-4cd5-8e75-c9bc08581739.png">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
