### PR TITLE
Chore/enable versioning for geohub

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "develop",
   "updateInternalDependencies": "minor",
-  "ignore": ["geohub"]
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.changeset/happy-rocks-yell.md
+++ b/.changeset/happy-rocks-yell.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+first changeset version release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,15 @@ jobs:
 
       - name: build packages
         run: |
-          pnpm --filter="./packages/**" build
-          pnpm --filter="./apps/**" build
+          pnpm build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm release
+          publish: pnpm changeset:release
+          version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,6 @@ jobs:
       - name: install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: build packages
-        run: |
-          pnpm build
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "precommit": "pnpm -r lint && pnpm -r format",
-    "release": "changeset publish"
+    "changeset:version": "changeset version",
+    "changeset:release": "changeset publish"
   },
   "repository": {
     "type": "git",

--- a/sites/static-image-api/package.json
+++ b/sites/static-image-api/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "geohub-static-image-api",
 	"version": "0.0.1",
-	"private": false,
+	"private": true,
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I enabled versioning for geohub app by changeset.

I found if we set `privatePackages` to `{ version: true, tag: true } `, changeset even can manage versioning app (not only for packages of NPM).
https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md

I think it is better to have changelog for geohub app iteself

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1234530533) by [Unito](https://www.unito.io)
