### PR TITLE
chore: enable `data` menu in header and footer

### DIFF
--- a/sites/geohub/src/components/Header.svelte
+++ b/sites/geohub/src/components/Header.svelte
@@ -42,7 +42,7 @@
           initLinks()
         },
       },
-      ...HeaderItems(['maps', /*'data',**/ 'dashboard', 'userguide']),
+      ...HeaderItems(['maps', 'data', 'dashboard', 'userguide']),
     ]
 
     if ($page.data.session && $layerList.length > 0) {

--- a/sites/geohub/src/lib/config/AppConfig/FooterItems.ts
+++ b/sites/geohub/src/lib/config/AppConfig/FooterItems.ts
@@ -8,10 +8,10 @@ export const FooterItems: { [key: string]: { title: string; url: string }[] } = 
       title: 'Shared Maps',
       url: '/maps',
     },
-    // {
-    //   title: 'My datasets',
-    //   url: '/data',
-    // },
+    {
+      title: 'My datasets',
+      url: '/data',
+    },
     {
       title: 'User Guide',
       url: 'https://docs.undpgeohub.org',

--- a/sites/geohub/src/routes/+error.svelte
+++ b/sites/geohub/src/routes/+error.svelte
@@ -4,7 +4,7 @@
   import { FooterItems, HeaderItems } from '$lib/config/AppConfig'
   import { Footer, Header, type HeaderLink } from '@undp-data/svelte-undp-design'
 
-  let links: HeaderLink[] = HeaderItems(['home', 'maps', /*'data',**/ 'dashboard', 'userguide'])
+  let links: HeaderLink[] = HeaderItems(['home', 'maps', 'data', 'dashboard', 'userguide'])
 </script>
 
 <Header

--- a/sites/geohub/src/routes/maps/+page.svelte
+++ b/sites/geohub/src/routes/maps/+page.svelte
@@ -12,7 +12,7 @@
 
   let headerHeight: number
 
-  let links: HeaderLink[] = HeaderItems(['home', /*'data',**/ 'dashboard', 'userguide'])
+  let links: HeaderLink[] = HeaderItems(['home', 'data', 'dashboard', 'userguide'])
 
   let stats: StatsCard[] = data.stats
 

--- a/sites/geohub/src/routes/settings/+page.svelte
+++ b/sites/geohub/src/routes/settings/+page.svelte
@@ -4,7 +4,7 @@
   import UserAccount from '$components/UserAccount.svelte'
   import { HeaderItems, FooterItems } from '$lib/config/AppConfig'
   let headerHeight: number
-  let links: HeaderLink[] = HeaderItems(['home', 'maps', /*'data',**/ 'dashboard', 'userguide'])
+  let links: HeaderLink[] = HeaderItems(['home', 'maps', 'data', 'dashboard', 'userguide'])
 </script>
 
 <div class="header">


### PR DESCRIPTION
Reverts UNDP-Data/geohub#1586 to enable `data` menu in header and footer

@iferencik, please merge this PR to main branch once data pipeline will be done.