### PR TITLE
fix: close cancel dialog after cancelling. use is-active only when it…

### DIFF
--- a/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRow.svelte
+++ b/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRow.svelte
@@ -184,6 +184,7 @@
 			},
 			'json'
 		);
+		closeCancelDialog();
 	};
 
 	onMount(() => {
@@ -477,107 +478,96 @@
 	{/if}
 </div>
 
-{#if confirmDeleteDialogVisible}
-	<div class="modal is-active" transition:fade|global>
-		<div
-			role="none"
-			class="modal-background"
-			on:click={closeDeleteDialog}
-			on:keydown={handleEnterKey}
-		/>
-		<div class="modal-card">
-			<header class="modal-card-head">
-				<p class="modal-card-title">Are you sure deleting this job?</p>
-				<button class="delete" aria-label="close" title="Close" on:click={closeDeleteDialog} />
-			</header>
-			<section class="modal-card-body is-size-6 has-text-weight-normal">
-				<Notification type="warning" showCloseButton={false}>
-					Unexpected bad things will happen if you don't read this!
-				</Notification>
-				<div class="has-text-weight-medium mt-2 mx-1">
-					This action <b>cannot</b> be undone. This will permanently delete
-					<b>{deletedDataset.raw.name}</b>
-					which were uploaded and ingested. All ingested datasets associated to this raw file will also
-					be deleted.
-					<br />
-					Please type <b>{deletedDataset.raw.name}</b> to confirm.
-				</div>
+<div class="modal {confirmDeleteDialogVisible ? 'is-active' : ''}" transition:fade|global>
+	<div
+		role="none"
+		class="modal-background"
+		on:click={closeDeleteDialog}
+		on:keydown={handleEnterKey}
+	/>
+	<div class="modal-card">
+		<header class="modal-card-head">
+			<p class="modal-card-title">Are you sure deleting this job?</p>
+			<button class="delete" aria-label="close" title="Close" on:click={closeDeleteDialog} />
+		</header>
+		<section class="modal-card-body is-size-6 has-text-weight-normal">
+			<Notification type="warning" showCloseButton={false}>
+				Unexpected bad things will happen if you don't read this!
+			</Notification>
+			<div class="has-text-weight-medium mt-2 mx-1">
+				This action <b>cannot</b> be undone. This will permanently delete
+				<b>{deletedDataset?.raw.name}</b>
+				which were uploaded and ingested. All ingested datasets associated to this raw file will also
+				be deleted.
 				<br />
-				<input class="input" type="text" bind:value={deletedDatasetName} />
-			</section>
-			<footer class="modal-card-foot">
-				<button
-					class="button is-primary is-fullwidth {isDeleting ? 'is-loading' : ''}"
-					on:click={handleDeleteDataset}
-					disabled={deletedDatasetName !== deletedDataset?.raw.name}
-				>
-					I understand the consequences, delete this ingesting dataset
-				</button>
-			</footer>
-		</div>
-	</div>
-{/if}
-
-{#if logDialogVisible}
-	<div class="modal is-active" transition:fade|global>
-		<div
-			role="none"
-			class="modal-background"
-			on:click={closeLogDialog}
-			on:keydown={handleEnterKey}
-		/>
-		<div class="modal-content">
-			<textarea class="textarea error-log" bind:value={logText} readonly />
-
+				Please type <b>{deletedDataset?.raw.name}</b> to confirm.
+			</div>
+			<br />
+			<input class="input" type="text" bind:value={deletedDatasetName} />
+		</section>
+		<footer class="modal-card-foot">
 			<button
-				class="delete close-dialog is-medium"
-				aria-label="close"
-				title="Close"
-				on:click={closeLogDialog}
-			/>
-		</div>
+				class="button is-primary is-fullwidth {isDeleting ? 'is-loading' : ''}"
+				on:click={handleDeleteDataset}
+				disabled={deletedDatasetName !== deletedDataset?.raw.name}
+			>
+				I understand the consequences, delete this ingesting dataset
+			</button>
+		</footer>
 	</div>
-{/if}
+</div>
 
-{#if cancelDialogVisible}
-	<div class="modal is-active" transition:fade|global>
-		<div
-			role="none"
-			class="modal-background"
-			on:click={closeCancelDialog}
-			on:keydown={handleEnterKey}
+<div class="modal {logDialogVisible ? 'is-active' : ''}" transition:fade|global>
+	<div role="none" class="modal-background" on:click={closeLogDialog} on:keydown={handleEnterKey} />
+	<div class="modal-content">
+		<textarea class="textarea error-log" bind:value={logText} readonly />
+
+		<button
+			class="delete close-dialog is-medium"
+			aria-label="close"
+			title="Close"
+			on:click={closeLogDialog}
 		/>
-		<div class="modal-card">
-			<header class="modal-card-head">
-				<p class="modal-card-title">Are you sure cancelling this job?</p>
-				<button class="delete" aria-label="close" title="Close" on:click={closeCancelDialog} />
-			</header>
-			<section class="modal-card-body is-size-6 has-text-weight-normal">
-				<Notification type="warning" showCloseButton={false}>
-					Unexpected bad things will happen if you don't read this!
-				</Notification>
-				<div class="has-text-weight-medium mt-2 mx-1">
-					This action <b>cannot</b> be undone. This will permanently cancel and delete
-					<b>{dataset.raw.name}</b>
-					which was uploaded and being ingested now.
-					<br />
-					Please type <b>{dataset.raw.name}</b> to confirm.
-				</div>
-				<br />
-				<input class="input" type="text" bind:value={cancelledDatasetName} />
-			</section>
-			<footer class="modal-card-foot">
-				<button
-					class="button is-primary is-fullwidth"
-					on:click={handleCancelDataset}
-					disabled={cancelledDatasetName !== dataset.raw.name}
-				>
-					I understand the consequences, cancel this ingesting process
-				</button>
-			</footer>
-		</div>
 	</div>
-{/if}
+</div>
+
+<div class="modal {cancelDialogVisible ? 'is-active' : ''}" transition:fade|global>
+	<div
+		role="none"
+		class="modal-background"
+		on:click={closeCancelDialog}
+		on:keydown={handleEnterKey}
+	/>
+	<div class="modal-card">
+		<header class="modal-card-head">
+			<p class="modal-card-title">Are you sure cancelling this job?</p>
+			<button class="delete" aria-label="close" title="Close" on:click={closeCancelDialog} />
+		</header>
+		<section class="modal-card-body is-size-6 has-text-weight-normal">
+			<Notification type="warning" showCloseButton={false}>
+				Unexpected bad things will happen if you don't read this!
+			</Notification>
+			<div class="has-text-weight-medium mt-2 mx-1">
+				This action <b>cannot</b> be undone. This will permanently cancel and delete
+				<b>{dataset?.raw.name}</b>
+				which was uploaded and being ingested now.
+				<br />
+				Please type <b>{dataset?.raw.name}</b> to confirm.
+			</div>
+			<br />
+			<input class="input" type="text" bind:value={cancelledDatasetName} />
+		</section>
+		<footer class="modal-card-foot">
+			<button
+				class="button is-primary is-fullwidth"
+				on:click={handleCancelDataset}
+				disabled={cancelledDatasetName !== dataset?.raw.name}
+			>
+				I understand the consequences, cancel this ingesting process
+			</button>
+		</footer>
+	</div>
+</div>
 
 <style lang="scss">
 	.row {


### PR DESCRIPTION
… is opened

Thank you for submitting a pull request!

## Description
forgot to close cancel dialog after doing

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1232262212) by [Unito](https://www.unito.io)
