### PR TITLE
fix: bug of ingesting api. now it can detect all ingested datasets

### DIFF
--- a/sites/geohub/src/lib/types/TileJson.ts
+++ b/sites/geohub/src/lib/types/TileJson.ts
@@ -1,5 +1,3 @@
-import type { VectorLayerTileStatLayer } from './VectorLayerTileStatLayer'
-
 //https://github.com/mapbox/tilejson-spec/tree/master/3.0.0
 export interface TileJson {
   tilejson: '3.0.0'

--- a/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
@@ -99,7 +99,8 @@ export const GET: RequestHandler = async ({ locals }) => {
         const properties = await blockBlobClient.getProperties()
         const names = item.name.split('/')
         const file_name = names[names.length - 1]
-        if (file_name === rawName) {
+
+        if (file_name.indexOf('.ingesting') === -1) {
           const _url = `${azureBaseUrl}/${UPLOAD_CONTAINER_NAME}/${item.name}`
           ingesting.id = generateHashKey(_url)
           ingesting.name = file_name
@@ -108,7 +109,7 @@ export const GET: RequestHandler = async ({ locals }) => {
           ingesting.createdat = properties.createdOn.toISOString()
           ingesting.updatedat = properties.lastModified.toISOString()
           ingesting.processing = false
-        } else if (file_name === `${rawName}.ingesting`) {
+        } else {
           ingesting.processing = true
           ingesting.processingFile = `${azureBaseUrl}/${UPLOAD_CONTAINER_NAME}/${item.name}${ACCOUNT_SAS_TOKEN_URL}`
         }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

now it can fetch all ingested datasets under datasets folder

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
