### PR TITLE
fix: fixed bug of not showing default style edit page for RGB true color raster dataset

### DIFF
--- a/.changeset/hip-needles-fetch.md
+++ b/.changeset/hip-needles-fetch.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of not showing default style edit page for RGB true color raster dataset

--- a/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
@@ -13,7 +13,8 @@
 		getDefaltLayerStyle,
 		getRandomColormap,
 		getSpriteImageList,
-		handleEnterKey
+		handleEnterKey,
+		isRgbRaster
 	} from '$lib/helper';
 	import type {
 		DatasetDefaultLayerStyle,
@@ -83,10 +84,12 @@
 	let selectedBand: string;
 	let layerType: 'point' | 'heatmap' | 'polygon' | 'linestring';
 	let tilestatsLayers: VectorLayerTileStatLayer[] = [];
+	let isRgbTile = false;
 	const getMetadata = async () => {
 		if (is_raster) {
 			rasterTileData = new RasterTileData(feature);
 			rasterMetadata = await rasterTileData.getMetadata();
+			isRgbTile = isRgbRaster(rasterMetadata.colorinterp) ?? false;
 		} else {
 			vectorTileData = new VectorTileData(feature);
 			vectorMetadata = await vectorTileData.getMetadata();
@@ -135,7 +138,11 @@
 				})
 				.then(() => {
 					isLoading = false;
-					handleLayerSelected();
+					if (is_raster) {
+						handleBandSelected();
+					} else {
+						handleLayerSelected();
+					}
 				});
 		});
 	};
@@ -193,7 +200,6 @@
 	// $: selectedBand, handleBandSelected();
 	const handleBandSelected = async () => {
 		if (!$map) return;
-		if (!selectedBand) return;
 
 		try {
 			isLoading = true;
@@ -216,7 +222,8 @@
 			}
 
 			if (is_raster) {
-				const data = await rasterTileData.add($map, parseInt(selectedBand) - 1);
+				const bandIndex = isRgbTile ? undefined : parseInt(selectedBand) - 1;
+				const data = await rasterTileData.add($map, bandIndex);
 				layerSpec = data.layer;
 				$colorMapNameStore = data.colormap_name ?? getRandomColormap();
 				$classificationMethod = data.classification_method ?? config.ClassificationMethod;
@@ -380,7 +387,7 @@
 							</div>
 						</div>
 					{/if}
-				{:else if is_raster && rasterMetadata}
+				{:else if is_raster && rasterMetadata && !isRgbTile}
 					<div class="field">
 						<!-- svelte-ignore a11y-label-has-associated-control -->
 						<label class="label">Please select a raster band</label>
@@ -396,12 +403,14 @@
 
 				<div class="layer-editor p-4">
 					{#if layerSpec}
-						{#if selectedBand && layerSpec?.type === 'raster'}
-							<RasterLegend
-								bind:layerId={layerSpec.id}
-								bind:metadata={rasterMetadata}
-								bind:tags={feature.properties.tags}
-							/>
+						{#if is_raster}
+							{#if isRgbTile || (!isRgbTile && selectedBand)}
+								<RasterLegend
+									bind:layerId={layerSpec.id}
+									bind:metadata={rasterMetadata}
+									bind:tags={feature.properties.tags}
+								/>
+							{/if}
 						{:else}
 							<VectorLegend bind:layerId={layerSpec.id} bind:metadata={vectorMetadata} />
 						{/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #2213

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1243318435) by [Unito](https://www.unito.io)
