### PR TITLE
refactor: separate data loading from frontend to +page.server.ts

### DIFF
--- a/sites/geohub/src/components/DataView.svelte
+++ b/sites/geohub/src/components/DataView.svelte
@@ -32,7 +32,7 @@
   ]
   const LIMIT = SEARCH_PAGINATION_LIMIT
   let query: string
-  let queryForSearch: string
+  let queryoperator: 'and' | 'or' = 'and'
   let sortingColumn: string = SortingColumns[0].value
   let bbox: [number, number, number, number]
   let isFilterByBBox = false
@@ -123,10 +123,9 @@
         }
       }
 
-      if (queryForSearch) {
-        if (queryForSearch.length > 0) {
-          apiUrl.searchParams.set('query', queryForSearch)
-        }
+      if (query && query.length > 0) {
+        apiUrl.searchParams.set('query', query)
+        apiUrl.searchParams.set('queryoperator', queryoperator)
       }
 
       if (bbox && bbox.length === 4) {
@@ -204,7 +203,8 @@
     await searchDatasets(url)
   }
 
-  const handleFilterInput = async () => {
+  const handleFilterInput = async (e) => {
+    queryoperator = e.detail.queryoperator
     if (
       !(breadcrumbs && breadcrumbs.length > 0 && breadcrumbs[breadcrumbs.length - 1].url.startsWith('/api/datasets')) &&
       query === ''
@@ -219,7 +219,8 @@
     await searchDatasets(url)
   }
 
-  const clearFilter = async () => {
+  const clearFilter = async (e) => {
+    queryoperator = e.detail.queryoperator
     clearFiltertext()
     if (breadcrumbs && breadcrumbs.length > 0) {
       const lastCategory = breadcrumbs[breadcrumbs.length - 1]
@@ -282,7 +283,6 @@
 
   let clearFiltertext = () => {
     query = ''
-    queryForSearch = ''
   }
 </script>
 
@@ -293,7 +293,6 @@
     placeholder="Type keywords to search data"
     bind:map={$map}
     bind:query
-    bind:queryForSearch
     bind:sortingColumn
     bind:bbox
     bind:isFilterByBBox

--- a/sites/geohub/src/components/data-view/TextFilter.svelte
+++ b/sites/geohub/src/components/data-view/TextFilter.svelte
@@ -14,7 +14,6 @@
   export let map: Map
   export let placeholder: string
   export let query = ''
-  export let queryForSearch = ''
   let queryType: 'and' | 'or' = 'and'
   let queryTypes: Radio[] = [
     {
@@ -38,14 +37,14 @@
 
   $: isQueryEmpty = !query || query?.length === 0
   $: queryType, handleQueryTypeChanged()
-  $: sortingColumn, fireChangeEvent('change', true)
+  $: sortingColumn, fireChangeEvent('change')
   const handleQueryTypeChanged = () => {
     if (query === '') return
-    fireChangeEvent('change', true)
+    fireChangeEvent('change')
   }
 
   const handleFilterInput = debounce(() => {
-    fireChangeEvent('change', true)
+    fireChangeEvent('change')
   }, 500)
 
   const clearInput = () => {
@@ -54,14 +53,11 @@
     fireChangeEvent('clear')
   }
 
-  const fireChangeEvent = (eventName: 'change' | 'clear', isNormalise = false) => {
-    queryForSearch = query
-    if (isNormalise) {
-      if (query.length > 0) {
-        queryForSearch = queryForSearch.trim().replace(/\s/g, ` ${queryType} `)
-      }
-    }
-    dispatch(eventName)
+  const fireChangeEvent = (eventName: 'change' | 'clear') => {
+    dispatch(eventName, {
+      query: query,
+      queryoperator: queryType,
+    })
   }
 
   $: isFilterByBBox, registerMapMovedEvent()
@@ -91,7 +87,7 @@
       bbox = undefined
       map.off('moveend', handleMapMoved)
     }
-    fireChangeEvent('change', true)
+    fireChangeEvent('change')
   }
 </script>
 

--- a/sites/geohub/src/components/maps/MapStyleCardList.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCardList.svelte
@@ -6,15 +6,14 @@
   import Notification from '$components/controls/Notification.svelte'
   import { Pagination, Loader } from '@undp-data/svelte-undp-design'
   import { debounce } from 'lodash-es'
-  import { AccessLevel } from '$lib/constants'
+  import { AccessLevel, DEFAULT_LIMIT, LimitOptions, MapOrderByOptions } from '$lib/constants'
   import AccessLevelSwitcher from '$components/AccessLevelSwitcher.svelte'
 
   let styles: { styles: DashboardMapStyle[]; links: StacLink[]; pages: Pages } = $page.data.styles
 
   let isLoading = false
 
-  let limits = [5, 10, 25, 50, 100]
-  let limit = $page.url.searchParams.get('limit') ? Number($page.url.searchParams.get('limit')) : 10
+  let limit = $page.url.searchParams.get('limit') ? Number($page.url.searchParams.get('limit')) : DEFAULT_LIMIT
   let offset = $page.url.searchParams.get('offset') ? Number($page.url.searchParams.get('offset')) : 0
 
   let query = $page.url.searchParams.get('query') ?? ''
@@ -50,36 +49,17 @@
 
   $: isQueryEmpty = !query || query?.length === 0
 
-  let orderbyOptions = [
-    {
-      value: 'updatedat,desc',
-      label: 'Most recent',
-    },
-    {
-      value: 'updatedat,asc',
-      label: 'less recent',
-    },
-    {
-      value: 'name,asc',
-      label: 'A to Z',
-    },
-    {
-      value: 'name,desc',
-      label: 'Z to A',
-    },
-  ]
-
   const getSortByFromUrl = (url: URL) => {
     const sortByValue = url.searchParams.get('sortby')
     if (sortByValue) {
-      const option = orderbyOptions.find((opt) => opt.value === sortByValue)
+      const option = MapOrderByOptions.find((opt) => opt.value === sortByValue)
       if (option) {
         return option.value
       }
     }
   }
 
-  let sortby = getSortByFromUrl($page.url) ?? orderbyOptions[0].value
+  let sortby = getSortByFromUrl($page.url) ?? MapOrderByOptions[0].value
 
   $: limit, handleLimitChanged()
   $: sortby, handleSortbyChanged()
@@ -122,6 +102,7 @@
       isLoading = true
       await goto(`?${url.searchParams.toString()}`, {
         invalidateAll: true,
+        noScroll: true,
       })
       styles = $page.data.styles
     } finally {
@@ -220,7 +201,7 @@
       <label class="label">Order by:</label>
       <div class="select">
         <select bind:value={sortby}>
-          {#each orderbyOptions as option}
+          {#each MapOrderByOptions as option}
             <option value={option.value}>{option.label}</option>
           {/each}
         </select>
@@ -234,7 +215,7 @@
       <label class="label">Shown in:</label>
       <div class="select">
         <select bind:value={limit}>
-          {#each limits as limit}
+          {#each LimitOptions as limit}
             <option value={limit}>{limit}</option>
           {/each}
         </select>

--- a/sites/geohub/src/lib/constants.ts
+++ b/sites/geohub/src/lib/constants.ts
@@ -101,6 +101,9 @@ export enum AccessLevel {
   PUBLIC = 3,
 }
 
+export const LimitOptions = [5, 10, 25, 50, 100]
+export const DEFAULT_LIMIT = 10
+
 export const styles: StyleDefinition[] = [
   {
     title: 'Carto',
@@ -281,3 +284,22 @@ export const footerItems: { [key: string]: { title: string; url: string }[] } = 
     },
   ],
 }
+
+export const MapOrderByOptions = [
+  {
+    value: 'updatedat,desc',
+    label: 'Most recent',
+  },
+  {
+    value: 'updatedat,asc',
+    label: 'less recent',
+  },
+  {
+    value: 'name,asc',
+    label: 'A to Z',
+  },
+  {
+    value: 'name,desc',
+    label: 'Z to A',
+  },
+]

--- a/sites/geohub/src/lib/constants.ts
+++ b/sites/geohub/src/lib/constants.ts
@@ -201,6 +201,7 @@ export const DatasetSearchQueryParams = [
   'sortby',
   'operator',
   'staronly',
+  'queryoperator',
 ]
 
 export const tagSearchKeys = [

--- a/sites/geohub/src/lib/server/helpers/createDatasetSearchWhereExpression.ts
+++ b/sites/geohub/src/lib/server/helpers/createDatasetSearchWhereExpression.ts
@@ -2,6 +2,10 @@ import { DatasetSearchQueryParams } from '$lib/constants'
 
 export const createDatasetSearchWhereExpression = async (url: URL, tableAlias: string, user_email?: string) => {
   let query = url.searchParams.get('query')
+  let queryOperator = url.searchParams.get('queryoperator')
+  if (!(queryOperator && ['and', 'or'].includes(queryOperator.trim().toLowerCase()))) {
+    queryOperator = 'and'
+  }
   const bbox = url.searchParams.get('bbox')
   let bboxCoordinates: number[]
   if (bbox) {
@@ -32,10 +36,8 @@ export const createDatasetSearchWhereExpression = async (url: URL, tableAlias: s
   const values = []
   if (query) {
     // normalise query text for to_tsquery function
-    query = query
-      .toLowerCase()
-      .replace(/\r?\s+and\s+/g, ' & ') // convert 'and' to '&'
-      .replace(/\r?\s+or\s+/g, ' | ') // convert 'or' to '|'
+    queryOperator = queryOperator.trim().toLowerCase()
+    query = query.toLowerCase().replace(/\s/g, ` ${queryOperator === 'and' ? '&' : '|'} `)
     values.push(query)
   }
 

--- a/sites/geohub/src/routes/data/+page.server.ts
+++ b/sites/geohub/src/routes/data/+page.server.ts
@@ -1,12 +1,11 @@
 import type { PageServerLoad } from './$types'
-import { error } from '@sveltejs/kit'
 import type { DatasetFeatureCollection } from '$lib/types'
 import { DEFAULT_LIMIT, SortingColumns } from '$lib/constants'
 
 export const load: PageServerLoad = async (event) => {
   const { locals, url } = event
   const session = await locals.getSession()
-  if (!session) throw error(403, { message: 'No permission' })
+  if (!session) return {}
 
   const limit = url.searchParams.get('limit') ? url.searchParams.get('limit') : `${DEFAULT_LIMIT}`
   const offset = url.searchParams.get('offset') ? url.searchParams.get('offset') : '0'

--- a/sites/geohub/src/routes/data/+page.server.ts
+++ b/sites/geohub/src/routes/data/+page.server.ts
@@ -1,44 +1,20 @@
 import type { PageServerLoad } from './$types'
 import { error } from '@sveltejs/kit'
 import type { DatasetFeatureCollection } from '$lib/types'
+import { DEFAULT_LIMIT, SortingColumns } from '$lib/constants'
 
 export const load: PageServerLoad = async (event) => {
   const { locals, url } = event
   const session = await locals.getSession()
   if (!session) throw error(403, { message: 'No permission' })
 
-  const limit = url.searchParams.get('limit') ? url.searchParams.get('limit') : '5'
+  const limit = url.searchParams.get('limit') ? url.searchParams.get('limit') : `${DEFAULT_LIMIT}`
   const offset = url.searchParams.get('offset') ? url.searchParams.get('offset') : '0'
 
   let sortby = url.searchParams.get('sortby')
-  let sortByColumn = 'name'
-  let SortOrder: 'asc' | 'desc' = 'asc'
-  if (sortby) {
-    const values = sortby.split(',')
-    const column: string = values[0].trim().toLowerCase()
-    if (column) {
-      const targetSortingColumns = ['name', 'license', 'createdat', 'updatedat', 'no_stars']
-      const targetSortingOrder = ['asc', 'desc']
-      if (!targetSortingColumns.includes(column)) {
-        console.log(targetSortingColumns, column)
-        throw error(400, {
-          message: `Bad parameter for 'sortby'. It must be one of '${targetSortingColumns.join(', ')}'`,
-        })
-      }
-      sortByColumn = column
-
-      if (values.length > 1) {
-        const order: string = values[1].trim().toLowerCase()
-        if (!targetSortingOrder.includes(order)) {
-          throw error(400, {
-            message: `Bad parameter for 'sortby'. Sorting order must be one of '${targetSortingOrder.join(', ')}'`,
-          })
-        }
-        SortOrder = order as 'asc' | 'desc'
-      }
-    }
+  if (!(sortby && SortingColumns?.find((v) => v.value === sortby))) {
+    sortby = SortingColumns[0].value
   }
-  sortby = [sortByColumn, SortOrder].join(',')
 
   const query = url.searchParams.get('query')
 
@@ -52,11 +28,10 @@ export const load: PageServerLoad = async (event) => {
     params.query = query
   }
 
-  const res = await event.fetch(
-    `/api/datasets?${Object.keys(params)
-      .map((p) => `${p}=${params[p]}`)
-      .join('&')}`,
-  )
+  const apiUrl = `/api/datasets?${Object.keys(params)
+    .map((p) => `${p}=${params[p]}`)
+    .join('&')}`
+  const res = await event.fetch(apiUrl)
   const features: DatasetFeatureCollection = await res.json()
 
   return {

--- a/sites/geohub/src/routes/data/+page.svelte
+++ b/sites/geohub/src/routes/data/+page.svelte
@@ -37,28 +37,19 @@
 
   const handleFilterInput = debounce(async (e) => {
     query = (e.target as HTMLInputElement).value
-    let queryForSearch = query
     if (query.length > 0) {
-      queryForSearch = normaliseQuery()
       offset = '0'
 
       const link = fc.links.find((l) => l.rel === 'self')
       if (link) {
         const href = new URL(link.href)
-        href.searchParams.set('query', queryForSearch)
+        href.searchParams.set('query', query.trim())
+        href.searchParams.set('queryoperator', 'and')
         href.searchParams.set('offset', offset)
         await reload(href)
       }
     }
   }, 500)
-
-  const normaliseQuery = () => {
-    if (query.length > 0) {
-      return query.trim().replace(/\s/g, ` and `)
-    } else {
-      return query
-    }
-  }
 
   const clearInput = async () => {
     if (isQueryEmpty === true) return

--- a/sites/geohub/src/routes/data/+page.svelte
+++ b/sites/geohub/src/routes/data/+page.svelte
@@ -3,7 +3,7 @@
   import { goto } from '$app/navigation'
   import type { DatasetFeatureCollection } from '$lib/types'
   import { Accordion, Pagination, Loader } from '@undp-data/svelte-undp-design'
-  import { SortingColumns } from '$lib/constants'
+  import { DEFAULT_LIMIT, LimitOptions, SortingColumns } from '$lib/constants'
   import { debounce } from 'lodash-es'
   import Notification from '$components/controls/Notification.svelte'
   import DataCardInfo from '$components/data-view/DataCardInfo.svelte'
@@ -13,8 +13,7 @@
   let expanded: { [key: string]: boolean } = {}
   let isLoading = false
 
-  let limits = [5, 10, 25, 50, 100].map((n) => `${n}`)
-  let limit = $page.url.searchParams.get('limit') ? $page.url.searchParams.get('limit') : '10'
+  let limit = $page.url.searchParams.get('limit') ? $page.url.searchParams.get('limit') : `${DEFAULT_LIMIT}`
   let offset = $page.url.searchParams.get('offset') ? $page.url.searchParams.get('offset') : '0'
   let sortby = $page.url.searchParams.get('sortby') ? $page.url.searchParams.get('sortby') : 'name,asc'
   let query = $page.url.searchParams.get('query') ?? ''
@@ -28,6 +27,7 @@
       isLoading = true
       await goto(`?${url.searchParams.toString()}`, {
         invalidateAll: true,
+        noScroll: true,
       })
       fc = $page.data.features
     } finally {
@@ -91,7 +91,7 @@
   const handleSortbyChanged = async () => {
     offset = '0'
 
-    const link = fc.links.find((l) => l.rel === 'self')
+    const link = fc.links?.find((l) => l.rel === 'self')
     if (link) {
       const href = new URL(link.href)
       href.searchParams.set('sortby', sortby)
@@ -177,8 +177,8 @@
       <label class="label">Shown in:</label>
       <div class="select">
         <select bind:value={limit}>
-          {#each limits as limit}
-            <option value={limit}>{limit}</option>
+          {#each LimitOptions as limit}
+            <option value={`${limit}`}>{limit}</option>
           {/each}
         </select>
       </div>
@@ -190,7 +190,7 @@
   <div class="align-center">
     <Loader />
   </div>
-{:else if fc.pages.totalCount > 0}
+{:else if fc.pages?.totalCount > 0}
   {#each fc.features as feature}
     <Accordion
       headerTitle={feature.properties.name}

--- a/sites/geohub/src/routes/data/publish/+page.server.ts
+++ b/sites/geohub/src/routes/data/publish/+page.server.ts
@@ -17,7 +17,7 @@ import { AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_ACCOUNT_UPLOAD } from '$lib/server
  */
 export const load: PageServerLoad = async ({ locals, url }) => {
   const session = await locals.getSession()
-  if (!session) throw error(403, { message: 'No permission' })
+  if (!session) return
 
   let datasetUrl = url.searchParams.get('url')
   if (!datasetUrl) {

--- a/sites/geohub/src/routes/data/upload/+page.server.ts
+++ b/sites/geohub/src/routes/data/upload/+page.server.ts
@@ -15,8 +15,7 @@ const FOLDER_NAME = 'raw'
 
 export const load: PageServerLoad = async ({ locals }) => {
   const session = await locals.getSession()
-  if (!session) throw error(403, { message: 'No permission' })
-  return {}
+  if (!session) return
 }
 
 export const actions = {
@@ -26,9 +25,7 @@ export const actions = {
   getSasUrl: async ({ request, locals }) => {
     try {
       const session = await locals.getSession()
-      if (!session) {
-        return fail(403, { message: 'No permission' })
-      }
+      if (!session) return {}
       const user_email = session?.user.email
       const userHash = generateHashKey(user_email)
       const fileName = (await request.formData()).get('fileName') as string

--- a/sites/geohub/src/routes/maps/+page.server.ts
+++ b/sites/geohub/src/routes/maps/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types'
 import { getMapStats } from '$lib/server/helpers'
-import { AccessLevel } from '$lib/constants'
+import { AccessLevel, DEFAULT_LIMIT, MapOrderByOptions } from '$lib/constants'
 import type { DashboardMapStyle, Pages, StacLink } from '$lib/types'
 
 export const load: PageServerLoad = async (event) => {
@@ -8,35 +8,13 @@ export const load: PageServerLoad = async (event) => {
 
   const map_stats = await getMapStats()
 
-  const limit: string = url.searchParams.get('limit') ?? '10'
+  const limit: string = url.searchParams.get('limit') ?? `${DEFAULT_LIMIT}`
   const offset: string = url.searchParams.get('offset') ?? '0'
 
   let sortby = url.searchParams.get('sortby')
-  let sortByColumn = 'name'
-  let SortOrder: 'asc' | 'desc' = 'desc'
-  if (sortby) {
-    const values = sortby.split(',')
-    const column: string = values[0].trim().toLowerCase()
-    if (column) {
-      const targetSortingColumns = ['updatedat', 'name']
-      const targetSortingOrder = ['asc', 'desc']
-      if (!targetSortingColumns.includes(column)) {
-        sortByColumn = 'updatedat'
-      } else {
-        sortByColumn = column
-      }
-
-      if (values.length > 1) {
-        const order: string = values[1].trim().toLowerCase()
-        if (!targetSortingOrder.includes(order)) {
-          SortOrder = 'desc'
-        } else {
-          SortOrder = order as 'asc' | 'desc'
-        }
-      }
-    }
+  if (!(sortby && MapOrderByOptions?.find((v) => v.value === sortby))) {
+    sortby = MapOrderByOptions[0].value
   }
-  sortby = [sortByColumn, SortOrder].join(',')
 
   let accesslevel: string = !locals.session ? `${AccessLevel.PUBLIC}` : url.searchParams.get('accesslevel')
   if (!accesslevel) {

--- a/sites/geohub/src/routes/maps/+page.server.ts
+++ b/sites/geohub/src/routes/maps/+page.server.ts
@@ -1,10 +1,68 @@
 import type { PageServerLoad } from './$types'
 import { getMapStats } from '$lib/server/helpers'
+import { AccessLevel } from '$lib/constants'
+import type { DashboardMapStyle, Pages, StacLink } from '$lib/types'
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async (event) => {
+  const { locals, url } = event
+
   const map_stats = await getMapStats()
-  const data = {
-    stats: map_stats,
+
+  const limit: string = url.searchParams.get('limit') ?? '10'
+  const offset: string = url.searchParams.get('offset') ?? '0'
+
+  let sortby = url.searchParams.get('sortby')
+  let sortByColumn = 'name'
+  let SortOrder: 'asc' | 'desc' = 'desc'
+  if (sortby) {
+    const values = sortby.split(',')
+    const column: string = values[0].trim().toLowerCase()
+    if (column) {
+      const targetSortingColumns = ['updatedat', 'name']
+      const targetSortingOrder = ['asc', 'desc']
+      if (!targetSortingColumns.includes(column)) {
+        sortByColumn = 'updatedat'
+      } else {
+        sortByColumn = column
+      }
+
+      if (values.length > 1) {
+        const order: string = values[1].trim().toLowerCase()
+        if (!targetSortingOrder.includes(order)) {
+          SortOrder = 'desc'
+        } else {
+          SortOrder = order as 'asc' | 'desc'
+        }
+      }
+    }
   }
-  return data
+  sortby = [sortByColumn, SortOrder].join(',')
+
+  let accesslevel: string = !locals.session ? `${AccessLevel.PUBLIC}` : url.searchParams.get('accesslevel')
+  if (!accesslevel) {
+    accesslevel = `${AccessLevel.PRIVATE}`
+  }
+
+  const query: string = url.searchParams.get('query') ?? ''
+
+  const params: { [key: string]: string } = {
+    limit,
+    offset,
+    sortby,
+    accesslevel,
+  }
+  if (query) {
+    params.query = query
+  }
+
+  const apiUrl = `/api/style?${Object.keys(params)
+    .map((p) => `${p}=${params[p]}`)
+    .join('&')}`
+  const res = await event.fetch(apiUrl)
+  const styles: { styles: DashboardMapStyle[]; links: StacLink[]; pages: Pages } = await res.json()
+
+  return {
+    stats: map_stats,
+    styles,
+  }
 }

--- a/sites/geohub/src/routes/maps/+page.server.ts
+++ b/sites/geohub/src/routes/maps/+page.server.ts
@@ -16,11 +16,11 @@ export const load: PageServerLoad = async (event) => {
     sortby = MapOrderByOptions[0].value
   }
 
-  let accesslevel: string = !locals.session ? `${AccessLevel.PUBLIC}` : url.searchParams.get('accesslevel')
+  const session = await locals.getSession()
+  let accesslevel: string = !session ? `${AccessLevel.PUBLIC}` : url.searchParams.get('accesslevel')
   if (!accesslevel) {
     accesslevel = `${AccessLevel.PRIVATE}`
   }
-
   const query: string = url.searchParams.get('query') ?? ''
 
   const params: { [key: string]: string } = {

--- a/sites/geohub/static/api/docs/swagger.yaml
+++ b/sites/geohub/static/api/docs/swagger.yaml
@@ -280,6 +280,15 @@ paths:
           in: query
           name: staronly
           description: 'if true, only search for favourite datasets'
+        - schema:
+            type: string
+            default: and
+            enum:
+              - and
+              - or
+          in: query
+          name: queryoperator
+          description: operator for query search. convert space to either 'and' or 'or'
   /stac/mosaicjson:
     get:
       summary: STAC mosaicjson processing API


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- separate logic of loading styles from frontend side to backend.
- added `queryoperator` (either `and` or `or`, default is `and`) in /datasets api. Now you just type keywords in `query` param with spaces. and /datasets api will handle to replace spaces to equivalent operator according to `queryoperator` param. 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
