### PR TITLE
fix: fixed bug of resetting SAS token for Microsoft Planetary Computer in saved maplibre style source

### DIFF
--- a/.changeset/friendly-beers-search.md
+++ b/.changeset/friendly-beers-search.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of resetting SAS token for Microsoft Planetary Computer in saved maplibre style source

--- a/sites/geohub/src/lib/server/helpers/getStyleById.ts
+++ b/sites/geohub/src/lib/server/helpers/getStyleById.ts
@@ -122,9 +122,14 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 						}
 
 						if (source.tiles) {
-							for (let tile of source.tiles) {
-								tile = `${tile.split('?')[0]}?url=${tileUrl}`;
+							const newTiles = [];
+							for (const tile of source.tiles) {
+								const href = new URL(tile);
+								href.searchParams.set('url', tileUrl);
+								const newTile = `${href.origin}${decodeURIComponent(href.pathname)}${href.search}`;
+								newTiles.push(newTile);
 							}
+							source.tiles = newTiles;
 						}
 					}
 				}

--- a/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
+++ b/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
@@ -377,7 +377,8 @@ export default class MicrosoftPlanetaryStac implements StacTemplate {
 						for (const tile of source.tiles) {
 							const href = new URL(tile);
 							href.searchParams.set('url', b64EncodedUrl);
-							newTiles.push(href.toString());
+							const newTile = `${href.origin}${decodeURIComponent(href.pathname)}${href.search}`;
+							newTiles.push(newTile);
 						}
 						source.tiles = newTiles;
 					}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixed bug of resetting SAS token for Microsoft Planetary Computer in saved maplibre style source

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1234570503) by [Unito](https://www.unito.io)
