### PR TITLE
fix: removed Default legend if the raster layer is unique value type

### DIFF
--- a/.changeset/sour-eels-behave.md
+++ b/.changeset/sour-eels-behave.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: removed Default legend if the raster layer is unique value type

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterClassifyLegend.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterClassifyLegend.svelte
@@ -311,7 +311,7 @@
 			</div>
 		</div>
 
-		<div class="field">
+		<div class="field {layerHasUniqueValues ? 'mt-4' : ''}">
 			<!-- svelte-ignore a11y-label-has-associated-control -->
 			<label class="label has-text-centered">Colormap</label>
 			<div class="control">

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLegend.svelte
@@ -112,7 +112,9 @@
 		</div>
 	{:then}
 		{#if !isRgbTile}
-			<LegendTypeSwitcher bind:legendType />
+			{#if !layerHasUniqueValues}
+				<LegendTypeSwitcher bind:legendType />
+			{/if}
 			<div class="help">
 				<Help>
 					<p class="has-text-justified">
@@ -148,11 +150,12 @@
 		</div>
 		{#if !isRgbTile}
 			<RasterBandSelector {layer} />
-			{#if legendType === LegendTypes.DEFAULT}
+			{#if !layerHasUniqueValues && legendType === LegendTypes.DEFAULT}
 				<div transition:slide|global>
 					<RasterDefaultLegend bind:layerId={layer.id} bind:colorMapName={layer.colorMapName} />
 				</div>
-			{:else if legendType === LegendTypes.CLASSIFY}
+			{/if}
+			{#if legendType === LegendTypes.CLASSIFY}
 				<div transition:slide|global>
 					<RasterClassifyLegend bind:layer bind:numberOfClasses bind:layerHasUniqueValues />
 				</div>
@@ -177,12 +180,14 @@
 			position: absolute;
 			top: 0em;
 			left: 0em;
+			z-index: 10;
 		}
 
 		.editor-button {
 			position: absolute;
 			top: 0em;
 			right: 0em;
+			z-index: 10;
 		}
 	}
 </style>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
For raster unique value data, default legend is not useful. only classifylegend is available for unique value raster

![image](https://github.com/UNDP-Data/geohub/assets/2639701/f7c295b3-6a9c-4526-b3d9-a475df9110bd)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1237704275) by [Unito](https://www.unito.io)
