### PR TITLE
fix: in maps page, now will open editor page in the same tab instead of opening in another tab

### DIFF
--- a/sites/geohub/src/components/maps/MapStyleCard.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCard.svelte
@@ -114,6 +114,10 @@
 			e.target.click();
 		}
 	};
+
+	const openSavedMapEditor = () => {
+		document.location = style.editor;
+	};
 </script>
 
 <Accordion headerTitle={style.name} bind:headerIcon bind:isExpanded>
@@ -124,7 +128,7 @@
 			role="button"
 			tabindex="0"
 			data-tooltip="Open map"
-			on:click={() => window.open(style.editor, '_blank')}
+			on:click={openSavedMapEditor}
 		>
 			<i class="fa-solid fa-arrow-up-right-from-square fa-xl" />
 		</span>
@@ -137,7 +141,7 @@
 					data-tooltip="Open map"
 					role="button"
 					tabindex="0"
-					on:click={() => window.open(style.editor, '_blank')}
+					on:click={openSavedMapEditor}
 					on:keydown={handleEnterKey}
 					bind:this={mapContainer}
 				>
@@ -171,11 +175,7 @@
 					{/if}
 				</div>
 				<div class="tile is-parent py-4">
-					<CtaLink
-						label="Open map"
-						on:clicked={() => window.open(style.editor, '_blank')}
-						isArrow={false}
-					/>
+					<CtaLink label="Open map" on:clicked={openSavedMapEditor} isArrow={false} />
 				</div>
 				{#if $page.data.session && style.created_user === $page.data.session.user.email}
 					<div class="columns is-12 align-center">


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I feel opening map editor page as different tab is disrupting. I changed it to open map in the same tab.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
