### PR TITLE
fix: add wrapped function for setLayoutProperty and setPaintProperty

### DIFF
--- a/sites/geohub/src/components/LayerVisibilitySwitcher.svelte
+++ b/sites/geohub/src/components/LayerVisibilitySwitcher.svelte
@@ -9,13 +9,11 @@
 	export let faIcon = 'fa-solid fa-mountain';
 
 	const isLayerVisible = () => {
-		if (!map?.isStyleLoaded()) return true;
-		if (!map.getLayer(target)) return true;
 		const visibility = map.getLayoutProperty(target, 'visibility');
 		return !(visibility && visibility === 'none');
 	};
 
-	let isVisible = isLayerVisible();
+	let isVisible = false;
 	let isLoading = false;
 
 	let isAerialStyle = false;
@@ -95,6 +93,9 @@
 				visibilityControl = new VisibilityControl();
 				map.addControl(visibilityControl, position);
 			}
+			map.once('load', () => {
+				isVisible = isLayerVisible();
+			});
 		}
 	});
 

--- a/sites/geohub/src/components/controls/OpacityPanel.svelte
+++ b/sites/geohub/src/components/controls/OpacityPanel.svelte
@@ -55,20 +55,20 @@
 		if (!style) return;
 		switch (style.type) {
 			case 'raster':
-				$map.setPaintProperty(id, 'raster-opacity', layerOpacity);
+				map.setPaintProperty(id, 'raster-opacity', layerOpacity);
 				break;
 			case 'symbol':
-				$map.setPaintProperty(id, 'icon-opacity', layerOpacity);
-				$map.setPaintProperty(id, 'text-opacity', layerOpacity);
+				map.setPaintProperty(id, 'icon-opacity', layerOpacity);
+				map.setPaintProperty(id, 'text-opacity', layerOpacity);
 				break;
 			case 'line':
-				$map.setPaintProperty(id, 'line-opacity', layerOpacity);
+				map.setPaintProperty(id, 'line-opacity', layerOpacity);
 				break;
 			case 'fill':
-				$map.setPaintProperty(id, 'fill-opacity', layerOpacity);
+				map.setPaintProperty(id, 'fill-opacity', layerOpacity);
 				break;
 			case 'heatmap':
-				$map.setPaintProperty(id, 'heatmap-opacity', layerOpacity);
+				map.setPaintProperty(id, 'heatmap-opacity', layerOpacity);
 				break;
 			default:
 				break;

--- a/sites/geohub/src/components/controls/RasterPropertyEditor.svelte
+++ b/sites/geohub/src/components/controls/RasterPropertyEditor.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { map } from '$stores';
 	import { initTippy } from '$lib/helper';
 	import RasterBrightnessMax from './raster-styles/RasterBrightnessMax.svelte';
 	import RasterContrast from './raster-styles/RasterContrast.svelte';
@@ -43,7 +42,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Brightness max </label>
 			<div class="control">
-				<RasterBrightnessMax bind:map={$map} bind:layerId />
+				<RasterBrightnessMax bind:layerId />
 			</div>
 		</div>
 
@@ -51,7 +50,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Brightness min </label>
 			<div class="control">
-				<RasterBrightnessMax bind:map={$map} bind:layerId />
+				<RasterBrightnessMax bind:layerId />
 			</div>
 		</div>
 
@@ -59,7 +58,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Contrast </label>
 			<div class="control">
-				<RasterContrast bind:map={$map} bind:layerId />
+				<RasterContrast bind:layerId />
 			</div>
 		</div>
 
@@ -67,7 +66,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Hue rotate </label>
 			<div class="control">
-				<RasterHueRotate bind:map={$map} bind:layerId />
+				<RasterHueRotate bind:layerId />
 			</div>
 		</div>
 
@@ -75,7 +74,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Resampling </label>
 			<div class="control">
-				<RasterResampling bind:map={$map} bind:layerId />
+				<RasterResampling bind:layerId />
 			</div>
 		</div>
 
@@ -83,7 +82,7 @@
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label is-normal"> Saturation </label>
 			<div class="control">
-				<RasterSaturation bind:map={$map} bind:layerId />
+				<RasterSaturation bind:layerId />
 			</div>
 		</div>
 	</div>

--- a/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
@@ -437,7 +437,7 @@
 					if (layerType === 'symbol') {
 						const iconSize = $map.getLayoutProperty(layer.id, 'icon-size');
 						if (!iconSize || (iconSize && ['interval', 'categorical'].includes(iconSize.type))) {
-							$map.setLayoutProperty(layer.id, 'icon-size', 1);
+							map.setLayoutProperty(layer.id, 'icon-size', 1);
 						}
 						map.setPaintProperty(layer.id, 'icon-color', {
 							type: vectorLegendType,

--- a/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/controls/VectorClassifyLegend.svelte
@@ -408,13 +408,13 @@
 			if (attribute.type === 'number') {
 				outlineStops = sortStops(outlineStops);
 			}
-			$map.setPaintProperty(layer.id, 'fill-outline-color', {
+			map.setPaintProperty(layer.id, 'fill-outline-color', {
 				property: propertySelectValue,
 				type: vectorLegendType,
 				stops: outlineStops,
 				default: defaultColorValue
 			});
-			$map.setPaintProperty(layer.id, 'fill-color', {
+			map.setPaintProperty(layer.id, 'fill-color', {
 				type: vectorLegendType,
 				property: propertySelectValue,
 				stops: stops,
@@ -439,15 +439,15 @@
 						if (!iconSize || (iconSize && ['interval', 'categorical'].includes(iconSize.type))) {
 							$map.setLayoutProperty(layer.id, 'icon-size', 1);
 						}
-						$map.setPaintProperty(layer.id, 'icon-color', {
+						map.setPaintProperty(layer.id, 'icon-color', {
 							type: vectorLegendType,
 							property: propertySelectValue,
 							stops: stops,
 							default: defaultColorValue
 						});
 					} else if (layerType === 'line') {
-						$map.setPaintProperty(layer.id, 'line-width', getLineWidth($map, layer.id));
-						$map.setPaintProperty(layer.id, 'line-color', {
+						map.setPaintProperty(layer.id, 'line-width', getLineWidth($map, layer.id));
+						map.setPaintProperty(layer.id, 'line-color', {
 							type: vectorLegendType,
 							property: propertySelectValue,
 							stops: stops,
@@ -474,8 +474,8 @@
 							}
 							return [item[0], ratio];
 						});
-						$map.setPaintProperty(layer.id, 'icon-color', defaultColor);
-						$map.setLayoutProperty(layer.id, 'icon-size', {
+						map.setPaintProperty(layer.id, 'icon-color', defaultColor);
+						map.setLayoutProperty(layer.id, 'icon-size', {
 							property: propertySelectValue,
 							type: 'interval',
 							stops: newStops,
@@ -488,8 +488,8 @@
 						]);
 
 						sizeArray = newStops.map((item) => item[1]);
-						$map.setPaintProperty(layer.id, 'line-color', defaultColor);
-						$map.setPaintProperty(layer.id, 'line-width', {
+						map.setPaintProperty(layer.id, 'line-color', defaultColor);
+						map.setPaintProperty(layer.id, 'line-width', {
 							property: propertySelectValue,
 							type: 'interval',
 							stops: newStops,

--- a/sites/geohub/src/components/controls/VectorLabelPanel.svelte
+++ b/sites/geohub/src/components/controls/VectorLabelPanel.svelte
@@ -78,13 +78,13 @@
 				textSize ?? $page.data.config.LabelFontSize
 			);
 			$map.setLayoutProperty(targetLayerId, 'text-max-width', textMaxWidth ?? 10);
-			$map.setPaintProperty(targetLayerId, 'text-color', textColor ?? 'rgba(0,0,0,1)');
-			$map.setPaintProperty(
+			map.setPaintProperty(targetLayerId, 'text-color', textColor ?? 'rgba(0,0,0,1)');
+			map.setPaintProperty(
 				targetLayerId,
 				'text-halo-color',
 				textHaloColor ?? 'rgba(255,255,255,1)'
 			);
-			$map.setPaintProperty(
+			map.setPaintProperty(
 				targetLayerId,
 				'text-halo-width',
 				textHaloWidth ?? $page.data.config.LabelHaloWidth

--- a/sites/geohub/src/components/controls/VectorLabelPanel.svelte
+++ b/sites/geohub/src/components/controls/VectorLabelPanel.svelte
@@ -72,12 +72,12 @@
 				'text-halo-width'
 			) as number;
 
-			$map.setLayoutProperty(
+			map.setLayoutProperty(
 				targetLayerId,
 				'text-size',
 				textSize ?? $page.data.config.LabelFontSize
 			);
-			$map.setLayoutProperty(targetLayerId, 'text-max-width', textMaxWidth ?? 10);
+			map.setLayoutProperty(targetLayerId, 'text-max-width', textMaxWidth ?? 10);
 			map.setPaintProperty(targetLayerId, 'text-color', textColor ?? 'rgba(0,0,0,1)');
 			map.setPaintProperty(
 				targetLayerId,

--- a/sites/geohub/src/components/controls/VisibilityButton.svelte
+++ b/sites/geohub/src/components/controls/VisibilityButton.svelte
@@ -20,7 +20,7 @@
 
 	const toggleVisibility = () => {
 		visibility = visibility === 'visible' ? 'none' : 'visible';
-		$map.setLayoutProperty(layerId, 'visibility', visibility);
+		map.setLayoutProperty(layerId, 'visibility', visibility);
 
 		const layerClone = cloneDeep(layer);
 		const layerIndex = $layerList.findIndex((layer) => layer.id === layerId);
@@ -29,7 +29,7 @@
 		if (layer.children && layer.children.length > 0) {
 			layer.children.forEach((child) => {
 				if (!$map.getLayer(child.id)) return;
-				$map.setLayoutProperty(child.id, 'visibility', visibility);
+				map.setLayoutProperty(child.id, 'visibility', visibility);
 			});
 		}
 	};

--- a/sites/geohub/src/components/controls/raster-styles/RasterBrightnessMax.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterBrightnessMax.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import Slider from './Slider.svelte';
-	import type { Map } from 'maplibre-gl';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layerId, 'raster-brightness-max');
+		let value = $map.getPaintProperty(layerId, 'raster-brightness-max');
 
 		if (!value) {
 			value = 1;
@@ -19,7 +18,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-brightness-max', value);
+		map.setPaintProperty(layerId, 'raster-brightness-max', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/raster-styles/RasterBrightnessMin.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterBrightnessMin.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import Slider from './Slider.svelte';
-	import type { Map } from 'maplibre-gl';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layerId, 'raster-brightness-min');
+		let value = $map.getPaintProperty(layerId, 'raster-brightness-min');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +18,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-brightness-min', value);
+		map.setPaintProperty(layerId, 'raster-brightness-min', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/raster-styles/RasterContrast.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterContrast.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import Slider from './Slider.svelte';
-	import type { Map } from 'maplibre-gl';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layerId, 'raster-contrast');
+		let value = $map.getPaintProperty(layerId, 'raster-contrast');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +18,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-contrast', value);
+		map.setPaintProperty(layerId, 'raster-contrast', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/raster-styles/RasterHueRotate.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterHueRotate.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import Slider from './Slider.svelte';
-	import type { Map } from 'maplibre-gl';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layerId, 'raster-hue-rotate');
+		let value = $map.getPaintProperty(layerId, 'raster-hue-rotate');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +18,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-hue-rotate', value);
+		map.setPaintProperty(layerId, 'raster-hue-rotate', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/raster-styles/RasterResampling.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterResampling.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import ToggleOptions from './ToggleOptions.svelte';
-	import type { Map } from 'maplibre-gl';
 	import type { ToggleOption } from '$lib/types';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	let options: ToggleOption[] = [
@@ -18,14 +17,14 @@
 	];
 
 	const getResamplingMethod = () => {
-		return map?.getPaintProperty(layerId, 'raster-resampling') || 'linear';
+		return $map.getPaintProperty(layerId, 'raster-resampling') || 'linear';
 	};
-	let value = getResamplingMethod();
+	let value = getResamplingMethod() as string;
 
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-resampling', value);
+		map.setPaintProperty(layerId, 'raster-resampling', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/raster-styles/RasterSaturation.svelte
+++ b/sites/geohub/src/components/controls/raster-styles/RasterSaturation.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import Slider from './Slider.svelte';
-	import type { Map } from 'maplibre-gl';
+	import { map } from '$stores';
 
-	export let map: Map;
 	export let layerId: string;
 
 	const getValue = () => {
-		let value = map.getPaintProperty(layerId, 'raster-saturation');
+		let value = $map.getPaintProperty(layerId, 'raster-saturation');
 
 		if (!value) {
 			value = 0;
@@ -19,7 +18,7 @@
 	$: value, setValue();
 
 	const setValue = () => {
-		map?.setPaintProperty(layerId, 'raster-saturation', value);
+		map.setPaintProperty(layerId, 'raster-saturation', value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/FillColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/FillColor.svelte
@@ -29,12 +29,12 @@
 
 	onMount(() => {
 		rgba = getFillColor();
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 	});
 
 	const handleSetColor = (e: CustomEvent) => {
 		rgba = e.detail.color;
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 		defaultColor = e.detail.color;
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/FillOutlineColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/FillOutlineColor.svelte
@@ -29,12 +29,12 @@
 
 	onMount(() => {
 		rgba = getFillOutlineColor();
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 	});
 
 	const handleSetColor = (e: CustomEvent) => {
 		rgba = e.detail.color;
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/HeatmapColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/HeatmapColor.svelte
@@ -87,7 +87,7 @@
 			}
 			heatMapValues[row.index * 2 + heatMapDataColorIndexStart + 1] = colorValue;
 		});
-		$map.setPaintProperty(layerId, propertyName, heatMapValues);
+		map.setPaintProperty(layerId, propertyName, heatMapValues);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/IconColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconColor.svelte
@@ -29,12 +29,12 @@
 
 	onMount(() => {
 		rgba = getIconColor();
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 	});
 
 	const handleSetColor = (e: CustomEvent) => {
 		if (e?.detail?.color) {
-			$map.setPaintProperty(layerId, propertyName, e.detail.color);
+			map.setPaintProperty(layerId, propertyName, e.detail.color);
 			defaultColor = e.detail.color;
 			$map.fire('icon-color:changed', { color: e.detail.color });
 		}

--- a/sites/geohub/src/components/controls/vector-styles/IconImage.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconImage.svelte
@@ -46,7 +46,7 @@
 	});
 
 	const updateLegend = () => {
-		$map.setLayoutProperty(layerId, propertyName, defaultIconImage);
+		map.setLayoutProperty(layerId, propertyName, defaultIconImage);
 		map.setPaintProperty(layerId, 'icon-halo-color', 'rgb(255,255,255)');
 		map.setPaintProperty(layerId, 'icon-halo-width', 1);
 		const layerStyle = getLayerStyle($map, layerId);

--- a/sites/geohub/src/components/controls/vector-styles/IconImage.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconImage.svelte
@@ -47,8 +47,8 @@
 
 	const updateLegend = () => {
 		$map.setLayoutProperty(layerId, propertyName, defaultIconImage);
-		$map.setPaintProperty(layerId, 'icon-halo-color', 'rgb(255,255,255)');
-		$map.setPaintProperty(layerId, 'icon-halo-width', 1);
+		map.setPaintProperty(layerId, 'icon-halo-color', 'rgb(255,255,255)');
+		map.setPaintProperty(layerId, 'icon-halo-width', 1);
 		const layerStyle = getLayerStyle($map, layerId);
 		if (layerStyle.layout && layerStyle.layout['icon-image']) {
 			const icon = $spriteImageList.find((icon) => icon.alt === layerStyle.layout['icon-image']);

--- a/sites/geohub/src/components/controls/vector-styles/IconOffset.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconOffset.svelte
@@ -27,7 +27,7 @@
 	$: yValue, setIconOffset();
 
 	const setIconOffset = () => {
-		$map.setLayoutProperty(layerId, propertyName, iconOffsetValues);
+		map.setLayoutProperty(layerId, propertyName, iconOffsetValues);
 
 		dispatch('change');
 	};

--- a/sites/geohub/src/components/controls/vector-styles/IconOverlap.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconOverlap.svelte
@@ -16,7 +16,7 @@
 	$: selected, setIconOverlap();
 
 	const setIconOverlap = () => {
-		$map.setLayoutProperty(layerId, propertyName, choices[selected[0]]);
+		map.setLayoutProperty(layerId, propertyName, choices[selected[0]]);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/IconSize.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/IconSize.svelte
@@ -33,7 +33,7 @@
 	});
 
 	const setValue = () => {
-		$map.setLayoutProperty(layer.id, propertyName, value);
+		map.setLayoutProperty(layer.id, propertyName, value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/LineColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/LineColor.svelte
@@ -29,12 +29,12 @@
 
 	onMount(() => {
 		rgba = getLineColor();
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 	});
 
 	const handleSetColor = (e: CustomEvent) => {
 		if (e?.detail?.color) {
-			$map.setPaintProperty(layerId, propertyName, e.detail.color);
+			map.setPaintProperty(layerId, propertyName, e.detail.color);
 			$map.fire('line-color:changed', { value: e.detail.color });
 			defaultColor = e.detail.color;
 		}

--- a/sites/geohub/src/components/controls/vector-styles/LinePattern.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/LinePattern.svelte
@@ -60,9 +60,9 @@
 
 		const value = LineTypes.find((item) => item.title === lineType).value;
 		if (value) {
-			$map.setPaintProperty(layer.id, propertyName, value);
+			map.setPaintProperty(layer.id, propertyName, value);
 		} else {
-			$map.setPaintProperty(layer.id, propertyName, undefined);
+			map.setPaintProperty(layer.id, propertyName, undefined);
 		}
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/LineWidth.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/LineWidth.svelte
@@ -28,7 +28,7 @@
 	});
 
 	const setValue = () => {
-		$map.setPaintProperty(layerId, propertyName, value);
+		map.setPaintProperty(layerId, propertyName, value);
 	};
 </script>
 

--- a/sites/geohub/src/components/controls/vector-styles/Slider.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/Slider.svelte
@@ -52,7 +52,7 @@
 		if (propertyType === 'paint') {
 			map.setPaintProperty(layerId, propertyName, values[0]);
 		} else {
-			$map.setLayoutProperty(layerId, propertyName, values[0]);
+			map.setLayoutProperty(layerId, propertyName, values[0]);
 		}
 
 		dispatch('change', {

--- a/sites/geohub/src/components/controls/vector-styles/Slider.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/Slider.svelte
@@ -50,7 +50,7 @@
 		newStyle[propertyType][propertyName] = values[0];
 
 		if (propertyType === 'paint') {
-			$map.setPaintProperty(layerId, propertyName, values[0]);
+			map.setPaintProperty(layerId, propertyName, values[0]);
 		} else {
 			$map.setLayoutProperty(layerId, propertyName, values[0]);
 		}

--- a/sites/geohub/src/components/controls/vector-styles/SymbolPlacement.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/SymbolPlacement.svelte
@@ -60,8 +60,8 @@
 		}
 
 		newStyle.layout[propertyNameSymbolPlacement] = selected;
-		$map.setLayoutProperty(layerId, propertyNameSymbolPlacement, selected);
-		$map.setLayoutProperty(layerId, propertyName, selected !== 'point');
+		map.setLayoutProperty(layerId, propertyNameSymbolPlacement, selected);
+		map.setLayoutProperty(layerId, propertyName, selected !== 'point');
 
 		dispatch('change');
 	};

--- a/sites/geohub/src/components/controls/vector-styles/TextColor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextColor.svelte
@@ -21,7 +21,7 @@
 	const handleSetColor = (e: CustomEvent) => {
 		if (style.type !== 'symbol') return;
 		rgba = e.detail.color;
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 		dispatch('change');
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/TextField.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextField.svelte
@@ -49,9 +49,9 @@
 					{ 'min-fraction-digits': 0, 'max-fraction-digits': 0 }
 				];
 			}
-			$map.setLayoutProperty(layerId, propertyName, propertyValue);
+			map.setLayoutProperty(layerId, propertyName, propertyValue);
 		} else {
-			$map.setLayoutProperty(layerId, propertyName, undefined);
+			map.setLayoutProperty(layerId, propertyName, undefined);
 		}
 	};
 
@@ -155,10 +155,10 @@
 					$map.removeLayer(layerId);
 				}
 			} else {
-				$map.setLayoutProperty(layerId, propertyName, undefined);
-				$map.setLayoutProperty(layerId, 'text-variable-anchor', undefined);
-				$map.setLayoutProperty(layerId, 'text-radial-offset', undefined);
-				$map.setLayoutProperty(layerId, 'text-justify', undefined);
+				map.setLayoutProperty(layerId, propertyName, undefined);
+				map.setLayoutProperty(layerId, 'text-variable-anchor', undefined);
+				map.setLayoutProperty(layerId, 'text-radial-offset', undefined);
+				map.setLayoutProperty(layerId, 'text-justify', undefined);
 			}
 		}
 		dispatch('change', {

--- a/sites/geohub/src/components/controls/vector-styles/TextHaloCalor.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextHaloCalor.svelte
@@ -21,7 +21,7 @@
 	const handleSetColor = (e: CustomEvent) => {
 		if (style.type !== 'symbol') return;
 		rgba = e.detail.color;
-		$map.setPaintProperty(layerId, propertyName, rgba);
+		map.setPaintProperty(layerId, propertyName, rgba);
 		dispatch('change');
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/TextHaloWidth.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextHaloWidth.svelte
@@ -25,7 +25,7 @@
 
 	const setValue = () => {
 		if (style.type !== layerType) return;
-		$map.setPaintProperty(layerId, propertyName, value);
+		map.setPaintProperty(layerId, propertyName, value);
 		dispatch('change');
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/TextMaxWidth.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextMaxWidth.svelte
@@ -25,7 +25,7 @@
 
 	const setValue = () => {
 		if (style.type !== layerType) return;
-		$map.setLayoutProperty(layerId, propertyName, value);
+		map.setLayoutProperty(layerId, propertyName, value);
 		dispatch('change');
 	};
 </script>

--- a/sites/geohub/src/components/controls/vector-styles/TextSize.svelte
+++ b/sites/geohub/src/components/controls/vector-styles/TextSize.svelte
@@ -25,7 +25,7 @@
 
 	const setValue = () => {
 		if (style.type !== layerType) return;
-		$map.setLayoutProperty(layerId, propertyName, value);
+		map.setLayoutProperty(layerId, propertyName, value);
 		dispatch('change');
 	};
 </script>

--- a/sites/geohub/src/stores/index.ts
+++ b/sites/geohub/src/stores/index.ts
@@ -1,5 +1,4 @@
 import { writable } from 'svelte/store';
-import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { Layer, SpriteImage } from '$lib/types';
 
 // progress / indicator bar displayed in the drawer for async fetch data
@@ -9,7 +8,7 @@ export const indicatorProgress = writable(false);
 export const layerList = writable(<Layer[]>[]);
 
 // map store for maplibre-gl object
-export const map = writable<MaplibreMap>(null);
+export * from './map';
 
 // vector : sprite list
 export const spriteImageList = writable(<SpriteImage[]>[]);

--- a/sites/geohub/src/stores/map.ts
+++ b/sites/geohub/src/stores/map.ts
@@ -29,7 +29,7 @@ function createMapStore() {
 				state.setPaintProperty(layerId, name, value, options);
 
 				const style = state.getStyle();
-				const layer = style.layers.find((l) => l.id === layerId);
+				const layer = style?.layers?.find((l) => l.id === layerId);
 				if (layer) {
 					if (!layer.paint) {
 						layer.paint = {};
@@ -73,7 +73,7 @@ function createMapStore() {
 				state.setLayoutProperty(layerId, name, value, options);
 
 				const style = state.getStyle();
-				const layer = style.layers.find((l) => l.id === layerId);
+				const layer = style?.layers?.find((l) => l.id === layerId);
 				if (layer) {
 					if (!layer.layout) {
 						layer.layout = {};

--- a/sites/geohub/src/stores/map.ts
+++ b/sites/geohub/src/stores/map.ts
@@ -49,11 +49,56 @@ function createMapStore() {
 		});
 	};
 
+	/**
+	 * Update Maplibre's LayoutProperty
+	 *
+	 * Note.
+	 * setLayoutProperty does render map canvas with new given property value.
+	 * But in some cases, it does not actually update style.json object in Map instance.
+	 * Because of this problem of Maplibre, the function is going to update style.json directly and call `setStyle` function.
+	 *
+	 * @param layerId The ID of the layer to set the paint property in.
+	 * @param name The name of the paint property to set.
+	 * @param value The value of the paint property to set. Must be of a type appropriate for the property, as defined in the MapLibre Style Specification.
+	 * @param options Options object.
+	 */
+	const setLayoutProperty = (
+		layerId: string,
+		name: string,
+		value: unknown,
+		options?: StyleSetterOptions
+	) => {
+		update((state) => {
+			if (state) {
+				state.setLayoutProperty(layerId, name, value, options);
+
+				const style = state.getStyle();
+				const layer = style.layers.find((l) => l.id === layerId);
+				if (layer) {
+					if (!layer.layout) {
+						layer.layout = {};
+					}
+					if (value) {
+						layer.layout[name] = value;
+					} else {
+						if (layer.layout[name]) {
+							delete layer.layout[name];
+						}
+					}
+					state.setStyle(style);
+				}
+			}
+
+			return state;
+		});
+	};
+
 	return {
 		subscribe,
 		update,
 		set,
-		setPaintProperty
+		setPaintProperty,
+		setLayoutProperty
 	};
 }
 

--- a/sites/geohub/src/stores/map.ts
+++ b/sites/geohub/src/stores/map.ts
@@ -1,0 +1,60 @@
+import { writable } from 'svelte/store';
+import type { Map as MaplibreMap, StyleSetterOptions } from 'maplibre-gl';
+
+// map store for maplibre-gl object
+function createMapStore() {
+	const { set, update, subscribe } = writable<MaplibreMap>(undefined);
+
+	/**
+	 * Update Maplibre's PaintProperty
+	 *
+	 * Note.
+	 * setPaintProperty does render map canvas with new given property value.
+	 * But in some cases, it does not actually update style.json object in Map instance.
+	 * Because of this problem of Maplibre, the function is going to update style.json directly and call `setStyle` function.
+	 *
+	 * @param layerId The ID of the layer to set the paint property in.
+	 * @param name The name of the paint property to set.
+	 * @param value The value of the paint property to set. Must be of a type appropriate for the property, as defined in the MapLibre Style Specification.
+	 * @param options Options object.
+	 */
+	const setPaintProperty = (
+		layerId: string,
+		name: string,
+		value: unknown,
+		options?: StyleSetterOptions
+	) => {
+		update((state) => {
+			if (state) {
+				state.setPaintProperty(layerId, name, value, options);
+
+				const style = state.getStyle();
+				const layer = style.layers.find((l) => l.id === layerId);
+				if (layer) {
+					if (!layer.paint) {
+						layer.paint = {};
+					}
+					if (value) {
+						layer.paint[name] = value;
+					} else {
+						if (layer.paint[name]) {
+							delete layer.paint[name];
+						}
+					}
+					state.setStyle(style);
+				}
+			}
+
+			return state;
+		});
+	};
+
+	return {
+		subscribe,
+		update,
+		set,
+		setPaintProperty
+	};
+}
+
+export const map = createMapStore();


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #1749

Maplibre's `setLayoutProperty` and `setPaintProperty` do not update actual style.json in Maplibre Map instance. I created customised functions to wrap both maplibre methods to forse updating style.json by using `setStyle` method.

To update maplibre's layer style, please always use new functions in map store, don't use Maplibre's functions directly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
