### PR TITLE
feat: enabled to edit/register pgtileserv layer if user is superuser

### DIFF
--- a/sites/geohub/src/components/data-upload/DataPreview.svelte
+++ b/sites/geohub/src/components/data-upload/DataPreview.svelte
@@ -22,16 +22,20 @@
   export let url: string
   export let size: 'is-small' | 'is-normal' | 'is-medium' | 'is-large' = 'is-small'
   export let disabled = false
+  export let feature: DatasetFeature = undefined
 
   let isPmtiles = url.indexOf('.pmtiles') !== -1 ? true : false
 
-  let feature: DatasetFeature = {
-    type: 'Feature',
-    properties: {
-      id,
-      url: isPmtiles ? `pmtiles://${url}` : url,
-      is_raster: !isPmtiles,
-    },
+  if (!feature) {
+    // if no feature is given, create feature object with minimum property
+    feature = {
+      type: 'Feature',
+      properties: {
+        id,
+        url: isPmtiles ? `pmtiles://${url}` : url,
+        is_raster: isPmtiles,
+      },
+    }
   }
 
   const handleLinkClicked = () => {

--- a/sites/geohub/src/components/data-view/MiniMap.svelte
+++ b/sites/geohub/src/components/data-view/MiniMap.svelte
@@ -35,7 +35,6 @@
   let isLoading = false
 
   export let metadata: RasterTileMetadata | VectorTileMetadata = undefined
-
   const is_raster: boolean = feature.properties.is_raster as unknown as boolean
   const url: string = feature.properties.url
 

--- a/sites/geohub/src/routes/data/publish/+page.svelte
+++ b/sites/geohub/src/routes/data/publish/+page.svelte
@@ -152,6 +152,7 @@
       <DataPreview
         size="is-normal"
         id={feature.properties.id}
+        bind:feature={data.feature}
         url={feature.properties.url.replace('pmtiles://', '')} />
     </div>
   </div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

this PR is going to enable `/data/publish` page to edit/register pgtileserv layers if login user is superuser. 

Note. pgtileserv layers are not shown in `/data` page. This is very secret feature for super user.

For using this feature, just open URL like below.

https://dev.undpgeohub.org/data/publish?url=https://pgtileserv.undpgeohub.org/rwanda.water_facilities/{z}/{x}/{y}.pbf

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
