### PR TITLE
chore: added automerge setting

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,23 @@
     "group:allNonMajor",
     ":semanticCommitTypeAll(chore)"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": ["devDependencies", "dependencies"],
+      "matchPackageNames": ["@types/node", "vite"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePatterns": ["lint", "prettier"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
   ]


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

added automerge setting for renovate by following this example.

https://docs.renovatebot.com/key-concepts/automerge/#configuration-examples
https://github.com/sveltejs/kit/blob/0ceab95d4b463540b6391b50e9b58af391b0a461/renovate.json#L22-L25

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
