### PR TITLE
refactor: changed undp tab to bulma tab for layer legend

### DIFF
--- a/sites/geohub/src/components/RasterLayer.svelte
+++ b/sites/geohub/src/components/RasterLayer.svelte
@@ -7,7 +7,6 @@
 	import RasterTransform from '$components/controls/RasterTransform.svelte';
 	import { LegendTypes, TabNames } from '$lib/config/AppConfig';
 	import type { Layer, RasterTileMetadata } from '$lib/types';
-	import { Tabs } from '@undp-data/svelte-undp-design';
 	import { fade } from 'svelte/transition';
 
 	export let layer: Layer;
@@ -37,6 +36,14 @@
 			{ label: TabNames.OPACITY, icon: 'fa-solid fa-droplet' }
 		];
 	}
+
+	const handleEnterKey = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			e.target.click();
+		}
+	};
 </script>
 
 <div class="raster-layer-container has-background-white-bis" transition:fade|global>
@@ -44,8 +51,28 @@
 		<p class="panel-heading has-background-grey-lighter p-2">
 			<LayerNameGroup {layer} />
 		</p>
-		<Tabs bind:tabs bind:activeTab fontSize="medium" isToggleTab={true} />
-		<p class="panel-content">
+
+		<div class="tabs is-fullwidth">
+			<ul>
+				{#each tabs as tab}
+					<li class={activeTab === tab.label ? 'is-active' : ''}>
+						<!-- svelte-ignore a11y-missing-attribute -->
+						<a
+							role="tab"
+							tabindex="0"
+							class="px-0 py-1"
+							on:click={() => (activeTab = tab.label)}
+							on:keydown={handleEnterKey}
+						>
+							<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
+							<span>{tab.label}</span>
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</div>
+
+		<p class="panel-content px-2 pb-2">
 			{#if activeTab === TabNames.LEGEND}
 				<RasterLegend bind:layer bind:numberOfClasses bind:legendType />
 			{/if}
@@ -63,12 +90,3 @@
 		</p>
 	</nav>
 </div>
-
-<style lang="scss">
-	.raster-layer-container {
-		.panel-content {
-			padding: 10px;
-			padding-top: 15px;
-		}
-	}
-</style>

--- a/sites/geohub/src/components/RasterLayer.svelte
+++ b/sites/geohub/src/components/RasterLayer.svelte
@@ -6,6 +6,7 @@
 	import RasterLegend from '$components/controls/RasterLegend.svelte';
 	import RasterTransform from '$components/controls/RasterTransform.svelte';
 	import { LegendTypes, TabNames } from '$lib/config/AppConfig';
+	import { handleEnterKey } from '$lib/helper';
 	import type { Layer, RasterTileMetadata } from '$lib/types';
 	import { fade } from 'svelte/transition';
 
@@ -36,14 +37,6 @@
 			{ label: TabNames.OPACITY, icon: 'fa-solid fa-droplet' }
 		];
 	}
-
-	const handleEnterKey = (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			e.target.click();
-		}
-	};
 </script>
 
 <div class="raster-layer-container has-background-white-bis" transition:fade|global>
@@ -60,12 +53,12 @@
 						<a
 							role="tab"
 							tabindex="0"
-							class="px-0 py-1"
+							class="px-1 py-1"
 							on:click={() => (activeTab = tab.label)}
 							on:keydown={handleEnterKey}
 						>
 							<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
-							<span>{tab.label}</span>
+							<span class="has-text-weight-semibold">{tab.label}</span>
 						</a>
 					</li>
 				{/each}

--- a/sites/geohub/src/components/VectorLayer.svelte
+++ b/sites/geohub/src/components/VectorLayer.svelte
@@ -7,7 +7,7 @@
 	import { getLayerSourceUrl, loadArgumentsInDynamicLayers, loadMap } from '$lib/helper';
 	import type { Layer } from '$lib/types';
 	import { map, spriteImageList } from '$stores';
-	import { Loader, Tabs } from '@undp-data/svelte-undp-design';
+	import { Loader } from '@undp-data/svelte-undp-design';
 	import { fade } from 'svelte/transition';
 	import VectorFilter from './controls/VectorFilter.svelte';
 	import VectorParamsPanel from './controls/VectorParamsPanel.svelte';
@@ -43,6 +43,14 @@
 		}
 		return isLoaded;
 	};
+
+	const handleEnterKey = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			e.target.click();
+		}
+	};
 </script>
 
 <div
@@ -59,14 +67,27 @@
 				<Loader size="small" />
 			</div>
 		{:then}
-			<Tabs
-				bind:tabs
-				bind:activeTab
-				fontSize={tabs.find((t) => t.label === TabNames.SIMULATION) ? 'small' : 'medium'}
-				isToggleTab={true}
-			/>
+			<div class="tabs is-fullwidth">
+				<ul>
+					{#each tabs as tab}
+						<li class={activeTab === tab.label ? 'is-active' : ''}>
+							<!-- svelte-ignore a11y-missing-attribute -->
+							<a
+								role="tab"
+								tabindex="0"
+								class="px-0 py-1"
+								on:click={() => (activeTab = tab.label)}
+								on:keydown={handleEnterKey}
+							>
+								<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
+								<span>{tab.label}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
 
-			<p class="panel-content">
+			<p class="panel-content px-2 pb-2">
 				{#if activeTab === TabNames.LEGEND}
 					{#if $spriteImageList?.length > 0}
 						<VectorLegend
@@ -96,13 +117,6 @@
 </div>
 
 <style lang="scss">
-	.vector-layer-container {
-		.panel-content {
-			padding: 10px;
-			padding-top: 15px;
-		}
-	}
-
 	.loader-container {
 		display: flex;
 		align-items: center;

--- a/sites/geohub/src/components/VectorLayer.svelte
+++ b/sites/geohub/src/components/VectorLayer.svelte
@@ -4,7 +4,12 @@
 	import VectorLabelPanel from '$components/controls/VectorLabelPanel.svelte';
 	import VectorLegend from '$components/controls/VectorLegend.svelte';
 	import { LegendTypes, TabNames, VectorApplyToTypes } from '$lib/config/AppConfig';
-	import { getLayerSourceUrl, loadArgumentsInDynamicLayers, loadMap } from '$lib/helper';
+	import {
+		getLayerSourceUrl,
+		handleEnterKey,
+		loadArgumentsInDynamicLayers,
+		loadMap
+	} from '$lib/helper';
 	import type { Layer } from '$lib/types';
 	import { map, spriteImageList } from '$stores';
 	import { Loader } from '@undp-data/svelte-undp-design';
@@ -43,14 +48,6 @@
 		}
 		return isLoaded;
 	};
-
-	const handleEnterKey = (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			e.target.click();
-		}
-	};
 </script>
 
 <div
@@ -75,12 +72,12 @@
 							<a
 								role="tab"
 								tabindex="0"
-								class="px-0 py-1"
+								class="px-1 py-1"
 								on:click={() => (activeTab = tab.label)}
 								on:keydown={handleEnterKey}
 							>
 								<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
-								<span>{tab.label}</span>
+								<span class="has-text-weight-semibold">{tab.label}</span>
 							</a>
 						</li>
 					{/each}


### PR DESCRIPTION
## Description

Bulma tab looks good, but we will lose the feature of toggle content if switch from UNDP tab. We need another way to hide contents.

@iferencik @Thuhaa What do you think this Bulma tab? Also. do you have any alternative design idea to toggle contents?

<img width="356" alt="image" src="https://github.com/UNDP-Data/geohub/assets/2639701/1fc92f40-e48b-4d33-9a27-bc988a6c1526">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
