### PR TITLE
feat: add text-font property when label is created

### DIFF
--- a/sites/geohub/src/lib/config/AppConfig/FontJonUrl.ts
+++ b/sites/geohub/src/lib/config/AppConfig/FontJonUrl.ts
@@ -1,0 +1,1 @@
+export const FontJsonUrl = 'https://fonts.undpgeohub.org/fonts.json';

--- a/sites/geohub/src/lib/config/AppConfig/index.ts
+++ b/sites/geohub/src/lib/config/AppConfig/index.ts
@@ -9,6 +9,7 @@ export * from './DataCategories';
 export * from './DatasetSearchQueryParams';
 export * from './DatasetSortingColumns';
 export * from './FetchTimeoutMsec';
+export * from './FontJonUrl';
 export * from './FooterItems';
 export * from './HeaderItems';
 export * from './IconOverlapPriority';

--- a/sites/geohub/src/lib/config/DefaultUserConfig/LabelTextFont.ts
+++ b/sites/geohub/src/lib/config/DefaultUserConfig/LabelTextFont.ts
@@ -1,0 +1,1 @@
+export const LabelTextFont = 'Proxima Nova Regular';

--- a/sites/geohub/src/lib/config/DefaultUserConfig/index.ts
+++ b/sites/geohub/src/lib/config/DefaultUserConfig/index.ts
@@ -22,6 +22,7 @@ import { IconImage } from '$lib/config/DefaultUserConfig/IconImage';
 import { LayerOpacity } from '$lib/config/DefaultUserConfig/LayerOpacity';
 import { LinePattern } from '$lib/config/DefaultUserConfig/LinePattern';
 import { MapPageSearchLimit } from './MapPageSearchLimit';
+import { LabelTextFont } from './LabelTextFont';
 
 export interface UserConfig {
 	DatasetSearchLimit: number;
@@ -47,6 +48,7 @@ export interface UserConfig {
 	LinePattern: 'solid' | 'dash' | 'dot' | 'dashdot';
 	LabelFontSize: number;
 	LabelHaloWidth: number;
+	LabelTextFont: string;
 }
 
 export const DefaultUserConfig = {
@@ -68,6 +70,7 @@ export const DefaultUserConfig = {
 	RasterResamplingMethod,
 	LabelFontSize,
 	LabelHaloWidth,
+	LabelTextFont,
 	IconOverlapPriority,
 	IconSize,
 	IconImage,


### PR DESCRIPTION
fixes #1838 

## Description

Due to the change of Glyph URL, now we need to add text-font property always.
I also added dafault font option in settings.

If users already have saved map with CARTO's glyph URL, text-font property will not be generated.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
