### PR TITLE
fix: set nearest for resampling of mosaicjson as default, and delete help from raster property editor to make it compact

### DIFF
--- a/sites/geohub/src/components/controls/RasterPropertyEditor.svelte
+++ b/sites/geohub/src/components/controls/RasterPropertyEditor.svelte
@@ -54,7 +54,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">Increase or reduce the maximum brightness of the image</p>
     </div>
 
     <div class="field">
@@ -64,7 +63,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">Increase or reduce the minimum brightness of the image</p>
     </div>
 
     <div class="field">
@@ -74,7 +72,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">Increase or reduce the contrast of the image</p>
     </div>
 
     <div class="field">
@@ -84,7 +81,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">Rotates hues around the color wheel</p>
     </div>
 
     <div class="field">
@@ -94,7 +90,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">The resampling/interpolation method to use for overscaling</p>
     </div>
 
     <div class="field">
@@ -104,7 +99,6 @@
           bind:map={$map}
           bind:layerId />
       </div>
-      <p class="help is-link is-size-6">Increase or reduce the saturation of the image</p>
     </div>
   </div>
 </div>

--- a/sites/geohub/src/lib/MosaicJsonData.ts
+++ b/sites/geohub/src/lib/MosaicJsonData.ts
@@ -197,6 +197,9 @@ export class MosaicJsonData {
       layout: {
         visibility: 'visible',
       },
+      paint: {
+        'raster-resampling': 'nearest',
+      },
     }
 
     let firstSymbolId = undefined


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- set raster resampling for mosaicjson
- delete help from raster property editor to make it compact

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
