### PR TITLE
fix: changed a tag to div element on Pagination component because svelte complains it does not use any href

### DIFF
--- a/.changeset/new-dancers-sip.md
+++ b/.changeset/new-dancers-sip.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: changed a tag to div element on Pagination component because svelte complains it does not use any href

--- a/packages/svelte-undp-design/src/lib/Pagination/Pagination.svelte
+++ b/packages/svelte-undp-design/src/lib/Pagination/Pagination.svelte
@@ -17,6 +17,11 @@
 			type: type
 		});
 	};
+	const handleKeyDown = (event: KeyboardEvent) => {
+		if (event.key === 'Enter') {
+			dispatch('clicked');
+		}
+	};
 </script>
 
 <nav class="pagination" aria-label="Pagination">
@@ -26,41 +31,39 @@
 			class={currentPage === 1 ? 'disabled' : ''}
 			aria-disabled={currentPage === 1 ? 'true' : 'false'}
 		>
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<a
+			<div
 				role="button"
 				tabindex="0"
 				aria-current="true"
 				aria-label="Previous"
 				data-testid="previous"
 				on:click={() => handleClicked('previous')}
+				on:keydown={handleKeyDown}
 			>
 				Previous
-			</a>
+			</div>
 		</li>
 		<li>
 			Page
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<span><a aria-label={currentPage.toString()}>{currentPage}</a></span>
+			<span><div aria-label={currentPage.toString()}>{currentPage}</div></span>
 			of
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<span><a aria-label={totalPages.toString()}>{totalPages}</a></span>
+			<span><div aria-label={totalPages.toString()}>{totalPages}</div></span>
 		</li>
-		<!-- svelte-ignore a11y-click-events-have-key-events -->
 		<!-- svelte-ignore a11y-role-supports-aria-props -->
 		<li
 			class={currentPage === totalPages ? 'disabled' : ''}
 			aria-disabled={currentPage === totalPages ? 'true' : 'false'}
 		>
-			<!-- svelte-ignore a11y-missing-attribute -->
-			<a
+			<div
 				role="button"
 				tabindex="0"
 				aria-label="Next"
 				data-testid="next"
-				on:click={() => handleClicked('next')}>Next</a
+				on:click={() => handleClicked('next')}
+				on:keydown={handleKeyDown}
 			>
+				Next
+			</div>
 		</li>
 	</ul>
 </nav>

--- a/packages/svelte-undp-design/src/lib/css/pagination.min.css
+++ b/packages/svelte-undp-design/src/lib/css/pagination.min.css
@@ -28,14 +28,14 @@
 .pagination ul li:last-of-type {
 	cursor: pointer;
 }
-.pagination ul li:first-of-type a,
-.pagination ul li:last-of-type a {
+.pagination ul li:first-of-type div,
+.pagination ul li:last-of-type div {
 	font-size: 0;
 	height: 45px;
 	width: 45px;
 }
-.pagination ul li:first-of-type a:before,
-.pagination ul li:last-of-type a:before {
+.pagination ul li:first-of-type div:before,
+.pagination ul li:last-of-type div:before {
 	background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDUiIGhlaWdodD0iNDQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj48cGF0aCBkPSJNMjIuMjc2IDBDOS45NzQgMCAuMDAxIDkuODQ4LjAwMSAyMS45OTZjMCAxMi4xNDggOS45NzMgMjEuOTk2IDIyLjI3NSAyMS45OTYgMTIuMzAyIDAgMjIuMjc1LTkuODQ4IDIyLjI3NS0yMS45OTZDNDQuNTUxIDkuODQ4IDM0LjU3OCAwIDIyLjI3NiAwWiIgZmlsbD0iIzIzMkUzRCIvPjxwYXRoIGQ9Im0yNi4wNSAzMC40OTItOS41NS03Ljk5NCA5LjU1LTgiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIyIi8+PC9nPjxkZWZzPjxjbGlwUGF0aCBpZD0iYSI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgMGg0NC41NTF2NDMuOTkySDB6Ii8+PC9jbGlwUGF0aD48L2RlZnM+PC9zdmc+)
 		no-repeat 50%;
 	content: ' ';
@@ -43,13 +43,13 @@
 	height: 45px;
 	width: 45px;
 }
-.pagination ul li.disabled a:before {
+.pagination ul li.disabled div:before {
 	opacity: 0.3;
 }
 .pagination ul li:last-of-type {
 	margin-right: 0;
 }
-.pagination ul li:last-of-type a:before {
+.pagination ul li:last-of-type div:before {
 	background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDUiIGhlaWdodD0iNDQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgY2xpcC1wYXRoPSJ1cmwoI2EpIj48cGF0aCBkPSJNMjIuMjc1IDQzLjk5MmMxMi4zMDIgMCAyMi4yNzUtOS44NDggMjIuMjc1LTIxLjk5NkM0NC41NSA5Ljg0OCAzNC41NzcgMCAyMi4yNzUgMCA5Ljk3MyAwIDAgOS44NDggMCAyMS45OTZjMCAxMi4xNDggOS45NzMgMjEuOTk2IDIyLjI3NSAyMS45OTZaIiBmaWxsPSIjMjMyRTNEIi8+PHBhdGggZD0ibTE4LjUgMTQuNSA5LjU1IDcuOTk0LTkuNTUgOCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiLz48L2c+PGRlZnM+PGNsaXBQYXRoIGlkPSJhIj48cGF0aCBmaWxsPSIjZmZmIiBkPSJNMCAwaDQ0LjU1MXY0My45OTJIMHoiLz48L2NsaXBQYXRoPjwvZGVmcz48L3N2Zz4=)
 		no-repeat 50%;
 }
@@ -61,7 +61,7 @@
 	margin-right: 0;
 	padding-right: 0;
 }
-[dir='rtl'] .pagination li:first-of-type a:before {
+[dir='rtl'] .pagination li:first-of-type div:before {
 	-webkit-transform: rotate(180deg);
 	-moz-transform: rotate(180deg);
 	-ms-transform: rotate(180deg);
@@ -71,7 +71,7 @@
 [dir='rtl'] .pagination li:last-of-type {
 	margin-left: 0;
 }
-[dir='rtl'] .pagination li:last-of-type a:before {
+[dir='rtl'] .pagination li:last-of-type div:before {
 	-webkit-transform: rotate(180deg);
 	-moz-transform: rotate(180deg);
 	-ms-transform: rotate(180deg);

--- a/sites/geohub/src/components/maps/MapStyleCard.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCard.svelte
@@ -19,11 +19,15 @@
 	let deletedStyleName = '';
 	let isDeleting = false;
 
+	let mapLink = style.links.find((l) => l.rel === 'map')?.href;
+	let styleLink = style.links.find((l) => l.rel === 'static-auto')?.href;
+	let apiLink = style.links.find((l) => l.rel === 'self')?.href;
+
 	const handleDeleteStyle = async () => {
+		if (!apiLink) return;
 		isDeleting = true;
 		try {
-			const apiUrl = style.links.find((l) => l.rel === 'self').href;
-			const res = await fetch(apiUrl, {
+			const res = await fetch(apiLink, {
 				method: 'DELETE'
 			});
 			if (res.ok) {
@@ -52,31 +56,32 @@
 
 <div class="map-card is-flex is-flex-direction-column">
 	<div class="map-container">
-		<a href={style.links.find((l) => l.rel === 'map').href}>
-			<figure class="image is-5by3">
-				<img
-					alt={style.name}
-					src={style.links
-						.find((l) => l.rel === 'static-auto')
-						.href.replace('{width}', '298')
-						.replace('{height}', '180')}
-					width="298"
-					height="180"
-					loading="lazy"
-					on:load={() => {
-						imageLoaded = true;
-					}}
-					on:error={() => {
-						imageLoaded = true;
-					}}
-				/>
-				{#if !imageLoaded}
-					<div class="image-loader">
-						<Loader size="medium" />
-					</div>
-				{/if}
-			</figure>
-		</a>
+		{#if mapLink}
+			<a href={mapLink}>
+				<figure class="image is-5by3">
+					{#if styleLink}
+						<img
+							alt={style.name}
+							src={styleLink.replace('{width}', '298').replace('{height}', '180')}
+							width="298"
+							height="180"
+							loading="lazy"
+							on:load={() => {
+								imageLoaded = true;
+							}}
+							on:error={() => {
+								imageLoaded = true;
+							}}
+						/>
+					{/if}
+					{#if !imageLoaded}
+						<div class="image-loader">
+							<Loader size="medium" />
+						</div>
+					{/if}
+				</figure>
+			</a>
+		{/if}
 		{#if $page.data.session && style.created_user === $page.data.session.user.email}
 			<div class="delete-button has-tooltip-left has-tooltip-arrow" data-tooltip="Delete map">
 				<button class="button is-link ml-2" on:click={() => (confirmDeleteDialogVisible = true)}>
@@ -89,11 +94,9 @@
 	</div>
 	<p class="py-2 is-flex">
 		<i class="{getAccessLevelIcon(style.access_level)} p-1 pr-2" />
-		<CtaLink
-			bind:label={style.name}
-			isArrow={true}
-			href={style.links.find((l) => l.rel === 'map').href}
-		/>
+		{#if mapLink}
+			<CtaLink bind:label={style.name} isArrow={true} href={mapLink} />
+		{/if}
 	</p>
 	<div class="justify-bottom">
 		<div class="columns">

--- a/sites/geohub/src/components/maps/MapStyleCardList.svelte
+++ b/sites/geohub/src/components/maps/MapStyleCardList.svelte
@@ -10,7 +10,7 @@
 		MapSortingColumns,
 		SearchDebounceTime
 	} from '$lib/config/AppConfig';
-	import type { MapsData, StacLink } from '$lib/types';
+	import type { MapsData } from '$lib/types';
 	import { Loader, Pagination, SearchExpand } from '@undp-data/svelte-undp-design';
 	import { createEventDispatcher } from 'svelte';
 	import MapStyleCard from './MapStyleCard.svelte';
@@ -105,8 +105,8 @@
 		dispatch('change');
 	};
 
-	const handlePaginationClicked = async (link: StacLink) => {
-		const apiUrl = new URL(link.href);
+	const handlePaginationClicked = async (url: string) => {
+		const apiUrl = new URL(url);
 		await reload(apiUrl);
 	};
 
@@ -215,9 +215,9 @@
 			totalPages={mapData.pages.totalPages}
 			currentPage={mapData.pages.currentPage}
 			on:clicked={(e) => {
-				const link = mapData.links?.find((l) => l.rel === e.detail.type);
-				if (!link) return;
-				handlePaginationClicked(link);
+				const url = mapData.links?.find((l) => l.rel === e.detail.type)?.href;
+				if (!url) return;
+				handlePaginationClicked(url);
 			}}
 		/>
 	</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
It is going to fix the following weird error.
![](https://github.com/UNDP-Data/geohub/assets/2639701/fdc1acb7-dc61-4b1d-ba51-39036fe7b8a1)

The problem was in UNDP Pagination component. It has several <a> tag and does not have any href prop. When the element come within viewport of browser, svelte failed to create URL object from a tag and it shows error.

I changed a tag to div element and it works well in localhost.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1227525592) by [Unito](https://www.unito.io)
