### PR TITLE
fix: add style for acordion to make it aligned when there is no button

### DIFF
--- a/.changeset/tame-llamas-retire.md
+++ b/.changeset/tame-llamas-retire.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+Add width style to ensure that the accordions are aligned at the same level

--- a/packages/svelte-undp-design/src/lib/Accordion/Accordion.svelte
+++ b/packages/svelte-undp-design/src/lib/Accordion/Accordion.svelte
@@ -23,8 +23,9 @@
 					{headerTitle}
 				</p>
 			</button>
-
-			<slot name="button" />
+			<div style="width:10%">
+				<slot name="button" />
+			</div>
 		</div>
 		<div
 			class={!isExpanded ? 'accordion__panel' : 'accordion--active'}
@@ -61,6 +62,7 @@
 				overflow: hidden;
 				text-overflow: ellipsis;
 				text-transform: capitalize;
+				text-align: left;
 				width: 90%;
 			}
 		}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Before the Accordion was not aligned. when there was not button. Adding a div that covers approximately the 10% of the width as the slot fixes this issue
![image](https://user-images.githubusercontent.com/45137948/217543789-42e69ac8-3f9e-4e56-bc25-c00d1a185382.png)

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
