### PR TITLE
fix: position of error message to be the next of Show details

### DIFF
--- a/sites/geohub/src/components/data-upload/IngestingDatasetRow.svelte
+++ b/sites/geohub/src/components/data-upload/IngestingDatasetRow.svelte
@@ -281,10 +281,31 @@
 				</button>
 			{/if}
 
-			{#if dataset.datasets.length > 0}
-				<br />
-				<ShowDetails bind:show={isDetailsShown} />
-			{/if}
+			<div class="columns is-vcentered">
+				{#if dataset.datasets.length > 0}
+					<div class="column is-3">
+						<ShowDetails bind:show={isDetailsShown} />
+					</div>
+				{/if}
+				{#if dataset.raw.error}
+					<div class="column is-flex">
+						<p class="help is-danger">It has errors. Check logs.</p>
+						<div
+							class="error-dialog-button pl-1"
+							role="button"
+							tabindex="0"
+							on:click={() => {
+								showLogDialog(dataset.raw.error);
+							}}
+							on:keydown={handleEnterKey}
+						>
+							<span class="icon">
+								<i class="fa-solid fa-arrow-up-right-from-square fa-lg has-text-primary" />
+							</span>
+						</div>
+					</div>
+				{/if}
+			</div>
 		</div>
 		<div class="column is-2 has-text-centered">
 			{#if status === 'Processed'}
@@ -327,8 +348,7 @@
 						{/if}
 					</span>
 				</span>
-				<br />
-				<!-- svelte-ignore a11y-missing-attribute -->
+				<!-- <br />
 				<a
 					class="pl-2 error-dialog-button is-flex is-justify-content-center is-align-items-center"
 					role="button"
@@ -342,7 +362,7 @@
 						<i class="fa-solid fa-arrow-up-right-from-square fa-lg has-text-primary" />
 					</span>
 					<span class="error-button-name has-text-black subtitle is-6">Show error logs</span>
-				</a>
+				</a> -->
 			{:else if status === 'Published'}
 				<span class="tag is-success is-light">
 					<span class="icon">
@@ -596,13 +616,6 @@
 
 	.error-dialog-button {
 		cursor: pointer;
-		width: fit-content;
-
-		.error-button-name {
-			border-bottom: 2px solid #d12800;
-			padding-bottom: 0.1em;
-			display: inline;
-		}
 	}
 
 	.modal-content {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
![](https://github.com/UNDP-Data/geohub/assets/2639701/a4b9d849-e299-410b-b487-fe86a71e1335)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1214735401) by [Unito](https://www.unito.io)
