### PR TITLE
fix: set default iconSize and lineWidth to zero for classify legend.

### DIFF
--- a/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
@@ -439,7 +439,7 @@
               property: propertySelectValue,
               type: 'interval',
               stops: newStops,
-              default: defaultColorValue,
+              default: 0,
             })
           } else if (layerType === 'line') {
             const newStops = stops.map((item) => [item[0] as number, (item[1] as number) / $map.getZoom()])
@@ -450,7 +450,7 @@
               property: propertySelectValue,
               type: 'interval',
               stops: newStops,
-              default: defaultColorValue,
+              default: 0,
             })
           }
         }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I did a mistake to set color value for icon-size and line-width. I set zero because NULL value should not be shown

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
