### PR TITLE
Fix: fire sourcechange event

### DIFF
--- a/sites/geohub/src/components/controls/vector-styles/Legend.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/Legend.svelte
@@ -237,6 +237,16 @@
       update()
     }, 300),
   )
+
+  map.on(
+    'source:changed',
+    debounce((e) => {
+      if (!layer) return
+      if (layer.id !== e.layerId) return
+      layer = getLayerStyle(map, e.layerId)
+      update()
+    }, 300),
+  )
 </script>
 
 <div class="legend">{@html container.innerHTML}</div>

--- a/sites/geohub/src/components/controls/vector-styles/Legend.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/Legend.svelte
@@ -229,24 +229,16 @@
     }
   }
 
-  map.on(
-    'styledata',
-    debounce(() => {
-      if (!layer) return
-      layer = getLayerStyle(map, layer.id)
-      update()
-    }, 300),
-  )
+  const updateLegend = debounce((e) => {
+    if (!layer) return
+    if (e.layerId && layer.id !== e.layerId) return
+    layer = getLayerStyle(map, layer.id)
+    update()
+  }, 300)
 
-  map.on(
-    'source:changed',
-    debounce((e) => {
-      if (!layer) return
-      if (layer.id !== e.layerId) return
-      layer = getLayerStyle(map, e.layerId)
-      update()
-    }, 300),
-  )
+  map.on('styledata', updateLegend)
+  // maplibre event is fired in updateParamsInURL function when raster's tiles URL is updated
+  map.on('source:changed', updateLegend)
 </script>
 
 <div class="legend">{@html container.innerHTML}</div>

--- a/sites/geohub/src/lib/helper/updateParamsInURL.ts
+++ b/sites/geohub/src/lib/helper/updateParamsInURL.ts
@@ -3,7 +3,9 @@ import type {
   HeatmapLayerSpecification,
   LineLayerSpecification,
   RasterLayerSpecification,
+  RasterSourceSpecification,
   SymbolLayerSpecification,
+  VectorSourceSpecification,
 } from 'maplibre-gl'
 
 import { get } from 'svelte/store'
@@ -24,10 +26,14 @@ export const updateParamsInURL = (
   })
   const map = get(mapStore)
   if (map.getSource(layerStyle.source)) {
-    map.getSource(layerStyle.source).tiles = [decodeURI(layerURL.toString())]
+    const source = map.getSource(layerStyle.source) as RasterSourceSpecification | VectorSourceSpecification
+    source.tiles = [decodeURI(layerURL.toString())]
     map.style.sourceCaches[layerStyle.source].clearTiles()
     map.style.sourceCaches[layerStyle.source].update(map.transform)
     map.triggerRepaint()
+    map.fire('source:changed', {
+      layerId: layerStyle.id,
+    })
   }
 }
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Since PR https://github.com/UNDP-Data/geohub/pull/1262 was merged, updateParamsInUrl function has no longer fire sourcedata event, styledata event, load event because the function is directly updating source URL and delete cache.

Thus, I added a code to fire custom maplibre event `source:changed` to update legend symbol in layer name. 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
