### PR TITLE
fix: set limit=999 for getting geohub dataset

### DIFF
--- a/sites/geohub/src/routes/(app)/management/stac/+page.svelte
+++ b/sites/geohub/src/routes/(app)/management/stac/+page.svelte
@@ -37,7 +37,7 @@
 	};
 
 	const getDatasets = async () => {
-		const res = await fetch(`/api/datasets?type=stac&stac=${selectedStac.id}`);
+		const res = await fetch(`/api/datasets?type=stac&stac=${selectedStac.id}&limit=999`);
 		const json = await res.json();
 		return json as DatasetFeatureCollection;
 	};
@@ -172,9 +172,10 @@
 						<tbody>
 							{#if filteredCollection}
 								{#each filteredCollection as collection, index}
-									{@const collectionUrl = collection.links.find((l) => l.rel === 'items').href}
-									{@const id = generateHashKey(collectionUrl)}
-									{@const registred = geohubDatasets.features.find((f) => f.properties.id === id)
+									{@const registred = geohubDatasets.features.find((f) => {
+										const id = f.properties.tags.find((t) => t.key === 'collection');
+										return id.value === collection.id;
+									})
 										? true
 										: false}
 									<tr>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Please describe what you changed briefly.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1230127224) by [Unito](https://www.unito.io)
