### PR TITLE
fix: to check type is pgtilerserv or martin before setting tile.json URL

### DIFF
--- a/sites/geohub/src/lib/VectorTileData.ts
+++ b/sites/geohub/src/lib/VectorTileData.ts
@@ -74,7 +74,7 @@ export class VectorTileData {
     )
     const isPmtiles = this.url.startsWith('pmtiles://')
     let source: VectorSourceSpecification
-    if (vectorInfo.type) {
+    if (vectorInfo.type && ['pgtileserv', 'martin'].includes(vectorInfo.type.value)) {
       source = {
         type: 'vector',
         url: vectorInfo.url.replace('metadata.json', 'tile.json'),


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes error of not showing pmtiles of narok water

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
