### PR TITLE
feat: moved share menu from header to maplibre control button

### DIFF
--- a/sites/geohub/src/components/Header.svelte
+++ b/sites/geohub/src/components/Header.svelte
@@ -1,33 +1,16 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { Header, type HeaderLink } from '@undp-data/svelte-undp-design';
-	import StyleShare from './StyleShare.svelte';
 	import { layerList } from '$stores';
 	import UserAccount from './UserAccount.svelte';
 	import { HeaderItems } from '$lib/config/AppConfig';
 
 	export let height: number = undefined;
 
-	let isStyleShareVisible = false;
-
-	const shareLink = {
-		id: 'header-link-styleshare',
-		title: 'Share',
-		tooltip: 'Save & share map',
-		href: '#',
-		callback: () => {
-			isStyleShareVisible = true;
-		}
-	};
-
 	let finalLink: HeaderLink[] = [];
 
 	const initLinks = () => {
 		let links: HeaderLink[] = [...HeaderItems(['maps', 'data', 'dashboard', 'userguide'])];
-
-		if ($page.data.session && $layerList.length > 0) {
-			links = [links[0], shareLink, ...links.slice(1)];
-		}
 		if (!$page.data.session) {
 			links = links.filter((l) => l.href !== '/data');
 		}
@@ -49,7 +32,6 @@
 		<UserAccount />
 	</div>
 </Header>
-<StyleShare bind:isModalVisible={isStyleShareVisible} />
 
 <style lang="scss">
 	:global(.menu-item) {

--- a/sites/geohub/src/components/Map.svelte
+++ b/sites/geohub/src/components/Map.svelte
@@ -12,6 +12,7 @@
 	import '@watergis/maplibre-gl-export/dist/maplibre-gl-export.css';
 
 	import MapQueryInfoControl from '$components/MapQueryInfoControl.svelte';
+	import StyleShareControl from '$components/StyleShareControl.svelte';
 	import StyleSwicher from '@undp-data/style-switcher';
 	import CurrentLocation from '@undp-data/current-location';
 	import { loadImageToDataUrl, fetchUrl, clipSprite } from '$lib/helper';
@@ -135,6 +136,7 @@
 {#if map}
 	<CurrentLocation bind:map isHover={false} position="top-left" />
 	<MapQueryInfoControl bind:map />
+	<StyleShareControl bind:map />
 	<StyleSwicher bind:map styles={MapStyles} position="bottom-left" />
 	<LayerVisibilitySwitcher bind:map position="bottom-right" />
 

--- a/sites/geohub/src/components/StyleShareControl.svelte
+++ b/sites/geohub/src/components/StyleShareControl.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { layerList } from '$stores';
+	import type { Map } from 'maplibre-gl';
+	import { onDestroy, onMount } from 'svelte';
+	import StyleShare from './StyleShare.svelte';
+
+	export let map: Map;
+	export let position: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' = 'top-right';
+
+	$: disabled = !($page.data.session && $layerList.length > 0);
+
+	let isStyleShareVisible = false;
+
+	const handleClick = () => {
+		isStyleShareVisible = true;
+	};
+
+	let visiblilityButton: HTMLButtonElement;
+
+	// eslint-disable-next-line
+	function StyleShareControl() {}
+
+	StyleShareControl.prototype.onAdd = function (map: Map) {
+		this.map = map;
+
+		this.controlContainer = document.createElement('div');
+		this.controlContainer.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+		visiblilityButton.addEventListener('click', handleClick);
+		this.controlContainer.appendChild(visiblilityButton);
+		return this.controlContainer;
+	};
+
+	StyleShareControl.prototype.onRemove = function () {
+		if (!this.container || !this.container.parentNode) {
+			return;
+		}
+		this.container.parentNode.removeChild(this.container);
+	};
+
+	/*global StyleShareControl */
+	/*eslint no-undef: "error"*/
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	let styleShareControl: StyleShareControl;
+
+	$: {
+		if (map) {
+			if (styleShareControl && map.hasControl(styleShareControl) === false) {
+				map.addControl(styleShareControl, position);
+			}
+		}
+	}
+
+	onMount(async () => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		styleShareControl = new StyleShareControl();
+	});
+
+	onDestroy(() => {
+		if (styleShareControl && map?.hasControl(styleShareControl)) {
+			map.removeControl(styleShareControl);
+		}
+	});
+</script>
+
+<button
+	class="maplibregl-ctrl-styleshare maplibre-ctrl-icon is-flex is-align-items-center has-tooltip-left has-tooltip-arrow"
+	bind:this={visiblilityButton}
+	data-tooltip={disabled ? 'Please sign in to save your map' : 'Save your map to share'}
+	{disabled}
+>
+	<i class="fa-solid fa-share-nodes fa-xl align-center" />
+</button>
+
+<StyleShare bind:isModalVisible={isStyleShareVisible} />
+
+<style lang="scss">
+	.maplibre-ctrl-icon {
+		width: 29px;
+		height: 29px;
+		cursor: pointer;
+	}
+
+	.align-center {
+		width: max-content;
+		margin: auto;
+	}
+</style>

--- a/sites/geohub/src/lib/config/AppConfig/TourOptions.ts
+++ b/sites/geohub/src/lib/config/AppConfig/TourOptions.ts
@@ -2,7 +2,7 @@ import type { TourGuideOptions } from '@watergis/svelte-maplibre-tour';
 
 export const TourOptions: TourGuideOptions = {
 	rememberStep: true,
-	showStepDots: true,
+	showStepDots: false,
 	steps: [
 		{
 			title: 'Welcome to UNDP GeoHub!',
@@ -100,12 +100,20 @@ export const TourOptions: TourGuideOptions = {
 			order: 10
 		},
 		{
+			title: 'Save your work to share with your colleagues',
+			content: `
+            Once you sign in to your account, this button will be enabled. You can save your current work to share it with your colleagues.
+            `,
+			target: '.maplibregl-ctrl-styleshare',
+			order: 11
+		},
+		{
 			title: 'Exporting map image',
 			content: `
             You can export the current map image with your preferences such as paper size, orientation, file format, etc.
             `,
 			target: '.maplibregl-export-control',
-			order: 11
+			order: 12
 		},
 		{
 			title: 'Disable hillshade layer',
@@ -113,7 +121,7 @@ export const TourOptions: TourGuideOptions = {
             As default, a hillshade layer is shown on the basemap. You can also disable hillshade layer if you want.
             `,
 			target: '.maplibregl-ctrl-hillshade-visibility',
-			order: 12
+			order: 13
 		},
 		{
 			title: 'Positioning your current location',
@@ -121,7 +129,7 @@ export const TourOptions: TourGuideOptions = {
             Your current location will be visible on the map if you enable this GNSS control.
             `,
 			target: '.maplibregl-ctrl-geolocate',
-			order: 13
+			order: 14
 		}
 	]
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Previously, there was a share menu in header as shown in the following figure.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/52d41e4e-e389-4e9f-a347-81f5ce698868)

SInce all other menus are to move to different page, this share menu has only different action to save user's work within the map editor. I feel this difference on share menu of header may confuse users. Hence, I moved share menu to maplibre control. Now it is shown in top-right of control.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/1e559dcb-66f3-44cc-b06e-541c246912b2)

I also added a tour for this share control.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
