### PR TITLE
refactor: moved rasterbandselector to raster legend, and only available if available bands are more than one

### DIFF
--- a/sites/geohub/src/components/LayerHeader.svelte
+++ b/sites/geohub/src/components/LayerHeader.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import DataCardInfoMenu from '$components/controls/DataCardInfoMenu.svelte';
 	import DeleteMenu from '$components/controls/DeleteMenu.svelte';
-	import RasterBandSelector from '$components/controls/RasterBandSelector.svelte';
 	import VisibilityButton from '$components/controls/VisibilityButton.svelte';
 	import Legend from '$components/controls/vector-styles/Legend.svelte';
 	import { clean, getLayerStyle, handleEnterKey, initTippy } from '$lib/helper';
@@ -102,10 +101,6 @@
 		<VisibilityButton {layer} />
 
 		<Legend bind:map={$map} bind:layer={layerStyle} />
-
-		{#if layerStyle?.type === 'raster'}
-			<span class="pl-1"><RasterBandSelector {layer} /></span>
-		{/if}
 	</div>
 
 	{#if hasLayerLabel}

--- a/sites/geohub/src/components/controls/RasterBandSelector.svelte
+++ b/sites/geohub/src/components/controls/RasterBandSelector.svelte
@@ -1,19 +1,8 @@
 <script lang="ts">
-	import {
-		getActiveBandIndex,
-		getLayerStyle,
-		handleEnterKey,
-		initTippy,
-		updateParamsInURL
-	} from '$lib/helper';
+	import { getActiveBandIndex, getLayerStyle, updateParamsInURL } from '$lib/helper';
 	import type { Layer, RasterTileMetadata } from '$lib/types';
 	import { layerList, map } from '$stores';
 	import type { RasterSourceSpecification } from 'maplibre-gl';
-
-	const tippy = initTippy({
-		placement: 'bottom-start'
-	});
-	let tooltipContent: HTMLElement;
 
 	export let layer: Layer;
 
@@ -66,36 +55,20 @@
 </script>
 
 {#if !isRgbTile && layerStyle && layerStyle.type === 'raster' && !info.isMosaicJson}
-	<button
-		class="selected-band tag is-success"
-		disabled={bands.length < 2}
-		use:tippy={{ content: tooltipContent }}>B{selected}</button
-	>
-	<div bind:this={tooltipContent} class="tooltip p-2">
-		<nav class="panel">
-			{#each bands as band}
-				<!-- svelte-ignore a11y-missing-attribute -->
-				<a
-					class="panel-block {selected === band ? 'is-active' : ''}"
-					role="button"
-					tabindex="0"
-					on:click={() => {
-						selected = band;
-					}}
-					on:keydown={handleEnterKey}
-				>
-					<span class="panel-icon">
-						<i class="fa-solid fa-layer-group" aria-hidden="true" />
-					</span>
-					B{band}
-				</a>
-			{/each}
-		</nav>
-	</div>
+	<!-- Only show raster band selector if bands are available more than one. -->
+	{#if bands.length > 1}
+		<div class="field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label has-text-centered">Raster band</label>
+			<div class="control">
+				<div class="select is-fullwidth">
+					<select bind:value={selected}>
+						{#each bands as band}
+							<option value={band}>B{band}</option>
+						{/each}
+					</select>
+				</div>
+			</div>
+		</div>
+	{/if}
 {/if}
-
-<style lang="scss">
-	.selected-band {
-		cursor: pointer;
-	}
-</style>

--- a/sites/geohub/src/components/controls/RasterLegend.svelte
+++ b/sites/geohub/src/components/controls/RasterLegend.svelte
@@ -9,6 +9,7 @@
 	import { Loader } from '@undp-data/svelte-undp-design';
 	import { slide } from 'svelte/transition';
 	import LegendTypeSwitcher from './LegendTypeSwitcher.svelte';
+	import RasterBandSelector from './RasterBandSelector.svelte';
 	import RasterPropertyEditor from './RasterPropertyEditor.svelte';
 
 	export let layer: Layer;
@@ -125,6 +126,7 @@
 		{/if}
 		<div class="editor-button"><RasterPropertyEditor bind:layerId={layer.id} /></div>
 		{#if !isRgbTile}
+			<RasterBandSelector {layer} />
 			{#if legendType === LegendTypes.DEFAULT}
 				<div transition:slide|global>
 					<RasterDefaultLegend bind:layerConfig={layer} />


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Since raster band selector does not need to be shown if only a band is available, now it is only shown if more than two bands are selectable. Also, moved it from layer header to raster legend component.

It will looks like the below screenshots if two bands are available in the layer. 
![](https://github.com/UNDP-Data/geohub/assets/2639701/1883b535-a199-44d9-8c9f-ad087faecea8)

But most of our raster datasets only have a band. I even don't know which databasets have two bands...

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1200040941) by [Unito](https://www.unito.io)
