### PR TITLE
fix: use goto method of sveltekit for go back to previous page button

### DIFF
--- a/.changeset/seven-parents-own.md
+++ b/.changeset/seven-parents-own.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use goto method of sveltekit for go back to previous page button

--- a/sites/geohub/src/components/util/BackToPreviousPage.svelte
+++ b/sites/geohub/src/components/util/BackToPreviousPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { afterNavigate } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import { page } from '$app/stores';
 
 	/**
@@ -24,11 +24,16 @@
 			}
 		}
 	});
+
+	const handleClicked = () => {
+		let url = previousPage ?? defaultLink;
+		goto(url, { noScroll: false, replaceState: false, keepFocus: false, invalidateAll: true });
+	};
 </script>
 
-<a type="button" class="button is-rounded is-link" href={previousPage ?? defaultLink}>
+<button type="button" class="button is-rounded is-link" on:click={handleClicked}>
 	<span class="icon">
 		<i class="fa-solid fa-circle-chevron-left fa-lg"></i>
 	</span>
 	<span>{title}</span>
-</a>
+</button>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I am not sure why, but the a link used in go back button seems not working in some cases, I changed to use a link to button element's on click event and `goto` method of sveltekit. Hope it can work.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1241580697) by [Unito](https://www.unito.io)
