### PR TITLE
refactor: moved filterInputTags from stores/index to VectorFilter/Vec…

### DIFF
--- a/sites/geohub/src/components/pages/map/layers/vector/ValueInput.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/ValueInput.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import Tags from '$components/pages/map/layers/vector/Tags.svelte';
-	import { filterInputTags, MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import arraystat from 'arraystat';
 	import { createEventDispatcher, getContext, onDestroy } from 'svelte';
 	import RangeSlider from 'svelte-range-slider-pips';
 	import { getLayerStyle } from '$lib/helper';
 	import type { Layer, VectorLayerTileStatAttribute, VectorTileMetadata } from '$lib/types';
 	import type { Listener, MapMouseEvent, SymbolLayerSpecification } from 'maplibre-gl';
+	import { FILTER_INPUTTAGS_CONTEXT_KEY, type FilterInputTags } from './VectorFilter.svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+
+	const filterInputTags: FilterInputTags = getContext(FILTER_INPUTTAGS_CONTEXT_KEY);
 
 	export let propertySelectedValue: string;
 	export let expressionValue: number[];

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorFilter.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorFilter.svelte
@@ -1,3 +1,11 @@
+<script context="module" lang="ts">
+	export const FILTER_INPUTTAGS_CONTEXT_KEY = 'vector-filter-input-tags';
+	export type FilterInputTags = Writable<unknown[]>;
+	const createFilterInputTagsStore = () => {
+		return writable([]);
+	};
+</script>
+
 <script lang="ts">
 	import Step from '$components/util/Step.svelte';
 	import Wizard from '$components/util/Wizard.svelte';
@@ -7,11 +15,15 @@
 	import { VectorFilterOperators } from '$lib/config/AppConfig';
 	import { clean, getLayerStyle } from '$lib/helper';
 	import type { Layer, VectorTileMetadata } from '$lib/types';
-	import { filterInputTags, MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import { toast } from '@zerodevx/svelte-toast';
-	import { getContext, onMount } from 'svelte';
+	import { getContext, onMount, setContext } from 'svelte';
+	import { writable, type Writable } from 'svelte/store';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+
+	const filterInputTags = createFilterInputTagsStore();
+	setContext(FILTER_INPUTTAGS_CONTEXT_KEY, filterInputTags);
 
 	export let layer: Layer;
 

--- a/sites/geohub/src/stores/index.ts
+++ b/sites/geohub/src/stores/index.ts
@@ -6,5 +6,3 @@ export * from './map';
 
 // vector : sprite list
 export const spriteImageList = writable(<SpriteImage[]>[]);
-
-export const filterInputTags = writable([]);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #1994

removed filterInputTags from global store since it is only used between VectorFilter and VectorInput.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others (refactoring)
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1230828996) by [Unito](https://www.unito.io)
