### PR TITLE
fix: moving code of generating user hash key to hooks.server.ts

### DIFF
--- a/sites/geohub/src/hooks.server.ts
+++ b/sites/geohub/src/hooks.server.ts
@@ -4,7 +4,7 @@ import { SvelteKitAuth } from '@auth/sveltekit';
 import AzureADProvider from '@auth/core/providers/azure-ad';
 import GitHub from '@auth/core/providers/github';
 import { env } from '$env/dynamic/private';
-import { getMe } from '$lib/server/helpers';
+import { generateHashKey, getMe } from '$lib/server/helpers';
 
 const redirects = {
 	'/dashboards': '/',
@@ -70,6 +70,12 @@ const handleAuth = SvelteKitAuth({
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			session.user.jobTitle = token.jobTitle;
+
+			if (session?.user?.email) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				session.user.id = generateHashKey(session.user.email);
+			}
 
 			// console.log(session)
 			return session;

--- a/sites/geohub/src/lib/server/helpers/upload.ts
+++ b/sites/geohub/src/lib/server/helpers/upload.ts
@@ -1,5 +1,3 @@
-import { generateHashKey } from '.';
-
 export const UPLOAD_CONTAINER_NAME = 'userdata';
 export const UPLOAD_RAW_FOLDER_NAME = 'raw';
 export const UPLOAD_DATASETS_FOLDER_NAME = 'datasets';
@@ -8,8 +6,7 @@ export const UPLOAD_BASE_URL = (account: string) => {
 	return `https://${account}.blob.core.windows.net`;
 };
 
-export const UPLOAD_BLOB_URL = (account: string, user_email: string, fileName: string) => {
-	const userHash = generateHashKey(user_email);
+export const UPLOAD_BLOB_URL = (account: string, userHash: string, fileName: string) => {
 	const folder = `${userHash}/${UPLOAD_RAW_FOLDER_NAME}`;
 	return `${UPLOAD_BASE_URL(account)}/${UPLOAD_CONTAINER_NAME}/${folder}/${fileName}`;
 };

--- a/sites/geohub/src/routes/(app)/data/publish/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/publish/+page.server.ts
@@ -31,7 +31,6 @@ export const load: PageServerLoad = async (event) => {
 	const { locals, url } = event;
 	const session = await locals.getSession();
 	if (!session) return;
-	const user_email = session?.user.email;
 
 	let datasetUrl = url.searchParams.get('url');
 	if (!datasetUrl) {
@@ -138,7 +137,7 @@ export const load: PageServerLoad = async (event) => {
 					message: `This dataset (${datasetUrl}) is not supported for this page.`
 				});
 			} else if (isUploadStorageAccount) {
-				const userHash = generateHashKey(user_email);
+				const userHash = session.user.id;
 				const isLoginUserDataset = datasetUrl.indexOf(userHash) === -1 ? false : true;
 				if (!isLoginUserDataset) {
 					throw error(403, { message: `No permission to access this dataset` });

--- a/sites/geohub/src/routes/+layout.server.ts
+++ b/sites/geohub/src/routes/+layout.server.ts
@@ -1,11 +1,7 @@
-import { generateHashKey } from '$lib/server/helpers';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	const session = await locals.getSession();
-	if (session?.user?.email) {
-		session.user.id = generateHashKey(session.user.email);
-	}
 	return {
 		session
 	};

--- a/sites/geohub/src/routes/api/datasets/[id]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/+server.ts
@@ -1,7 +1,6 @@
 import type { RequestHandler } from './$types';
 import {
 	createDatasetLinks,
-	generateHashKey,
 	getBlobServiceClient,
 	getDatasetById,
 	isSuperuser
@@ -99,7 +98,7 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 				env.AZURE_STORAGE_ACCESS_KEY_UPLOAD
 			);
 			const containerName = 'userdata';
-			const userHash = generateHashKey(user_email);
+			const userHash = session.user.id;
 			if (dataset.properties.url.indexOf(`${containerName}/${userHash}/datasets`) !== -1) {
 				// only generate .ingesting file if the file is under /userdata/{id}/raw folder
 				const containerClient = blobServiceClient.getContainerClient(containerName);

--- a/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
@@ -26,8 +26,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 			status: 403
 		});
 	}
-	const user_email = session?.user.email;
-	const userHash = generateHashKey(user_email);
+	const userHash = session.user.id;
 
 	const sortby = url.searchParams.get('sortby') ?? 'createdat';
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Make user hash key in hooks.server.ts now. so all server.ts can use user id as defalt through `session.user.id`.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1207637061) by [Unito](https://www.unito.io)
