### PR TITLE
fix: forgot to change URL of saved map in /style api

### DIFF
--- a/sites/geohub/src/routes/api/style/+server.ts
+++ b/sites/geohub/src/routes/api/style/+server.ts
@@ -240,7 +240,7 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
     const styleJsonUrl = `${url.origin}/api/style/${id}.json`
     const style = await getStyleById(id)
     style.style = styleJsonUrl
-    style.viewer = `${url.origin}/viewer?style=${styleJsonUrl}`
+    style.viewer = `${url.origin}?style=${id}`
     return new Response(JSON.stringify(style))
   } catch (err) {
     return new Response(JSON.stringify({ message: err.message }), {
@@ -318,7 +318,7 @@ export const PUT: RequestHandler = async ({ request, url, locals }) => {
     const styleJsonUrl = `${url.origin}/api/style/${id}.json`
     style = await getStyleById(id)
     style.style = styleJsonUrl
-    style.viewer = `${url.origin}/viewer?style=${styleJsonUrl}`
+    style.viewer = `${url.origin}?style=${id}`
     return new Response(JSON.stringify(style))
   } catch (err) {
     return new Response(JSON.stringify({ message: err.message }), {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

forgot to change URL of saved map in /style api. It was using old `/viewer` URL in share dialog

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
