### PR TITLE
fix: created /api/datasets/style/{layer}/{type} endpoint to create default layer style for the dataset which is not registered yet

### DIFF
--- a/.changeset/ten-baboons-hide.md
+++ b/.changeset/ten-baboons-hide.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: created /api/datasets/style/{layer}/{type} endpoint to create default layer style for the dataset which is not registered yet

--- a/sites/geohub/src/lib/VectorTileData.ts
+++ b/sites/geohub/src/lib/VectorTileData.ts
@@ -46,11 +46,22 @@ export class VectorTileData {
 			maplibreLayerType = 'circle';
 		}
 		// check and restore from saved layer style
-		const savedLayerStyle = await getDefaltLayerStyle(
+		let savedLayerStyle = await getDefaltLayerStyle(
 			this.feature,
 			selectedLayerId,
 			maplibreLayerType
 		);
+
+		if (!savedLayerStyle?.style) {
+			const data = new FormData();
+			data.append('feature', JSON.stringify(this.feature));
+			const res = await fetch(`/api/datasets/style/${selectedLayerId}/${maplibreLayerType}`, {
+				method: 'POST',
+
+				body: data
+			});
+			savedLayerStyle = await res.json();
+		}
 
 		const layerSpec = JSON.parse(
 			JSON.stringify(savedLayerStyle.style)

--- a/sites/geohub/src/routes/api/datasets/style/[layer]/[type]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/style/[layer]/[type]/+server.ts
@@ -1,0 +1,53 @@
+import { createDatasetLinks } from '$lib/server/helpers';
+import type { RequestHandler } from './$types';
+import { error } from '@sveltejs/kit';
+import type { DatasetDefaultLayerStyle, DatasetFeature } from '$lib/types';
+import RasterDefaultStyle from '$lib/server/defaultStyle/RasterDefaultStyle';
+import type { UserConfig } from '$lib/config/DefaultUserConfig';
+import { env } from '$env/dynamic/private';
+import VectorDefaultStyle from '$lib/server/defaultStyle/VectorDefaultStyle';
+
+const LAYER_TYPES = ['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap'];
+
+export const POST: RequestHandler = async ({ request, params, url, fetch }) => {
+	const layer_id = params.layer;
+	const layer_type = params.type;
+	const colormap_name = url.searchParams.get('colormap_name');
+
+	if (!LAYER_TYPES.includes(layer_type)) {
+		throw error(404, {
+			message: `Invalid parameter of type. It must be one of ${LAYER_TYPES.join(', ')}`
+		});
+	}
+
+	const body = await request.formData();
+	const featureString = body.get('feature') as string;
+	const dataset: DatasetFeature = JSON.parse(featureString);
+	dataset.properties = createDatasetLinks(dataset, url.origin, env.TITILER_ENDPOINT);
+
+	const response = await fetch('/api/settings');
+	const config: UserConfig = await response.json();
+
+	let data: DatasetDefaultLayerStyle;
+	if (layer_type === 'raster') {
+		const bandIndex = parseInt(layer_id) - 1;
+		const rasterDefaultStyle = new RasterDefaultStyle(dataset, config, bandIndex);
+		data = await rasterDefaultStyle.create(colormap_name);
+	} else {
+		const vectorDefaultStyle = new VectorDefaultStyle(dataset, config, layer_id, layer_type);
+		data = await vectorDefaultStyle.create(colormap_name);
+	}
+
+	if (!data.metadata) {
+		if (layer_type === 'raster') {
+			const bandIndex = parseInt(layer_id) - 1;
+			const rasterDefaultStyle = new RasterDefaultStyle(dataset, config, bandIndex);
+			data.metadata = await rasterDefaultStyle.getMetadata();
+		} else {
+			const vectorDefaultStyle = new VectorDefaultStyle(dataset, config, layer_id, layer_type);
+			data.metadata = await vectorDefaultStyle.getMetadata();
+		}
+	}
+
+	return new Response(JSON.stringify(data));
+};

--- a/sites/geohub/static/api/swagger/spec.yaml
+++ b/sites/geohub/static/api/swagger/spec.yaml
@@ -198,6 +198,53 @@ paths:
         - datasets
       security:
         - Azure AD authentication: []
+  '/datasets/style/{layer}/{type}':
+    parameters:
+      - schema:
+          type: string
+          enum:
+            - fill
+            - line
+            - symbol
+            - circle
+            - heatmap
+            - raster
+          example: fill
+        name: type
+        in: path
+        required: true
+        description: 'Maplibre layer type (fill, line, symbol, circle, heatmap, raster)'
+      - schema:
+          type: string
+          example: drr.dynamic_subnational_hhr
+        name: layer
+        in: path
+        required: true
+        description: 'Layer ID. Band name if it is raster, layer ID if it is vector.'
+    post:
+      summary: Create default layer style for unregistered dataset
+      operationId: post-datasets-style-layer-type
+      responses:
+        '200':
+          description: OK
+      description: 'This endpoint is to return the default layer style for the dataset which is not registered to the database yet. The response is equivalent to the `/datasets/{id}/style/{layer}/{type}` API. But DatasetFeature object should be in body of POST request.'
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: colormap_name
+          description: 'Option. If specified, use this colormap to create layer style'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                feature:
+                  $ref: '#/components/schemas/GeoJSONFeature'
+        description: Dataset feature object
+      tags:
+        - datasets
   '/datasets/{id}':
     parameters:
       - schema:


### PR DESCRIPTION

Thank you for submitting a pull request!

## Description

fixes #2205

created new endpoint for returning defalt layer style of unregistered dataset by POST method

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
