### PR TITLE
refactor: use ContextAPI for spriteImageList store. For settings, I changed not to use store since it is used within a page.

### DIFF
--- a/sites/geohub/src/components/maplibre/symbol/IconImage.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconImage.svelte
@@ -7,9 +7,15 @@
 	import IconImagePicker from '$components/maplibre/symbol/IconImagePicker.svelte';
 	import { clean, getLayerStyle, initTippy } from '$lib/helper';
 	import type { Layer } from '$lib/types';
-	import { spriteImageList, type MapStore, MAPSTORE_CONTEXT_KEY } from '$stores';
+	import {
+		type MapStore,
+		MAPSTORE_CONTEXT_KEY,
+		SPRITEIMAGE_CONTEXT_KEY,
+		type SpriteImageStore
+	} from '$stores';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
 	const tippy = initTippy();
 	let tooltipContent: HTMLElement;
@@ -51,7 +57,7 @@
 		map.setPaintProperty(layerId, 'icon-halo-color', 'rgb(255,255,255)');
 		map.setPaintProperty(layerId, 'icon-halo-width', 1);
 		const layerStyle = getLayerStyle($map, layerId);
-		if (layerStyle.layout && layerStyle.layout['icon-image']) {
+		if (layerStyle?.layout && layerStyle.layout['icon-image']) {
 			const icon = $spriteImageList.find((icon) => icon.alt === layerStyle.layout['icon-image']);
 			iconImageSrc = icon.src;
 			if (icon) {

--- a/sites/geohub/src/components/maplibre/symbol/IconImagePicker.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconImagePicker.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import IconImagePickerCard from '$components/maplibre/symbol/IconImagePickerCard.svelte';
+	import { SPRITEIMAGE_CONTEXT_KEY, type SpriteImageStore } from '$stores';
 	import { handleEnterKey } from '$lib/helper';
-	import { spriteImageList } from '$stores';
 	import { Tabs, type Tab } from '@undp-data/svelte-undp-design';
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
+
+	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
 	export let iconImageAlt: string;
 

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -8,9 +8,10 @@
 	import type { Layer } from '$lib/types';
 	import {
 		layerList as layerListStore,
-		spriteImageList,
 		type MapStore,
-		MAPSTORE_CONTEXT_KEY
+		MAPSTORE_CONTEXT_KEY,
+		type SpriteImageStore,
+		SPRITEIMAGE_CONTEXT_KEY
 	} from '$stores';
 	import MaplibreCgazAdminControl from '@undp-data/cgaz-admin-tool';
 	import StyleSwicher from '@undp-data/style-switcher';
@@ -29,6 +30,7 @@
 	import { getContext, onMount } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
 	let tourOptions: TourGuideOptions;
 	let tourLocalStorageKey = `geohub-map-${$page.url.host}`;

--- a/sites/geohub/src/components/pages/map/layers/header/LayerHeader.svelte
+++ b/sites/geohub/src/components/pages/map/layers/header/LayerHeader.svelte
@@ -8,7 +8,7 @@
 	import type { Layer, RasterTileMetadata, VectorTileMetadata } from '$lib/types';
 	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import type { LayerSpecification, LngLatBoundsLike } from 'maplibre-gl';
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
@@ -17,18 +17,12 @@
 
 	let isDeleteDialogVisible = false;
 
-	let layerStyle: LayerSpecification;
+	let layerStyle: LayerSpecification = getLayerStyle($map, layer.id);
 
 	const accessIcon = getAccessLevelIcon(
 		layer.dataset.properties.access_level ?? AccessLevel.PUBLIC,
 		true
 	);
-
-	onMount(() => {
-		if (!$map) return;
-
-		layerStyle = getLayerStyle($map, layer.id);
-	});
 
 	const tippy = initTippy({
 		placement: 'bottom-end',
@@ -97,7 +91,7 @@
 
 		<VisibilityButton {layer} />
 
-		<Legend bind:map={$map} bind:layer={layerStyle} />
+		<Legend bind:layer={layerStyle} />
 	</div>
 
 	<span class="layer-name pl-1">

--- a/sites/geohub/src/components/pages/map/layers/order/LayerOrderPanelButton.svelte
+++ b/sites/geohub/src/components/pages/map/layers/order/LayerOrderPanelButton.svelte
@@ -64,13 +64,7 @@
 	</div>
 
 	<div class="layer-order">
-		<LayerOrderPanel
-			bind:map={$map}
-			bind:style
-			bind:onlyRendered
-			bind:onlyRelative
-			bind:relativeLayers
-		/>
+		<LayerOrderPanel bind:style bind:onlyRendered bind:onlyRelative bind:relativeLayers />
 	</div>
 </PanelButton>
 

--- a/sites/geohub/src/components/pages/map/layers/order/SortLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/order/SortLayer.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
 	import Legend from '$components/pages/map/layers/header/Legend.svelte';
-	import { layerList } from '$stores';
-	import type { LayerSpecification, Map } from 'maplibre-gl';
-	import { createEventDispatcher } from 'svelte';
+	import { layerList, MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import type { LayerSpecification } from 'maplibre-gl';
+	import { createEventDispatcher, getContext } from 'svelte';
 
 	const dispatch = createEventDispatcher();
 
-	export let map: Map;
+	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+
 	export let layer: LayerSpecification;
 	export let relativeLayers: { [key: string]: string } = {};
 
-	let visibility = map.getLayer(layer.id).visibility;
+	let visibility = $map.getLayer(layer.id).visibility;
 
 	let checked = visibility === 'none' ? false : true;
 	$: checked, setVisibility();
@@ -27,13 +28,13 @@
 	};
 
 	const getLayerIndex = () => {
-		const layers = map?.getStyle()?.layers;
+		const layers = $map?.getStyle()?.layers;
 		const index = layers?.findIndex((l) => l.id === layer.id);
 		return index;
 	};
 
 	const getTotalCount = () => {
-		return map?.getStyle()?.layers.length;
+		return $map?.getStyle()?.layers.length;
 	};
 
 	const checkIsFirstLayer = () => {
@@ -42,7 +43,7 @@
 	};
 
 	const checkIsLastLayer = () => {
-		const layers = map?.getStyle()?.layers;
+		const layers = $map?.getStyle()?.layers;
 		const index = getLayerIndex();
 		return index === layers.length - 1;
 	};
@@ -52,9 +53,9 @@
 
 	const moveBefore = () => {
 		const currentIndex = getLayerIndex();
-		const layers = map?.getStyle()?.layers;
+		const layers = $map?.getStyle()?.layers;
 		const beforeLayerId = layers[currentIndex - 1].id;
-		map.moveLayer(layer.id, beforeLayerId);
+		$map.moveLayer(layer.id, beforeLayerId);
 		isFirstLater = checkIsFirstLayer();
 		isLastLayer = checkIsLastLayer();
 		dispatch('layerOrderChanged');
@@ -68,9 +69,9 @@
 
 	const moveAfter = () => {
 		const currentIndex = getLayerIndex();
-		const layers = map?.getStyle()?.layers;
+		const layers = $map?.getStyle()?.layers;
 		const afterLayerId = layers[currentIndex + 1].id;
-		map.moveLayer(afterLayerId, layer.id);
+		$map.moveLayer(afterLayerId, layer.id);
 		isFirstLater = checkIsFirstLayer();
 		isLastLayer = checkIsLastLayer();
 		dispatch('layerOrderChanged');
@@ -92,7 +93,7 @@
 	</span>
 	{#if $layerList.find((l) => l.id === layer.id)}
 		<div class="pr-1">
-			<Legend bind:map bind:layer />
+			<Legend bind:layer />
 		</div>
 	{/if}
 	<div class="layer-name">

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorClassifyLegend.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorClassifyLegend.svelte
@@ -31,7 +31,13 @@
 		VectorLayerTileStatLayer,
 		VectorTileMetadata
 	} from '$lib/types';
-	import { layerList, spriteImageList, type MapStore, MAPSTORE_CONTEXT_KEY } from '$stores';
+	import {
+		layerList,
+		type MapStore,
+		MAPSTORE_CONTEXT_KEY,
+		type SpriteImageStore,
+		SPRITEIMAGE_CONTEXT_KEY
+	} from '$stores';
 	import { Radios, type Radio } from '@undp-data/svelte-undp-design';
 	import chroma from 'chroma-js';
 	import { hexToCSSFilter } from 'hex-to-css-filter';
@@ -46,6 +52,7 @@
 	import PropertySelect from '$components/maplibre/symbol/PropertySelect.svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
 	export let applyToOption: VectorApplyToTypes;
 	export let layer: Layer;

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -14,13 +14,20 @@
 		toLocalStorage
 	} from '$lib/helper';
 	import type { Layer } from '$lib/types';
-	import { layerList, spriteImageList, type MapStore, MAPSTORE_CONTEXT_KEY } from '$stores';
+	import {
+		layerList,
+		type MapStore,
+		MAPSTORE_CONTEXT_KEY,
+		type SpriteImageStore,
+		SPRITEIMAGE_CONTEXT_KEY
+	} from '$stores';
 	import { Loader } from '@undp-data/svelte-undp-design';
 	import VectorFilter from '$components/pages/map/layers/vector/VectorFilter.svelte';
 	import VectorParamsPanel from '$components/pages/map/layers/vector/VectorParamsPanel.svelte';
 	import { getContext } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
 	export let layer: Layer;
 
@@ -92,7 +99,20 @@
 
 		<p class="panel-content px-2 pb-2">
 			{#if activeTab === TabNames.LEGEND}
-				{#if $spriteImageList?.length > 0}
+				{#if !$spriteImageList}
+					<div class="loader-container">
+						<Loader size="small" />
+					</div>
+				{:else}
+					<VectorLegend
+						{layer}
+						bind:applyToOption
+						bind:legendType
+						bind:defaultColor
+						bind:defaultLineColor
+					/>
+				{/if}
+				<!-- {#if $spriteImageList?.length > 0}
 					<VectorLegend
 						{layer}
 						bind:applyToOption
@@ -101,10 +121,8 @@
 						bind:defaultLineColor
 					/>
 				{:else}
-					<div class="loader-container">
-						<Loader size="small" />
-					</div>
-				{/if}
+					
+				{/if} -->
 			{:else if activeTab === TabNames.FILTER}
 				<VectorFilter {layer} />
 			{:else if activeTab === TabNames.LABEL}

--- a/sites/geohub/src/routes/(app)/settings/+page.svelte
+++ b/sites/geohub/src/routes/(app)/settings/+page.svelte
@@ -23,8 +23,7 @@
 	import { DefaultUserConfig, type UserConfig } from '$lib/config/DefaultUserConfig';
 	import { getSpriteImageList, initTippy } from '$lib/helper';
 	import { clean } from '$lib/helper/index.js';
-	import type { SidebarPosition } from '$lib/types';
-	import { spriteImageList } from '$stores';
+	import type { SidebarPosition, SpriteImage } from '$lib/types';
 	import { Radios } from '@undp-data/svelte-undp-design';
 	import { SvelteToast, toast } from '@zerodevx/svelte-toast';
 	import type { StyleSpecification } from 'maplibre-gl';
@@ -77,7 +76,8 @@
 
 	let linePatterns = setLinePatterns();
 
-	$: iconImageSrc = $spriteImageList.find((i) => i.alt === selectedIcon)?.src;
+	let spriteImageList: SpriteImage[];
+	$: iconImageSrc = spriteImageList?.find((i) => i.alt === selectedIcon)?.src;
 	let tooltipContent: HTMLElement;
 
 	let settingTabs = [
@@ -166,8 +166,7 @@
 		const res = await fetch(style.uri);
 		const json: StyleSpecification = await res.json();
 		const spriteUrl = json.sprite as string;
-		const iconList = await getSpriteImageList(spriteUrl);
-		spriteImageList.update(() => iconList);
+		spriteImageList = await getSpriteImageList(spriteUrl);
 	};
 
 	const getFonts = async () => {
@@ -770,7 +769,7 @@
 				<FieldControl title="Icon Symbol" class="icon-selector">
 					<div slot="help">Pick the default icon symbol for symbol layers</div>
 					<div slot="control">
-						{#if $spriteImageList?.length > 0}
+						{#if spriteImageList?.length > 0}
 							<div
 								style="cursor: pointer"
 								use:tippy={{ content: tooltipContent }}
@@ -807,7 +806,7 @@
 								bind:this={tooltipContent}
 							>
 								<div class="columns m-2 is-multiline is-justify-content-space-evenly">
-									{#each $spriteImageList as image}
+									{#each spriteImageList as image}
 										<IconImagePickerCard
 											on:iconSelected={(e) => (selectedIcon = e.detail.iconImageAlt)}
 											iconImageAlt={image.alt}

--- a/sites/geohub/src/routes/(map)/map/+layout.svelte
+++ b/sites/geohub/src/routes/(map)/map/+layout.svelte
@@ -7,7 +7,14 @@
 	import Notification from '$components/util/Notification.svelte';
 	import { fromLocalStorage, isStyleChanged, storageKeys, toLocalStorage } from '$lib/helper';
 	import type { DashboardMapStyle, Layer, SidebarPosition } from '$lib/types';
-	import { MAPSTORE_CONTEXT_KEY, createMapStore, layerList } from '$stores';
+	import {
+		MAPSTORE_CONTEXT_KEY,
+		createMapStore,
+		layerList,
+		type SpriteImageStore,
+		createSpriteImageStore,
+		SPRITEIMAGE_CONTEXT_KEY
+	} from '$stores';
 	import { MenuControl } from '@watergis/svelte-maplibre-menu';
 	import { SvelteToast } from '@zerodevx/svelte-toast';
 	import type { StyleSpecification } from 'maplibre-gl';
@@ -20,6 +27,9 @@
 
 	const map = createMapStore();
 	setContext(MAPSTORE_CONTEXT_KEY, map);
+
+	const spriteImageList: SpriteImageStore = createSpriteImageStore();
+	setContext(SPRITEIMAGE_CONTEXT_KEY, spriteImageList);
 
 	let isMenuShown = true;
 	let innerWidth: number;

--- a/sites/geohub/src/stores/index.ts
+++ b/sites/geohub/src/stores/index.ts
@@ -1,8 +1,3 @@
-import { writable } from 'svelte/store';
-import type { SpriteImage } from '$lib/types';
-
 export * from './layerList';
 export * from './map';
-
-// vector : sprite list
-export const spriteImageList = writable(<SpriteImage[]>[]);
+export * from './spriteImageList';

--- a/sites/geohub/src/stores/spriteImageList.ts
+++ b/sites/geohub/src/stores/spriteImageList.ts
@@ -1,0 +1,10 @@
+import { writable, type Writable } from 'svelte/store';
+import type { SpriteImage } from '$lib/types';
+
+export const SPRITEIMAGE_CONTEXT_KEY = 'maplibre-sprite-image-store';
+
+export type SpriteImageStore = Writable<SpriteImage[]>;
+
+export const createSpriteImageStore = () => {
+	return writable(<SpriteImage[]>[]);
+};


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #1996 

* In settings page, it does not need to use store for SpriteImageList variable, so I just simply removed and directly use the variable.
* In map page, now create spriteImageStore in +layout.svelte and setContext. In children components, they getContext for sprite image.
* also, fixes some minor bugs related to Legend.svelte

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others (refactoring)
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1230940761) by [Unito](https://www.unito.io)
