### PR TITLE
fix: update current zoom when map extent is changed in STAC explorer.

### DIFF
--- a/.changeset/flat-cooks-punch.md
+++ b/.changeset/flat-cooks-punch.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: update current zoom when map extent is changed in STAC explorer.

--- a/sites/geohub/src/components/util/StacExplorer.svelte
+++ b/sites/geohub/src/components/util/StacExplorer.svelte
@@ -249,6 +249,7 @@
 	$: searchDateTo, handleSearchParameterChanged();
 
 	const handleMapExtentChanged = debounce(async () => {
+		currentZoom = map.getZoom();
 		if (currentZoom <= StacMinimumZoom) return;
 
 		try {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #2160

I found currentZoom is not updated when map extent is changed. 

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1241591463) by [Unito](https://www.unito.io)
