### PR TITLE
fix: disabled commands for azblob, pgtileserv and cogunit

### DIFF
--- a/.changeset/slow-gorillas-decide.md
+++ b/.changeset/slow-gorillas-decide.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/geohub-cli": major
+---
+
+disabled commands for azblob, pgtileserv and cogunit

--- a/packages/geohub-cli/README.md
+++ b/packages/geohub-cli/README.md
@@ -13,33 +13,10 @@ Options:
   -h, --help        display help for command
 
 Commands:
-  azblob [options]      scan azure blob containers to register metadata into PostgreSQL database.
-  martin [options]      scan martin layers to register metadata into PostgreSQL database.
-  pgtileserv [options]  scan pg_tileserv layers to register metadata into PostgreSQL database.
-  stac [options]        scan STAC collections to register metadata into PostgreSQL database.
-  delete [options]      Delete items by storage URL
-  help [command]        display help for command
+  martin [options]  scan martin layers to register metadata into PostgreSQL database.
+  stac [options]    scan STAC collections to register metadata into PostgreSQL database.
+  help [command]    display help for command
 ```
-
-- Register Azure Blob Containers
-
-```shell
-$geohub azblob -h
-Usage: geohub azblob [options]
-
-scan azure blob containers to register metadata into PostgreSQL database.
-
-Options:
-  -d, --database <dsn>                           PostgreSQL database connection string
-  -a, --azaccount <azure_storage_account>        Azure Storage Account
-  -k, --azaccountkey <azure_storage_access_key>  Azure Storage Access Key
-  -n, --name [container_name...]                 Targeted Azure Blob Container name to scan. It will scan all containers if it is not specified.
-  -o, --output [output]                          Output directory for temporary working folder (default: "tmp")
-  -t, --titiler-url [titiler-url]                base URL for titiler (default: "https://titiler.undpgeohub.org")
-  -h, --help                                     display help for command
-```
-
-it takes approximately 23 minutes to finish importing all Azure blob containers (20 NO) of geohub.
 
 - Register martin layers
 
@@ -54,21 +31,6 @@ Options:
   -m, --martin-url [martin-url]  URL for martin index.json (default: "https://martin.undpgeohub.org/index.json")
   -o, --output [output]          Output directory for temporary working folder (default: "tmp")
   -h, --help                     display help for command
-```
-
-- Register pg_tilesrev layers
-
-```shell
-$geohub pgtileserv -h
-Usage: geohub pgtileserv [options]
-
-scan pg_tileserv layers to register metadata into PostgreSQL database.
-
-Options:
-  -d, --database <dsn>                   PostgreSQL database connection string
-  -p, --pgtileserv-url [pgtileserv-url]  URL for pg_tileserv index.json (default: "https://pgtileserv.undpgeohub.org/index.json")
-  -o, --output [output]                  Output directory for temporary working folder (default: "tmp")
-  -h, --help                             display help for command
 ```
 
 - Register STAC collections

--- a/packages/geohub-cli/src/cli/index.ts
+++ b/packages/geohub-cli/src/cli/index.ts
@@ -1,18 +1,18 @@
 import { Command } from 'commander';
-import azblob from './azblob';
 import martin from './martin';
-import pgtileserv from './pgtileserv';
 import stac from './stac';
-import cogUnit from './cog-unit-update';
+// import azblob from './azblob';
+// import pgtileserv from './pgtileserv';
+// import cogUnit from './cog-unit-update';
 
 const program = new Command();
 const version = require('../../package.json').version;
 program
 	.version(version, '-v, --version', 'output the version number')
-	.addCommand(azblob)
+	// .addCommand(azblob)
+	// .addCommand(pgtileserv)
+	// .addCommand(cogUnit)
 	.addCommand(martin)
-	.addCommand(pgtileserv)
-	.addCommand(stac)
-	.addCommand(cogUnit);
+	.addCommand(stac);
 
 program.parse(process.argv);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

disabled commands to update azblob and pgtileserv because it will break our database if we use it now.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
