### PR TITLE
fix: adjusted SDG filter height

### DIFF
--- a/sites/geohub/src/components/data-upload/PublishedDatasets.svelte
+++ b/sites/geohub/src/components/data-upload/PublishedDatasets.svelte
@@ -258,7 +258,7 @@
 							<span class="icon is-small">
 								<i class="fas fa-star"></i>
 							</span>
-							<span>Favourite</span>
+							<span>Favourites</span>
 						</button>
 					</p>
 				</div>
@@ -266,14 +266,6 @@
 		{/if}
 		<div class="column px-0 py-1 mr-4">
 			<div class="is-flex is-justify-content-end is-align-items-center">
-				<div class="field px-1 m-0">
-					<SdgPicker
-						bind:tags={selectedSDGs}
-						size="small"
-						showSelectionOnButton={false}
-						on:change={handleSDGtagChanged}
-					/>
-				</div>
 				<div class="control has-icons-left filter-text-box pl-1">
 					<input
 						data-testid="filter-bucket-input"
@@ -298,7 +290,14 @@
 						</div>
 					{/if}
 				</div>
-
+				<div class="field px-1 m-0 pb-1">
+					<SdgPicker
+						bind:tags={selectedSDGs}
+						size="small"
+						showSelectionOnButton={false}
+						on:change={handleSDGtagChanged}
+					/>
+				</div>
 				<div class="field tag-filter m-0">
 					<PanelButton
 						icon="fas fa-sliders"
@@ -343,7 +342,7 @@
 {#if selectedSDGs.length > 0}
 	<div class="field">
 		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label class="label">Filtered by SDG{selectedSDGs.length > 1 ? '(s)' : ''}</label>
+		<label class="label">Filtered by SDG{selectedSDGs.length > 1 ? 's' : ''}</label>
 		<div class="control">
 			<div class="is-flex">
 				{#key selectedSDGs}

--- a/sites/geohub/src/components/data-upload/SdgPicker.svelte
+++ b/sites/geohub/src/components/data-upload/SdgPicker.svelte
@@ -66,7 +66,7 @@
 </script>
 
 <div class="sdgs-select-button" use:tippy={{ content: tooltipContent }}>
-	<div class="box p-2">
+	<div class="box p-1">
 		{#if showSelectionOnButton && Object.keys(selectedSDGs).filter((sdg) => selectedSDGs[sdg] === true).length > 0}
 			<div class="is-flex is-flex-direction-row is-flex-wrap-wrap">
 				{#each Object.keys(selectedSDGs).filter((sdg) => selectedSDGs[sdg] === true) as sdg}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Adjusted height of SDG filter button

![](https://github.com/UNDP-Data/geohub/assets/2639701/73485ef7-ec64-44bf-9e36-bf3c42b48cea)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1202750000) by [Unito](https://www.unito.io)
