### PR TITLE
fix: make width of sidebar to 100% in mobile and added xmark in sidebar

### DIFF
--- a/sites/geohub/src/components/MainApp.svelte
+++ b/sites/geohub/src/components/MainApp.svelte
@@ -13,10 +13,11 @@
 
   let innerWidth: number
   let innerHeight: number
+  $: isMobile = innerWidth < 768 ? true : false
   $: splitHeight = innerHeight - headerHeight
 
-  let initialPrimaryWidth = 355
-  let minPrimaryWidth = '400px'
+  let initialPrimaryWidth = 360
+  let minPrimaryWidth = `${initialPrimaryWidth}px`
   let minSecondaryWidth = '50%'
   let defaultsplitterSize = '10px'
   let widthPecent = 0
@@ -29,7 +30,7 @@
 
   $: if (map) {
     mapStore.update(() => map)
-    setSplitControl()
+    // setSplitControl()
   }
 
   const setWidthPercent = () => {
@@ -50,9 +51,15 @@
   const setSplitControl = () => {
     if (!splitControl) return
     if (isMenuShown === true) {
-      setWidthPercent()
-      splitControl.setPercent(widthPecent)
-      splitterSize = defaultsplitterSize
+      if (isMobile) {
+        splitControl.setPercent(100)
+        splitterSize = '0px'
+      } else {
+        const widthPecent = (initialPrimaryWidth / innerWidth) * 100
+        setWidthPercent()
+        splitControl.setPercent(widthPecent)
+        splitterSize = defaultsplitterSize
+      }
     } else {
       splitControl.setPercent(0)
       splitterSize = '0px'
@@ -67,6 +74,10 @@
 
   const splitterChanged = () => {
     resizeMap()
+  }
+
+  $: if (splitControl) {
+    setSplitControl()
   }
 </script>
 
@@ -84,13 +95,25 @@
   <Split
     initialPrimarySize={`${widthPecent}%`}
     minPrimarySize={isMenuShown ? `${minPrimaryWidth}` : '0px'}
-    minSecondarySize={minSecondaryWidth}
+    minSecondarySize={isMobile ? '0px' : minSecondaryWidth}
     {splitterSize}
     on:changed={splitterChanged}
     bind:this={splitControl}>
     <div
       slot="primary"
       class="primary-content">
+      {#if isMobile}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span
+          class="span close-icon"
+          on:click={() => {
+            isMenuShown = false
+          }}>
+          <i
+            class="fa-solid fa-circle-xmark fa-2x"
+            style="color:#1c1c1c;" />
+        </span>
+      {/if}
       <Content bind:splitterHeight={splitHeight} />
     </div>
 
@@ -114,6 +137,14 @@
   .split-container {
     .primary-content {
       position: relative;
+
+      .close-icon {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.6rem;
+        cursor: pointer;
+        z-index: 10;
+      }
     }
 
     .secondary-content {

--- a/sites/geohub/src/components/VectorLayer.svelte
+++ b/sites/geohub/src/components/VectorLayer.svelte
@@ -45,7 +45,7 @@
     <Tabs
       bind:tabs
       bind:activeTab
-      fontSize="medium"
+      fontSize={tabs.find((t) => t.label === TabNames.SIMULATION) ? 'small' : 'medium'}
       isToggleTab={true} />
 
     <p class="panel-content">


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #1329 

- make sidebar width as 100% in mobile
- revert sidebar min width to 360px, and made tab size smaller when there is simulate tab
- add xmark icon in the top-right of sidebar in mobile (no xmark in desktop)

<img width="447" alt="image" src="https://user-images.githubusercontent.com/2639701/217293440-bdd76d7f-5b70-4664-bec6-242155ef2ecb.png">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
