### PR TITLE
fix: fixes data table flickering when my data page is reloaded

### DIFF
--- a/.changeset/blue-planets-mix.md
+++ b/.changeset/blue-planets-mix.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixes data table flickering when my data page is reloaded

--- a/sites/geohub/src/components/pages/data/ingesting/IngestingDatasets.svelte
+++ b/sites/geohub/src/components/pages/data/ingesting/IngestingDatasets.svelte
@@ -52,10 +52,8 @@
 
 {#if datasets}
 	{#if datasets.length > 0}
-		{#each datasets as data}
-			{#key data}
-				<IngestingDatasetRow dataset={data} on:change={handleDataChanged} />
-			{/key}
+		{#each datasets as dataset}
+			<IngestingDatasetRow bind:dataset on:change={handleDataChanged} />
 		{/each}
 	{:else}
 		<div class="m-2">


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #2177 (hopefully)

at least, it is not now flickering in my localhost when I reload browser

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
