### PR TITLE
fix: use uniquevalue legend if value is only one

### DIFF
--- a/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
@@ -292,7 +292,10 @@
 
             const propertySelectValues = []
             const values = stat.values
-            if (stat.type !== 'number' && values && values.length > 0 && values.length <= UniqueValueThreshold) {
+            if (
+              (values && values.length === 1) ||
+              (stat.type !== 'number' && values && values.length > 0 && values.length <= UniqueValueThreshold)
+            ) {
               hasUniqueValues = true
               applyToOption = VectorApplyToTypes.COLOR
 

--- a/sites/geohub/src/lib/helper/getIntervalList.ts
+++ b/sites/geohub/src/lib/helper/getIntervalList.ts
@@ -12,9 +12,13 @@ export const getIntervalList = (
 ) => {
   let intervalList: number[]
   if (classificationMethod === ClassificationMethodTypes.NATURAL_BREAK) {
-    intervalList = new Jenks([layerMin, ...randomSample, layerMax], numberOfClasses).naturalBreak().map((element) => {
-      return Number(element.toFixed(2))
-    })
+    if (layerMin === layerMax) {
+      return [layerMin, layerMax]
+    } else {
+      intervalList = new Jenks([layerMin, ...randomSample, layerMax], numberOfClasses).naturalBreak().map((element) => {
+        return Number(element.toFixed(2))
+      })
+    }
   } else if ((classificationMethod === ClassificationMethodTypes.LOGARITHMIC && layerMin < 1) || layerMax < 1) {
     const range = layerMax - layerMin
     const positive = [layerMin, ...randomSample, layerMax].map((v) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #1538

use unique value legend if values is only one

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
