### PR TITLE
fix: #2103 stac explorer

### DIFF
--- a/.changeset/rude-donuts-press.md
+++ b/.changeset/rude-donuts-press.md
@@ -3,3 +3,5 @@
 ---
 
 fix: fixed bahaviour of STAC Explorer. Set MaxZoom and MaxBounds in the explorer, and fixed some behaviours when parameters are changed.
+fix: [BREAKING CHANGE]fixed mosaicjson path like https://undpngddlsgeohubdev01.blob.core.windows.net/mosaicjson/microsoft-pc/sentinel-2-l2a/S2A_MSIL2A_20230714T072621_R049_T37MDP_20230714T145720/S2B_MSIL2A_20230907T072619_R049_T37MEP_20230907T152656/mosaicjson.json (microsoft-pc/{collection id}/{...item}/mosaicjson.json)
+

--- a/.changeset/rude-donuts-press.md
+++ b/.changeset/rude-donuts-press.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bahaviour of STAC Explorer. Set MaxZoom and MaxBounds in the explorer, and fixed some behaviours when parameters are changed.

--- a/sites/geohub/src/components/util/StacExplorer.svelte
+++ b/sites/geohub/src/components/util/StacExplorer.svelte
@@ -169,8 +169,8 @@
 			mapResize();
 		});
 
-		map.on('moveend', handleMapMoved);
-		map.on('zoomend', handleMapMoved);
+		map.on('moveend', handleMapExtentChanged);
+		map.on('zoomend', handleMapExtentChanged);
 
 		map.on('click', async (e: MapMouseEvent) => {
 			if (!map?.getLayer('stac-fill')) return;
@@ -228,18 +228,6 @@
 		}
 	};
 
-	const handleMapMoved = debounce(async () => {
-		currentZoom = map.getZoom();
-		if (currentZoom > StacMinimumZoom) {
-			isLoading = true;
-			try {
-				await searchStacItems();
-			} finally {
-				isLoading = false;
-			}
-		}
-	}, 300);
-
 	const handleDateFilterOptionChanged = () => {
 		if (!selectedDateFilterOption) return;
 		if (selectedDateFilterOption === -1) {
@@ -255,10 +243,20 @@
 		}
 	};
 
-	$: searchLimit, handleSearchParameterChanged();
+	$: searchLimit, handleMapExtentChanged();
 	$: cloudCoverRate, handleSearchParameterChanged();
 	$: searchDateFrom, handleSearchParameterChanged();
 	$: searchDateTo, handleSearchParameterChanged();
+
+	const handleMapExtentChanged = debounce(async () => {
+		if (currentZoom <= StacMinimumZoom) return;
+
+		try {
+			await searchStacItems();
+		} finally {
+			isLoading = false;
+		}
+	}, 300);
 
 	const handleSearchParameterChanged = debounce(async () => {
 		if (currentZoom <= StacMinimumZoom) return;
@@ -352,10 +350,7 @@
 	const handleSelectedAssets = async () => {
 		if (clickedFeatures.length === 0) return;
 		if (!collection) return;
-		if (!selectedAsset) {
-			clickedFeatures = [];
-			return;
-		}
+		if (!selectedAsset) return;
 		isLoading = true;
 		try {
 			const ids = clickedFeatures.map((f) => f.properties.id);

--- a/sites/geohub/src/components/util/StacExplorer.svelte
+++ b/sites/geohub/src/components/util/StacExplorer.svelte
@@ -29,6 +29,7 @@
 		Map,
 		MapMouseEvent,
 		NavigationControl,
+		type LngLatBoundsLike,
 		type MapGeoJSONFeature,
 		type RasterLayerSpecification,
 		type RasterSourceSpecification
@@ -40,6 +41,7 @@
 	const dispatch = createEventDispatcher();
 
 	const NOTIFICATION_MESSAGE_TIME = 5000;
+	const MAX_ZOOOM = 8;
 
 	let config: UserConfig = $page.data.config;
 
@@ -120,10 +122,12 @@
 		const lng = center[0];
 		const lat = center[1];
 		if (!(lng > extent[0] && lng < extent[2] && lat > extent[1] && lat < extent[3])) {
-			map.fitBounds([
+			const bounds: LngLatBoundsLike = [
 				[extent[0], extent[1]],
 				[extent[2], extent[3]]
-			]);
+			];
+			map.setMaxBounds(bounds);
+			map.fitBounds(bounds);
 		}
 
 		temporalIntervalFrom = dayjs(stacInstance.intervalFrom).toDate();
@@ -139,7 +143,8 @@
 			container: mapContainer,
 			style: MapStyles[0].uri,
 			center: [center[0], center[1]],
-			zoom: currentZoom
+			zoom: currentZoom,
+			maxZoom: MAX_ZOOOM
 		});
 
 		map.addControl(new NavigationControl(), 'bottom-left');
@@ -276,8 +281,8 @@
 			bbox,
 			searchLimit,
 			cloudCoverRate[0],
-			searchDateFrom.toISOString(),
-			searchDateTo.toISOString()
+			searchDateFrom?.toISOString(),
+			searchDateTo?.toISOString()
 		);
 
 		for (const feature of fc.features) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2103

* fix: fixed bahaviour of STAC Explorer. Set MaxZoom and MaxBounds in the explorer, and fixed some behaviours when parameters are changed.
* I set MaxZoom as 8 for now.
* fixed mosaicjson path like `https://undpngddlsgeohubdev01.blob.core.windows.net/mosaicjson/microsoft-pc/sentinel-2-l2a/S2A_MSIL2A_20230714T072621_R049_T37MDP_20230714T145720/S2B_MSIL2A_20230907T072619_R049_T37MEP_20230907T152656/mosaicjson.json` (microsoft-pc/{collection id}/{...item}/mosaicjson.json)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1240001636) by [Unito](https://www.unito.io)
