### PR TITLE
fix: added space, &, % for file name validation

### DIFF
--- a/sites/geohub/src/routes/data/upload/+page.svelte
+++ b/sites/geohub/src/routes/data/upload/+page.svelte
@@ -84,8 +84,14 @@
       return
     }
 
-    if (!isValidFilename(names[0]) || /[+\s&%]/g.test(names[0])) {
-      toast.push(`Special characters (<, >, ", /, \\, |, ?, *, +, &, %, space, tab) cannot be used in file name.`)
+    if (
+      !isValidFilename(names[0]) ||
+      /[+\s&%]/g.test(names[0]) ||
+      /[^\u0000-\u007F]+/g.test(names[0]) // eslint-disable-line no-control-regex
+    ) {
+      toast.push(
+        `Special characters (<, >, ", /, \\, |, ?, *, +, &, %, space, tab and non-ascii letters) cannot be used in file name.`,
+      )
       return
     }
 

--- a/sites/geohub/src/routes/data/upload/+page.svelte
+++ b/sites/geohub/src/routes/data/upload/+page.svelte
@@ -84,8 +84,8 @@
       return
     }
 
-    if (!isValidFilename(names[0]) || /\+/g.test(names[0])) {
-      toast.push(`Special characters (<, >, ", /, \\, |, ?, *, +) cannot be used in file name.`)
+    if (!isValidFilename(names[0]) || /[+\s&%]/g.test(names[0])) {
+      toast.push(`Special characters (<, >, ", /, \\, |, ?, *, +, &, %, space, tab) cannot be used in file name.`)
       return
     }
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

added space, &, % for file name validation

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with pnpm test and lint the project with pnpm lint and pnpm check
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
