### PR TITLE
Fix: show unique value legend by default

### DIFF
--- a/sites/geohub/src/components/LayerList.svelte
+++ b/sites/geohub/src/components/LayerList.svelte
@@ -86,7 +86,6 @@
   $: if ($map) {
     $map.once('load', () => {
       getLegendState()
-      console.log(layerList)
     })
   }
 </script>

--- a/sites/geohub/src/components/LayerList.svelte
+++ b/sites/geohub/src/components/LayerList.svelte
@@ -86,6 +86,7 @@
   $: if ($map) {
     $map.once('load', () => {
       getLegendState()
+      console.log(layerList)
     })
   }
 </script>
@@ -113,7 +114,9 @@
     <div class="box p-0 mx-1 my-3">
       {#if getLayerStyle($map, layer.id).type === LayerTypes.RASTER}
         {@const cmp =
-          legendState?.[layer.id]?.colorMapName || getValueFromRasterTileUrl($map, layer.id, 'colormap_name')}
+          legendState?.[layer.id]?.colorMapName ||
+          getValueFromRasterTileUrl($map, layer.id, 'colormap_name') ||
+          layer.colorMapName}
         <RasterLayer
           {layer}
           classificationMethod={cls}

--- a/sites/geohub/src/components/data-view/DataCard.svelte
+++ b/sites/geohub/src/components/data-view/DataCard.svelte
@@ -89,13 +89,14 @@
           const rasterInfo = metadata as RasterTileMetadata
           const rasterTile = new RasterTileData($map, feature, rasterInfo)
           const data = await rasterTile.add(defaultColormap)
-
+          console.log(data)
           $layerList = [
             {
               id: data.layer.id,
               name: feature.properties.name,
               info: data.metadata,
               dataset: feature,
+              colorMapName: data.colorMapName,
             },
             ...$layerList,
           ]

--- a/sites/geohub/src/components/data-view/DataCard.svelte
+++ b/sites/geohub/src/components/data-view/DataCard.svelte
@@ -89,7 +89,6 @@
           const rasterInfo = metadata as RasterTileMetadata
           const rasterTile = new RasterTileData($map, feature, rasterInfo)
           const data = await rasterTile.add(defaultColormap)
-          console.log(data)
           $layerList = [
             {
               id: data.layer.id,

--- a/sites/geohub/src/components/data-view/DataCard.svelte
+++ b/sites/geohub/src/components/data-view/DataCard.svelte
@@ -95,7 +95,7 @@
               name: feature.properties.name,
               info: data.metadata,
               dataset: feature,
-              colorMapName: data.colorMapName,
+              colorMapName: data.colormap,
             },
             ...$layerList,
           ]

--- a/sites/geohub/src/components/data-view/DataStacAssetCard.svelte
+++ b/sites/geohub/src/components/data-view/DataStacAssetCard.svelte
@@ -23,6 +23,7 @@
           name: `${asset.collectionId}-${asset.title}`,
           info: data.metadata,
           dataset: feature,
+          colorMapName: data.colormap,
         },
         ...$layerList,
       ]

--- a/sites/geohub/src/lib/MosaicJsonData.ts
+++ b/sites/geohub/src/lib/MosaicJsonData.ts
@@ -123,7 +123,7 @@ export class MosaicJsonData {
 
     bandMetaStats.STATISTICS_UNIQUE_VALUES = mosaicjson.classmap
 
-    let colormap = defaultColormap ?? getRandomColormap()
+    let colormap = defaultColormap ?? getRandomColormap(isUniqueValueLayer ? 'diverging' : 'sequential')
     if (rasterInfo.band_metadata.length > 1) {
       colormap = ''
     }

--- a/sites/geohub/src/lib/MosaicJsonData.ts
+++ b/sites/geohub/src/lib/MosaicJsonData.ts
@@ -4,6 +4,7 @@ import { getBase64EncodedUrl, getRandomColormap } from './helper'
 import type { BandMetadata, RasterTileMetadata, StacItemFeature } from './types'
 import { PUBLIC_TITILER_ENDPOINT } from './variables/public'
 import type { Map, RasterLayerSpecification, RasterSourceSpecification } from 'maplibre-gl'
+import chroma from 'chroma-js'
 
 export class MosaicJsonData {
   private feature: StacItemFeature
@@ -98,7 +99,6 @@ export class MosaicJsonData {
       bounds.getNorthEast().lng,
       bounds.getNorthEast().lat,
     ]
-
     const tags: [{ key: string; value: string }] = this.feature.properties.tags as unknown as [
       { key: string; value: string },
     ]
@@ -112,7 +112,7 @@ export class MosaicJsonData {
     if (!res.ok) throw new Error(res.statusText)
     const mosaicjson = await res.json()
     const numberOfClasses = mosaicjson.classmap ? Object.keys(mosaicjson.classmap).length : 0
-    const isUniqueValueLayer = numberOfClasses > 0 && numberOfClasses <= COLOR_CLASS_COUNT_MAXIMUM ? true : false
+    const isUniqueValueLayer = numberOfClasses > 0 && numberOfClasses <= COLOR_CLASS_COUNT_MAXIMUM
     res = await fetch(mosaicjson.tilejson)
     if (!res.ok) throw new Error(res.statusText)
     const tilejson = await res.json()
@@ -133,11 +133,24 @@ export class MosaicJsonData {
         return tile
       } else {
         const _url = new URL(tile)
-        _url.searchParams.delete('colormap_name')
-        _url.searchParams.delete('rescale')
-        _url.searchParams.set('colormap_name', colormap)
-        _url.searchParams.set('rescale', [layerBandMetadataMin, layerBandMetadataMax].join(','))
-        return decodeURI(_url.toString())
+        if (isUniqueValueLayer) {
+          const colorsList = chroma.scale(colormap).colors(Object.keys(bandMetaStats.STATISTICS_UNIQUE_VALUES).length)
+          const colorMap = {}
+          Object.keys(bandMetaStats.STATISTICS_UNIQUE_VALUES).forEach((key, index) => {
+            const color = chroma(colorsList[index]).rgba()
+            colorMap[key] = [color[0], color[1], color[2], color[3] * 255]
+          })
+          _url.searchParams.delete('colormap_name')
+          _url.searchParams.delete('rescale')
+          _url.searchParams.set('colormap', JSON.stringify(colorMap))
+          return decodeURI(_url.toString())
+        } else {
+          _url.searchParams.delete('colormap_name')
+          _url.searchParams.delete('rescale')
+          _url.searchParams.set('colormap_name', colormap)
+          _url.searchParams.set('rescale', [layerBandMetadataMin, layerBandMetadataMax].join(','))
+          return decodeURI(_url.toString())
+        }
       }
     })
 
@@ -194,6 +207,7 @@ export class MosaicJsonData {
       source,
       sourceId,
       metadata: rasterInfo,
+      colormap: colormap,
     }
   }
 }

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -20,7 +20,7 @@ export class RasterTileData {
   }
 
   public getMetadata = async () => {
-    if (this.metadata) return this.metadata
+    // if (this.metadata) return this.metadata
     const b64EncodedUrl = getBase64EncodedUrl(this.url)
     const res = await fetch(`${PUBLIC_TITILER_ENDPOINT}/info?url=${b64EncodedUrl}`)
     this.metadata = await res.json()
@@ -60,7 +60,6 @@ export class RasterTileData {
 
     const bandMetaStats = rasterInfo.band_metadata[bandIndex][1] as BandMetadata
     bandMetaStats.STATISTICS_UNIQUE_VALUES = await this.getClassesMap(bandIndex, rasterInfo)
-
     const layerBandMetadataMin = bandMetaStats['STATISTICS_MINIMUM']
     const layerBandMetadataMax = bandMetaStats['STATISTICS_MAXIMUM']
 
@@ -76,7 +75,7 @@ export class RasterTileData {
       resampling: 'nearest',
       rescale: `${layerBandMetadataMin},${layerBandMetadataMax}`,
       return_mask: true,
-      colormap_name: defaultColormap,
+      colormap_name: colormap,
     }
 
     const colorMap = {}
@@ -150,7 +149,7 @@ export class RasterTileData {
       source,
       sourceId,
       metadata: rasterInfo,
-      colorMapName: colormap,
+      colormap: colormap,
     }
   }
 

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -76,6 +76,7 @@ export class RasterTileData {
       resampling: 'nearest',
       rescale: `${layerBandMetadataMin},${layerBandMetadataMax}`,
       return_mask: true,
+      colormap_name: defaultColormap,
     }
 
     const colorMap = {}

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -62,9 +62,9 @@ export class RasterTileData {
     bandMetaStats.STATISTICS_UNIQUE_VALUES = await this.getClassesMap(bandIndex, rasterInfo)
     const layerBandMetadataMin = bandMetaStats['STATISTICS_MINIMUM']
     const layerBandMetadataMax = bandMetaStats['STATISTICS_MAXIMUM']
-
+    const isUniqueValueLayer = Object.keys(bandMetaStats.STATISTICS_UNIQUE_VALUES).length > 0
     // choose default colormap randomly
-    const colormap = defaultColormap ?? getRandomColormap()
+    const colormap = defaultColormap ?? getRandomColormap(isUniqueValueLayer ? 'diverging' : 'sequential')
 
     const titilerApiUrlParams = {
       scale: 1,
@@ -79,7 +79,7 @@ export class RasterTileData {
     }
 
     const colorMap = {}
-    if (Object.keys(bandMetaStats.STATISTICS_UNIQUE_VALUES).length > 0) {
+    if (isUniqueValueLayer) {
       const colorMapKeys = Object.keys(bandMetaStats.STATISTICS_UNIQUE_VALUES)
       const colorsList = chroma.scale(colormap).colors(colorMapKeys.length)
       colorMapKeys.forEach((key, index) => {

--- a/sites/geohub/src/lib/helper/getRandomColormap.ts
+++ b/sites/geohub/src/lib/helper/getRandomColormap.ts
@@ -1,9 +1,14 @@
-import { SequentialColormaps } from '$lib/colormaps'
-
+import { SequentialColormaps, DivergingColorMaps, QualitativeColorMaps } from '$lib/colormaps'
 /**
  * choose default colormap randomly
  * @returns colormap name
  */
-export const getRandomColormap = () => {
-  return SequentialColormaps[Math.floor(Math.random() * SequentialColormaps.length)]
+export const getRandomColormap = (type: 'sequential' | 'diverging' | 'qualitative' = 'sequential') => {
+  if (type === 'sequential') {
+    return SequentialColormaps[Math.floor(Math.random() * SequentialColormaps.length)]
+  } else if (type === 'diverging') {
+    return DivergingColorMaps[Math.floor(Math.random() * DivergingColorMaps.length)]
+  } else {
+    return QualitativeColorMaps[Math.floor(Math.random() * QualitativeColorMaps.length)]
+  }
 }

--- a/sites/geohub/src/lib/types/Layer.ts
+++ b/sites/geohub/src/lib/types/Layer.ts
@@ -10,6 +10,6 @@ export interface Layer {
   children?: Layer[]
   parentId?: string
   dataset: StacItemFeature
-  colormapName?: string
+  colorMapName?: string
   classificationMethod?: ClassificationMethodTypes
 }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
For Raster layers that have unique values, the Unique Value Legend will be available by default.
Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
