### PR TITLE
chore: add new CI job to create PR to merge develop to main

### DIFF
--- a/.github/RELEASE_PULL_REQUEST_TEMPLATE.md
+++ b/.github/RELEASE_PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+This is going to merge develop branch to main branch to release to production server.
+
+You don't have to merge this PR now. You can merge this when it will be ready to merge for production.
+
+### Checklist before merging
+
+<!-- ignore-task-list-start -->
+
+- [ ] Have you merged `Version Packages` pull request by Changesets?
+- [ ] Have you add or modify environmental variables in Azure AppService if you have changed anything?
+- [ ] Are you sure everything works in `dev.undpgeohub.org`?
+- [ ] Finally, DON'T USE `squash and merge` and just use normal merge for this PR, so there will be the same commit history between `main` and `develop`.
+<!-- ignore-task-list-end -->
+
+---
+
+This PR was auto-created by GitHub actions.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Changesets
+name: Release
 on:
   push:
     branches:
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write # to create release (changesets/action)
       pull-requests: write # to create pull request (changesets/action)
-    name: Release
+    name: Changesets Release
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
@@ -51,3 +51,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  production_release:
+    # prevents this action from running on forks
+    if: github.repository == 'undp-data/geohub'
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
+    name: Production Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: release/develop-to-main
+          title: "[RELEASE] Merge develop to main"
+          delete-branch: true
+          base: main
+          commit-message: "[RELEASE] merge develop to main branch"
+          body-path: ./.github/RELEASE_PULL_REQUEST_TEMPLATE.md
+          labels: release
+          reviewers: |
+            iferencik
+            Thuhaa
+            JinIgarashi


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
adding a CI job to create a PR automatically from develop to main

checkout `develop` branch and set `main` to base branch

https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1240821327) by [Unito](https://www.unito.io)
