### PR TITLE
fix: default tab on colormappicker is selected by current colormap name

### DIFF
--- a/sites/geohub/src/components/controls/ColorMapPicker.svelte
+++ b/sites/geohub/src/components/controls/ColorMapPicker.svelte
@@ -12,8 +12,8 @@
   const tippy = initTippy()
   let tooltipContent: HTMLElement
 
-  export let activeColorMapType = ColorMapTypes.SEQUENTIAL
   export let colorMapName: string
+
   export let buttonWidth = 40
 
   const dispatch = createEventDispatcher()
@@ -22,6 +22,11 @@
     { name: ColorMapTypes.DIVERGING, codes: DivergingColorMaps },
     { name: ColorMapTypes.QUALITATIVE, codes: QualitativeColorMaps },
   ]
+
+  export let activeColorMapType =
+    colorMapTypes
+      .map((type) => (type.codes.find((code) => code === colorMapName) ? type.name : null))
+      .find((name) => name !== null) || colorMapTypes[0].name
 
   let tabs: Tab[] = colorMapTypes.map((type) => {
     return { label: type.name }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request
Fixes #1326 
<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
