### PR TITLE
fix: don't copy package.json to deployment

### DIFF
--- a/sites/geohub/build-nodemodules.sh
+++ b/sites/geohub/build-nodemodules.sh
@@ -6,5 +6,4 @@ sed -e 's/workspace://g' ./package.json > ./package2.json
 rm package.json
 mv package2.json package.json
 npm install --omit=dev --legacy-peer-deps
-cp package.json build/.
 mv node_modules build/.


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
In dashboards/electricity and map page, the following error is shown when we reload the page (Moving from links in other page can work)

【 code  】
500
require is not defined in ES module scope, you can use import instead This file is being treated as an ES module because it has a '.js' file extension and '/home/site/wwwroot/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
【 end code 】

According to what the error says, package.json in deployment folder looks affecting nodejs server behaviour. Let me try not to copy package.json in build folder through this PR.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1214739327) by [Unito](https://www.unito.io)
