### PR TITLE
fix: set default layer type when geometry is linestring

### DIFF
--- a/sites/geohub/src/components/data-view/LayerTypeSwitch.svelte
+++ b/sites/geohub/src/components/data-view/LayerTypeSwitch.svelte
@@ -5,6 +5,17 @@
 	export let layer: VectorLayerTileStatLayer;
 	export let layerType: 'point' | 'heatmap' | 'polygon' | 'linestring';
 
+	$: layer, setDefaultLayerType();
+	const setDefaultLayerType = () => {
+		if (['linestring', 'multilinestring'].includes(layer.geometry.toLowerCase())) {
+			layerType = 'linestring';
+		} else if (['polygon', 'multipolygon'].includes(layer.geometry.toLowerCase())) {
+			layerType = 'polygon';
+		} else {
+			layerType = 'point';
+		}
+	};
+
 	let symbolVectorType: 'point' | 'heatmap' = 'point';
 
 	let symbolVectorTypes: Radio[] = [


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
