### PR TITLE
feat: add confirmation dialog to save or discard changes on map

### DIFF
--- a/.changeset/khaki-worms-wave.md
+++ b/.changeset/khaki-worms-wave.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: changed FluidCarousel and CtaLink to use a tag's href for link

--- a/.changeset/nice-cobras-sell.md
+++ b/.changeset/nice-cobras-sell.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: changed header menu's click event to a tag's href since beforeNavigate event of sveltekit is not triggered

--- a/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.stories.ts
+++ b/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.stories.ts
@@ -45,3 +45,11 @@ export const WithoutArrow: Story = {
 		isArrow: false
 	}
 };
+
+export const WithHref: Story = {
+	args: {
+		label: 'Read more',
+		isArrow: false,
+		href: '#'
+	}
+};

--- a/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.svelte
+++ b/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.svelte
@@ -4,6 +4,7 @@
 
 	export let label: string;
 	export let isArrow = true;
+	export let href = ''
 
 	const handleClicked = () => {
 		dispatch('clicked');
@@ -16,17 +17,33 @@
 	};
 </script>
 
-<!-- svelte-ignore a11y-missing-attribute -->
-<a
-	class="cta__link {isArrow ? 'cta--arrow' : 'cta--space'}"
-	role="button"
-	tabindex="0"
-	on:keydown={handleKeyDown}
-	on:click={handleClicked}
->
-	{label}
-	<i />
-</a>
+{#if href}
+
+	<a
+		class="cta__link {isArrow ? 'cta--arrow' : 'cta--space'}"
+		role="button"
+		tabindex="0"
+		href={href}
+	>
+		{label}
+		<i />
+	</a>
+
+{:else}
+
+	<!-- svelte-ignore a11y-missing-attribute -->
+	<a
+		class="cta__link {isArrow ? 'cta--arrow' : 'cta--space'}"
+		role="button"
+		tabindex="0"
+		on:keydown={handleKeyDown}
+		on:click={handleClicked}
+	>
+		{label}
+		<i />
+	</a>
+
+{/if}
 
 <style lang="scss">
 	@use '../css/base-minimal.min.css';

--- a/packages/svelte-undp-design/src/lib/FluidCarousel/FluidCarousel.svelte
+++ b/packages/svelte-undp-design/src/lib/FluidCarousel/FluidCarousel.svelte
@@ -3,18 +3,6 @@
 	import type { CarouselContent } from '$lib/interfaces';
 
 	export let contents: CarouselContent[] = [];
-
-	const openLink = (content: CarouselContent) => {
-		document.location = content.linkUrl
-	}
-
-	const handleEnterKey = (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			e.target.click();
-		}
-	};
 </script>
 
 <section
@@ -36,10 +24,10 @@
 						<h6>{content.tag}</h6>
 						<h4>{content.title}</h4>
 						<p>{content.description}</p>
-						<button class="cta__link cta--space" on:click={()=>{openLink(content)}} on:keydown={handleEnterKey}>
+						<a class="cta__link cta--space" href={content.linkUrl}>
 							{content.linkName}
 							<i />
-						</button>
+						</a>
 					</article>
 				</div>
 			{/each}

--- a/packages/svelte-undp-design/src/lib/Header/Header.svelte
+++ b/packages/svelte-undp-design/src/lib/Header/Header.svelte
@@ -68,12 +68,11 @@
 											{link.title}
 											</a>
 										{:else}
-											<!-- svelte-ignore a11y-missing-attribute -->
 											<a
 												role="button"
-												on:click={() => document.location=link.href}
+												href={link.href} 
+												rel="noreferrer"
 												tabindex="0"
-												on:keydown={onKeyPressed}
 											>
 											{link.title}
 											</a>
@@ -125,19 +124,19 @@
 														{/if}
 													</div>
 												{:else}
-													<div
+													<a
 														class="cta__link cta--space"
 														role="button"
 														id={link.id}
-														on:click={() => document.location=link.href}
+														href={link.href} 
+														rel="noreferrer"
 														tabindex="0"
-														on:keydown={onKeyPressed}
 													>
 														{link.title}
 														{#if link.tooltip}
 															- {link.tooltip}
 														{/if}
-													</div>
+													</a>
 												{/if}
 											</li>
 										{/if}

--- a/sites/geohub/src/components/Content.svelte
+++ b/sites/geohub/src/components/Content.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import DataView from '$components/DataView.svelte';
 	import LayerList from '$components/LayerList.svelte';
@@ -55,12 +54,7 @@
 		activeTab = tabId;
 		const url = $page.url;
 		url.searchParams.set('activetab', activeTab);
-		goto(url, {
-			invalidateAll: false,
-			replaceState: true,
-			keepFocus: true,
-			noScroll: true
-		});
+		history.replaceState({}, null, url.toString());
 	};
 </script>
 

--- a/sites/geohub/src/components/DataView.svelte
+++ b/sites/geohub/src/components/DataView.svelte
@@ -10,7 +10,7 @@
 	import { Breadcrumbs, Loader, type Breadcrumb } from '@undp-data/svelte-undp-design';
 	import type { Tag } from '$lib/types/Tag';
 	import SelectedTags from './data-view/SelectedTags.svelte';
-	import { goto } from '$app/navigation';
+	import { invalidateAll } from '$app/navigation';
 	import { getSelectedTagsFromUrl } from '$lib/helper';
 	import { TagSearchKeys, StacMinimumZoom } from '$lib/config/AppConfig';
 	import Help from './Help.svelte';
@@ -100,7 +100,8 @@
 				}
 				await reload(apiUrl.toString());
 			} else {
-				await goto(apiUrl, { replaceState: true, invalidateAll: true });
+				history.replaceState({}, null, apiUrl.toString());
+				await invalidateAll();
 				dataCategories = $page.data.menu;
 			}
 		} finally {
@@ -124,12 +125,8 @@
 		const apiUrl = `${$page.url.origin}${$page.url.pathname}${datasetUrl.search}`;
 
 		if (invalidate) {
-			await goto(apiUrl, {
-				replaceState: true,
-				noScroll: true,
-				keepFocus: true,
-				invalidateAll: true
-			});
+			history.replaceState({}, null, apiUrl.toString());
+			await invalidateAll();
 		}
 		selectedTags = getSelectedTagsFromUrl(new URL(apiUrl));
 		breadcrumbs = $page.data.breadcrumbs;
@@ -185,7 +182,8 @@
 		expanded = {};
 		try {
 			isLoading = true;
-			await goto(apiUrl, { replaceState: true, invalidateAll: true });
+			history.replaceState({}, null, apiUrl.toString());
+			await invalidateAll();
 			dataCategories = $page.data.menu;
 			breadcrumbs = $page.data.breadcrumbs;
 		} finally {

--- a/sites/geohub/src/components/Header.svelte
+++ b/sites/geohub/src/components/Header.svelte
@@ -16,8 +16,9 @@
 		const initialMapStyleId: string = fromLocalStorage(mapStyleIdStorageKey, null)?.toString();
 		if (initialMapStyleId) {
 			const map = links.find((l) => l.id === 'header-link-map');
+			map.href = `/map/${initialMapStyleId}`;
 			map.callback = () => {
-				document.location = `${$page.url.origin}/map/${initialMapStyleId}`;
+				document.location = map.href;
 			};
 		}
 	};

--- a/sites/geohub/src/components/Header.svelte
+++ b/sites/geohub/src/components/Header.svelte
@@ -17,9 +17,6 @@
 		if (initialMapStyleId) {
 			const map = links.find((l) => l.id === 'header-link-map');
 			map.href = `/map/${initialMapStyleId}`;
-			map.callback = () => {
-				document.location = map.href;
-			};
 		}
 	};
 	updateLinks();

--- a/sites/geohub/src/components/UserAccount.svelte
+++ b/sites/geohub/src/components/UserAccount.svelte
@@ -2,7 +2,6 @@
 	import { signIn, signOut } from '@auth/sveltekit/client';
 	import { page } from '$app/stores';
 	import chroma from 'chroma-js';
-	import { goto } from '$app/navigation';
 	import { clickOutside } from 'svelte-use-click-outside';
 
 	let panelWidth = '350px';
@@ -16,9 +15,6 @@
 
 	const handleDropdown = () => {
 		dropdownActive = !dropdownActive;
-	};
-	const gotToSettings = async () => {
-		await goto('/settings');
 	};
 
 	const handleEnterKey = (e: KeyboardEvent) => {
@@ -117,11 +113,10 @@
 					<p>{$page.data.session.user.email}</p>
 					<hr class="dropdown-divider" />
 				</div>
-				<div
+				<a
 					role="button"
 					tabindex="0"
-					on:click={gotToSettings}
-					on:keydown={handleEnterKey}
+					href="/settings"
 					class="dropdown-item settings-div is-flex is-justify-content-space-between is-align-items-center"
 				>
 					<div class="is-flex-grow-1">
@@ -132,7 +127,7 @@
 							<i class="fas fa-chevron-right" aria-hidden="true" />
 						</span>
 					</div>
-				</div>
+				</a>
 				<hr class="dropdown-divider" />
 				<div
 					role="button"

--- a/sites/geohub/src/components/controls/Modal.svelte
+++ b/sites/geohub/src/components/controls/Modal.svelte
@@ -8,7 +8,7 @@
 	export let title: string;
 	export let message: string;
 	export let messageType: 'warning' | 'info' = 'warning';
-	export let target: string;
+	export let target = '';
 	export let continueText: string;
 	export let cancelText: string;
 	const handleCancel = () => {

--- a/sites/geohub/src/components/data-view/SelectedTags.svelte
+++ b/sites/geohub/src/components/data-view/SelectedTags.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+	import { invalidateAll } from '$app/navigation';
 	import { createEventDispatcher } from 'svelte';
 	import type { Tag } from '$lib/types/Tag';
 	import { getSelectedTagsFromUrl } from '$lib/helper';
@@ -26,12 +26,8 @@
 			apiUrl.searchParams.append(t.key, t.value);
 		});
 
-		await goto(apiUrl, {
-			replaceState: true,
-			noScroll: true,
-			keepFocus: true,
-			invalidateAll: true
-		});
+		history.replaceState({}, null, apiUrl.toString());
+		await invalidateAll();
 
 		dispatch('change', {
 			tags: selectedTags,

--- a/sites/geohub/src/components/data-view/TagFilter.svelte
+++ b/sites/geohub/src/components/data-view/TagFilter.svelte
@@ -9,7 +9,7 @@
 	import Notification from '$components/controls/Notification.svelte';
 	import { debounce } from 'lodash-es';
 	import { TagSearchKeys } from '$lib/config/AppConfig';
-	import { goto } from '$app/navigation';
+	import { invalidateAll } from '$app/navigation';
 
 	const dispatch = createEventDispatcher();
 
@@ -50,12 +50,8 @@
 
 	const fireChangeEvent = async (url: URL, reload = true) => {
 		if (reload) {
-			await goto(url, {
-				replaceState: true,
-				noScroll: true,
-				keepFocus: true,
-				invalidateAll: true
-			});
+			history.replaceState({}, null, url.toString());
+			await invalidateAll();
 		}
 
 		tagsPromise = $page.data.promises.tags;

--- a/sites/geohub/src/components/data-view/TextFilter.svelte
+++ b/sites/geohub/src/components/data-view/TextFilter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+	import { invalidateAll } from '$app/navigation';
 	import { createEventDispatcher } from 'svelte';
 	import { debounce } from 'lodash-es';
 	import PanelButton from '$components/controls/PanelButton.svelte';
@@ -74,7 +74,8 @@
 	};
 
 	const fireChangeEvent = async (url: URL) => {
-		await goto(url, { replaceState: true, invalidateAll: true });
+		history.replaceState({}, null, url.toString());
+		await invalidateAll();
 
 		dispatch('change', {
 			url: url.toString()

--- a/sites/geohub/src/components/maps/MapStyleCard.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCard.svelte
@@ -113,19 +113,21 @@
 
 <div class="map-card is-flex is-flex-direction-column">
 	<div class="map-container">
-		<div
-			class="image pointor has-tooltip-bottom has-tooltip-arrow"
-			data-tooltip="Open map"
-			role="button"
-			tabindex="0"
-			on:click={openSavedMapEditor}
-			on:keydown={handleEnterKey}
-			bind:this={mapContainer}
-		>
-			{#if isLoading}
-				<Loader size="medium" />
-			{/if}
-		</div>
+		<a href={style?.links?.find((l) => l.rel === 'map')?.href ?? '/map'}>
+			<div
+				class="image pointor has-tooltip-bottom has-tooltip-arrow"
+				data-tooltip="Open map"
+				role="button"
+				tabindex="0"
+				on:click={openSavedMapEditor}
+				on:keydown={handleEnterKey}
+				bind:this={mapContainer}
+			>
+				{#if isLoading}
+					<Loader size="medium" />
+				{/if}
+			</div>
+		</a>
 		{#if $page.data.session && style.created_user === $page.data.session.user.email}
 			<div class="delete-button has-tooltip-left has-tooltip-arrow" data-tooltip="Delete map">
 				<button class="button is-link ml-2" on:click={() => (confirmDeleteDialogVisible = true)}>
@@ -138,7 +140,11 @@
 	</div>
 	<p class="py-2 is-flex">
 		<i class="{headerIcon} p-1 pr-2" />
-		<CtaLink bind:label={style.name} isArrow={true} on:clicked={openSavedMapEditor} />
+		<CtaLink
+			bind:label={style.name}
+			isArrow={true}
+			href={style?.links?.find((l) => l.rel === 'map')?.href ?? '/map'}
+		/>
 	</p>
 	<div class="justify-bottom">
 		<div class="columns">

--- a/sites/geohub/src/routes/(app)/+page.svelte
+++ b/sites/geohub/src/routes/(app)/+page.svelte
@@ -216,19 +216,14 @@
 			</p>
 
 			<div class="explore-button-grid">
-				<button
+				<a
 					class="button is-large is-primary"
-					on:click={() => {
-						document.location = initialMapStyleId ? `/map/${initialMapStyleId}` : '/map';
-					}}>Launch map</button
+					href={initialMapStyleId ? `/map/${initialMapStyleId}` : '/map'}
 				>
+					Launch map
+				</a>
 
-				<button
-					class="button is-large is-primary"
-					on:click={() => {
-						document.location = '/data';
-					}}>Explore datasets</button
-				>
+				<a class="button is-large is-primary" href={`/data`}> Explore datasets </a>
 			</div>
 		</div>
 	</div>

--- a/sites/geohub/src/routes/(app)/map/+layout@.svelte
+++ b/sites/geohub/src/routes/(app)/map/+layout@.svelte
@@ -5,7 +5,7 @@
 	import Header from '$components/Header.svelte';
 	import { fromLocalStorage, isStyleChanged, storageKeys, toLocalStorage } from '$lib/helper';
 	import { layerList, map } from '$stores';
-	import { beforeNavigate, goto } from '$app/navigation';
+	import { beforeNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import type { DashboardMapStyle, Layer } from '$lib/types';
 	import Notification from '$components/controls/Notification.svelte';
@@ -64,7 +64,7 @@
 		toLocalStorage(mapStyleStorageKey, storageMapStyle);
 
 		dialogOpen = false;
-		goto(toUrl.toString());
+		window.location.href = toUrl.toString();
 	};
 
 	const handleDiscard = () => {
@@ -72,7 +72,7 @@
 		toLocalStorage(mapStyleStorageKey, null);
 		toLocalStorage(mapStyleIdStorageKey, null);
 		dialogOpen = false;
-		goto(toUrl.toString());
+		window.location.href = toUrl.toString();
 	};
 
 	const handleCancel = () => {
@@ -156,9 +156,14 @@
 		<section class="modal-card-body has-text-weight-normal">
 			<Notification type="warning" showCloseButton={false}>
 				<div class="has-text-weight-medium">
-					You have unsaved changes. Click 'Keep state' button to keep your map state locally. If you
-					want to discard all changes, click 'Discard'. If want to save your work to the database,
-					close the dialog to cancel.
+					You have unsaved changes.
+					<br />
+					Click <b>Keep state</b> button to keep your map state locally.
+					<br />
+					If you want to discard all changes, click <b>Discard</b>.
+					<br />
+					If want to save your work to the database, close the dialog to cancel. Then use
+					<b>Share</b> feature to save your map before leaving.
 				</div>
 			</Notification>
 		</section>

--- a/sites/geohub/src/routes/(app)/map/+page.svelte
+++ b/sites/geohub/src/routes/(app)/map/+page.svelte
@@ -22,7 +22,9 @@
 
 	const resetStyleToDefault = () => {
 		// no style query param
-		toLocalStorage(mapStyleIdStorageKey, null);
+		if (mapStyleIdStorageKey) {
+			toLocalStorage(mapStyleIdStorageKey, null);
+		}
 		if (initiaMapStyle && initialLayerList && initialLayerList.length > 0) {
 			let existAllLayers = true;
 			initialLayerList.forEach((l) => {
@@ -37,8 +39,6 @@
 				toLocalStorage(layerListStorageKey, []);
 				toLocalStorage(mapStyleStorageKey, $map.getStyle());
 			}
-		} else {
-			toLocalStorage(layerListStorageKey, []);
 		}
 	};
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Due to adding confirmation dialog, moving to pages by `document.location` does not trigger `beforeNavigate` event of sveltekit. So I changed most of links to use `<a href="url">`. Now every time if there is unsaved changes on map page, confirmation dialog will be appeared.

Furthermore, I found using `history.replaceState({}, null, url.toString());` can update page URL without triggering `beforeNavigate`. So, replaceState function is now used for all dataset search events in data tab.

<img width="657" alt="image" src="https://github.com/UNDP-Data/geohub/assets/2639701/c5b32d5b-c63c-488e-afc4-7d05372625c3">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
