### PR TITLE
fix: regenerate elements after sorting in client side

### DIFF
--- a/sites/geohub/src/components/data-upload/IngestingDatasets.svelte
+++ b/sites/geohub/src/components/data-upload/IngestingDatasets.svelte
@@ -1,22 +1,12 @@
 <script lang="ts">
 	import type { IngestingDataset } from '$lib/types';
-	import { Loader } from '@undp-data/svelte-undp-design';
 	import { createEventDispatcher } from 'svelte';
 	import IngestingDatasetHeader from './IngestingDatasetHeader.svelte';
 	import IngestingDatasetRow from './IngestingDatasetRow.svelte';
 
 	const dispatch = createEventDispatcher();
 
-	export let datasets: Promise<IngestingDataset[]>;
-	let ingestingDatasets: IngestingDataset[];
-
-	$: datasets, updateDatasets();
-	const updateDatasets = () => {
-		datasets.then((res) => {
-			ingestingDatasets = res;
-		});
-	};
-	updateDatasets();
+	export let datasets: IngestingDataset[];
 
 	const handleDataChanged = () => {
 		dispatch('change');
@@ -26,9 +16,9 @@
 		const sortby = e.detail.sortby;
 		const sortingorder = e.detail.sortingorder;
 
-		if (!(ingestingDatasets && ingestingDatasets.length > 0)) return;
+		if (!(datasets && datasets.length > 0)) return;
 
-		const sortedDatasets = ingestingDatasets.sort((a, b) => {
+		const sortedDatasets = datasets.sort((a, b) => {
 			if (a.raw[sortby] > b.raw[sortby]) {
 				return sortingorder === 'desc' ? -1 : 1;
 			} else if (a.raw[sortby] < b.raw[sortby]) {
@@ -37,25 +27,14 @@
 				return 0;
 			}
 		});
-		ingestingDatasets = [...sortedDatasets];
+		datasets = [...sortedDatasets];
 	};
 </script>
 
 <IngestingDatasetHeader on:sortChanged={handleSortChanged} />
 
-{#await datasets}
-	<div class="align-center my-4">
-		<Loader />
-	</div>
-{:then}
-	{#each ingestingDatasets as dataset}
-		<IngestingDatasetRow bind:dataset on:change={handleDataChanged} />
-	{/each}
-{/await}
-
-<style lang="scss">
-	.align-center {
-		width: max-content;
-		margin: auto;
-	}
-</style>
+{#each datasets as data}
+	{#key data}
+		<IngestingDatasetRow dataset={data} on:change={handleDataChanged} />
+	{/key}
+{/each}

--- a/sites/geohub/src/routes/(app)/data/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/+page.svelte
@@ -8,6 +8,7 @@
 	import { handleEnterKey } from '$lib/helper';
 	import type { DatasetFeatureCollection, IngestingDataset } from '$lib/types';
 	import { signIn } from '@auth/sveltekit/client';
+	import { Loader } from '@undp-data/svelte-undp-design';
 	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
@@ -122,7 +123,13 @@
 				</button>
 			</div>
 
-			<IngestingDatasets bind:datasets={ingestingDatasets} on:change={updateDatasets} />
+			{#await ingestingDatasets}
+				<div class="is-flex is-justify-content-center my-4">
+					<Loader />
+				</div>
+			{:then ds}
+				<IngestingDatasets datasets={ds} on:change={updateDatasets} />
+			{/await}
 		{/if}
 	</div>
 </div>
@@ -150,10 +157,3 @@
 		</div>
 	</div>
 </section>
-
-<style lang="scss">
-	.align-center {
-		width: max-content;
-		margin: auto;
-	}
-</style>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
There was a bug that elements on ingesting table were not updated when sorting setting is changed. I added `key` tag to force to recreate table.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1202286856) by [Unito](https://www.unito.io)
