### PR TITLE
fix: hide unpublish button in responsive, and open pmtiles viewer with href

### DIFF
--- a/.changeset/lazy-suits-flow.md
+++ b/.changeset/lazy-suits-flow.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+feat: add target property for CtaLink component

--- a/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.svelte
+++ b/packages/svelte-undp-design/src/lib/CtaLink/CtaLink.svelte
@@ -5,6 +5,7 @@
 	export let label: string;
 	export let isArrow = true;
 	export let href = '';
+	export let target = '';
 
 	const handleClicked = () => {
 		dispatch('clicked');
@@ -18,7 +19,7 @@
 </script>
 
 {#if href}
-	<a class="cta__link {isArrow ? 'cta--arrow' : 'cta--space'}" role="button" {href}>
+	<a class="cta__link {isArrow ? 'cta--arrow' : 'cta--space'}" role="button" {href} {target}>
 		{label}
 		<i />
 	</a>

--- a/sites/geohub/src/components/data-upload/DataPreviewContent.svelte
+++ b/sites/geohub/src/components/data-upload/DataPreviewContent.svelte
@@ -9,11 +9,6 @@
 	export let feature: DatasetFeature;
 
 	let isPmtiles = url.indexOf('.pmtiles') !== -1 ? true : false;
-
-	const handleLinkClicked = () => {
-		const viewerUrl = `https://undp-data.github.io/PMTiles?url=${encodeURIComponent(url)}`;
-		window.open(viewerUrl, '_blank');
-	};
 </script>
 
 <div>
@@ -22,7 +17,12 @@
 	{/if}
 	{#if isPmtiles}
 		<div class="mt-2">
-			<CtaLink label="See more details" isArrow={false} on:clicked={handleLinkClicked} />
+			<CtaLink
+				label="See more details"
+				isArrow={false}
+				href={`https://protomaps.github.io/PMTiles?url=${encodeURIComponent(url)}`}
+				target="_blank"
+			/>
 		</div>
 	{/if}
 </div>

--- a/sites/geohub/src/components/data-upload/IngestingDatasetRowDetail.svelte
+++ b/sites/geohub/src/components/data-upload/IngestingDatasetRowDetail.svelte
@@ -107,21 +107,23 @@
 						{/if}
 					</span>
 				</a>
-				<!-- svelte-ignore a11y-missing-attribute -->
-				<a
-					class="button is-primary table-button is-small"
-					role="button"
-					tabindex="0"
-					on:click={() => {
-						confirmDeleteDialogVisible = true;
-					}}
-					on:keydown={handleEnterKey}
-				>
-					<span class="icon">
-						<i class="fa-solid fa-trash" />
-					</span>
-					<span>Unpublish</span>
-				</a>
+				{#if !dataset.processing}
+					<!-- svelte-ignore a11y-missing-attribute -->
+					<a
+						class="button is-primary table-button is-small"
+						role="button"
+						tabindex="0"
+						on:click={() => {
+							confirmDeleteDialogVisible = true;
+						}}
+						on:keydown={handleEnterKey}
+					>
+						<span class="icon">
+							<i class="fa-solid fa-trash" />
+						</span>
+						<span>Unpublish</span>
+					</a>
+				{/if}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description


* hide `unpublish` button when the dataset is not published yet in responsive mode.
* changed PMTiles viewer for original one. since UNDP one does not show basemap correctly (maybe because of CORS)
* open PMTiles viewer from href link. 
* Added target property in CtaLink component of UNDP design. So it can be opened to new tab by specifying `_blank`. default is emptying string `''`.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1201215417) by [Unito](https://www.unito.io)
