### PR TITLE
fix: set defaultcolor value (transparent color) for interval/categorical expression

### DIFF
--- a/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
@@ -292,7 +292,7 @@
 
             const propertySelectValues = []
             const values = stat.values
-            if (values && values.length > 0 && values.length <= UniqueValueThreshold) {
+            if (stat.type !== 'number' && values && values.length > 0 && values.length <= UniqueValueThreshold) {
               hasUniqueValues = true
               applyToOption = VectorApplyToTypes.COLOR
 
@@ -349,6 +349,7 @@
     const statLayer = vectorInfo.json.tilestats.layers.find((l) => l.layer === layerStyle['source-layer'])
     const attribute = statLayer?.attributes.find((attr) => attr.attribute === propertySelectValue)
     const vectorLegendType = attribute.type !== 'number' ? 'categorical' : 'interval'
+    let defaultColorValue = 'rgba(0,0,0,0)'
     if (layerType === 'fill') {
       let stops = colorMapRows.map((row) => {
         const rgb = `rgba(${row.color[0]}, ${row.color[1]}, ${row.color[2]}, ${row.color[3]})`
@@ -371,11 +372,13 @@
         property: propertySelectValue,
         type: vectorLegendType,
         stops: outlineStops,
+        default: defaultColorValue,
       })
       $map.setPaintProperty(layer.id, 'fill-color', {
         type: vectorLegendType,
         property: propertySelectValue,
         stops: stops,
+        default: defaultColorValue,
       })
     } else {
       let stops = colorMapRows.map((row) => {
@@ -400,6 +403,7 @@
               type: vectorLegendType,
               property: propertySelectValue,
               stops: stops,
+              default: defaultColorValue,
             })
           } else if (layerType === 'line') {
             $map.setPaintProperty(layer.id, 'line-width', getLineWidth($map, layer.id))
@@ -407,6 +411,7 @@
               type: vectorLegendType,
               property: propertySelectValue,
               stops: stops,
+              default: defaultColorValue,
             })
           }
         } else if (applyToOption === VectorApplyToTypes.SIZE) {
@@ -434,6 +439,7 @@
               property: propertySelectValue,
               type: 'interval',
               stops: newStops,
+              default: defaultColorValue,
             })
           } else if (layerType === 'line') {
             const newStops = stops.map((item) => [item[0] as number, (item[1] as number) / $map.getZoom()])
@@ -444,6 +450,7 @@
               property: propertySelectValue,
               type: 'interval',
               stops: newStops,
+              default: defaultColorValue,
             })
           }
         }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

closes #1514

This PR is going to set default color when the property value is NULL for vector interval or categorical legend.
I set default color as `rgba(0,0,0,0)` (transparent value).

https://maplibre.org/maplibre-gl-js-docs/style-spec/other/#function-default

However, new view layers which are from pg_tileserv has numeric value as string data type, if we select `value_yyyy` column, it cannot be visualised. but the error was solved now. no weird error from maplibre

Furthermore, I force to use interval legend if the value is number

<img width="889" alt="MicrosoftTeams-image" src="https://user-images.githubusercontent.com/2639701/224479590-0b9ea6cb-a1f9-4806-9477-54152f2d7371.png">

<img width="522" alt="MicrosoftTeams-image (1)" src="https://user-images.githubusercontent.com/2639701/224479596-e08c21bd-213f-49bd-bf2a-318c3f24a711.png">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
