### PR TITLE
feat: User new color classification component for fill layer type. If layer style uses deprecated function, the component will transoform from function to expression

### DIFF
--- a/.changeset/orange-horses-unite.md
+++ b/.changeset/orange-horses-unite.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+feat: User new color classification component for fill layer type. If layer style uses deprecated function, the component will transoform from function to expression

--- a/sites/geohub/src/components/maplibre/fill/FillColor.svelte
+++ b/sites/geohub/src/components/maplibre/fill/FillColor.svelte
@@ -1,40 +1,12 @@
 <script lang="ts">
-	import MaplibreColorPicker from '$components/maplibre/MaplibreColorPicker.svelte';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
-	import { getContext, onMount } from 'svelte';
-
-	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	import VectorColorClassification from '$components/maplibre/vector/VectorColorClassification.svelte';
+	import type { VectorTileMetadata } from '$lib/types';
 
 	export let layerId: string;
-	const propertyName = 'fill-color';
+	export let metadata: VectorTileMetadata;
 	export let defaultColor: string = undefined;
 
-	const getFillColor = (): string => {
-		let fillColor = $map.getPaintProperty(layerId, propertyName);
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		if (
-			!fillColor ||
-			(fillColor && fillColor.type === 'interval') ||
-			(fillColor && fillColor.type === 'categorical')
-		) {
-			fillColor = defaultColor;
-		}
-		return fillColor as string;
-	};
-
-	let rgba = getFillColor();
-
-	onMount(() => {
-		rgba = getFillColor();
-		map.setPaintProperty(layerId, propertyName, rgba);
-	});
-
-	const handleSetColor = (e: CustomEvent) => {
-		rgba = e.detail.color;
-		map.setPaintProperty(layerId, propertyName, rgba);
-		defaultColor = e.detail.color;
-	};
+	const propertyName = 'fill-color';
 </script>
 
-<MaplibreColorPicker {rgba} on:change={handleSetColor} />
+<VectorColorClassification {layerId} {metadata} {defaultColor} {propertyName} />

--- a/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
+++ b/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
@@ -1,25 +1,16 @@
 <script lang="ts">
 	import FillColor from '$components/maplibre/fill/FillColor.svelte';
-	import FillOutlineColor from '$components/maplibre/fill/FillOutlineColor.svelte';
+	import FieldControl from '$components/util/FieldControl.svelte';
+	import type { VectorTileMetadata } from '$lib/types';
 
 	export let layerId: string;
 	export let defaultFillColor: string = undefined;
-	export let defaultFillOutlineColor: string = undefined;
+	export let metadata: VectorTileMetadata;
 </script>
 
-<div class="line-simple-container" data-testid="polygon-simple-container">
-	<div class="columns is-mobile">
-		<div class="column is-5">
-			<div class="has-text-centered pb-2">Fill Color</div>
-			<div class="is-flex is-justify-content-center bring-to-front">
-				<FillColor {layerId} bind:defaultColor={defaultFillColor} />
-			</div>
-		</div>
-		<div class="column is-7">
-			<div class="has-text-centered pb-2">Fill Outline Color</div>
-			<div class="is-flex is-justify-content-center send-to-back">
-				<FillOutlineColor {layerId} bind:defaultColor={defaultFillOutlineColor} />
-			</div>
-		</div>
+<FieldControl title="Fill color">
+	<div slot="help">Change polygon fill color by using single color or selected property.</div>
+	<div slot="control">
+		<FillColor {layerId} {metadata} bind:defaultColor={defaultFillColor} />
 	</div>
-</div>
+</FieldControl>

--- a/sites/geohub/src/components/maplibre/vector/VectorLegend.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorLegend.svelte
@@ -55,10 +55,6 @@
 		) {
 			legendType = LegendTypes.CLASSIFY;
 		}
-	} else if (style?.type === 'fill') {
-		if (isVectorIntervalExpression($map, layerId, 'fill-color')) {
-			legendType = LegendTypes.CLASSIFY;
-		}
 	}
 
 	$defaultColor =
@@ -73,8 +69,6 @@
 	$defaultLineColor =
 		style?.type === 'line'
 			? getVectorDefaultColor($map, layerId, 'line-color', $defaultColor)
-			: style?.type === 'fill'
-			? getVectorDefaultColor($map, layerId, 'fill-outline-color', $defaultColor)
 			: undefined;
 
 	// set default values
@@ -93,7 +87,7 @@
 </script>
 
 <div class="legend-container">
-	{#if !['heatmap', 'circle', 'fill-extrusion'].includes(style.type)}
+	{#if !['heatmap', 'circle', 'fill-extrusion', 'fill'].includes(style.type)}
 		<LegendTypeSwitcher bind:legendType />
 		<div class="help">
 			<Help>
@@ -132,18 +126,14 @@
 			<VectorHeatmap {layerId} />
 		{:else if style.type === 'circle'}
 			<VectorCircle {layerId} {metadata} bind:defaultColor={$defaultColor} />
+		{:else if style.type === 'fill'}
+			<VectorPolygon {layerId} {metadata} bind:defaultFillColor={$defaultColor} />
 		{:else if style.type === 'fill-extrusion'}
 			<VectorFillExtrusion {layerId} {metadata} bind:defaultFillColor={$defaultColor} />
 		{:else if legendType === LegendTypes.DEFAULT}
 			<div transition:slide|global>
 				{#if style.type === 'line'}
 					<VectorLine {layerId} bind:defaultColor={$defaultLineColor} />
-				{:else if style.type === 'fill'}
-					<VectorPolygon
-						{layerId}
-						bind:defaultFillColor={$defaultColor}
-						bind:defaultFillOutlineColor={$defaultLineColor}
-					/>
 				{:else if style.type === 'symbol'}
 					<VectorSymbol {layerId} bind:defaultColor={$defaultColor} />
 				{/if}

--- a/sites/geohub/src/components/maplibre/vector/VectorPropertyEditor.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorPropertyEditor.svelte
@@ -7,6 +7,7 @@
 	import FillExtrusionBase from '$components/maplibre/fill-extrusion/FillExtrusionBase.svelte';
 	import FillExtrusionHeight from '$components/maplibre/fill-extrusion/FillExtrusionHeight.svelte';
 	import FillExtrusionVerticalGradient from '$components/maplibre/fill-extrusion/FillExtrusionVerticalGradient.svelte';
+	import FillOutlineColor from '$components/maplibre/fill/FillOutlineColor.svelte';
 	import HeatmapIntensity from '$components/maplibre/heatmap/HeatmapIntensity.svelte';
 	import HeatmapRadius from '$components/maplibre/heatmap/HeatmapRadius.svelte';
 	import HeatmapWeight from '$components/maplibre/heatmap/HeatmapWeight.svelte';
@@ -27,6 +28,7 @@
 		type MapStore
 	} from '$stores';
 	import { Accordion } from '@undp-data/svelte-undp-design';
+	import chroma from 'chroma-js';
 	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
@@ -37,6 +39,8 @@
 	export let metadata: VectorTileMetadata;
 	export let legendType: LegendTypes;
 	export let defaultColor: string;
+
+	let defaultFillOutlineColor: string = defaultColor ? chroma(defaultColor).darken(2.5).hex() : '';
 
 	const style: VectorLayerSpecification = $map
 		.getStyle()
@@ -134,6 +138,21 @@
 						<div slot="control"><LineWidth {layerId} /></div>
 					</FieldControl>
 				{/if}
+			{:else if style.type === 'fill'}
+				<FieldControl title="Fill outline color">
+					<div slot="help">Change polygon outline color.</div>
+					<div slot="control">
+						<FillOutlineColor {layerId} bind:defaultColor={defaultFillOutlineColor} />
+					</div>
+				</FieldControl>
+
+				<FieldControl title="Classification method">
+					<div slot="help">
+						Whether to apply a classification method for a vector layer in selected property. This
+						setting is only used when you select a property to classify the layer appearance.
+					</div>
+					<div slot="control"><ClassificationMethods /></div>
+				</FieldControl>
 			{:else if style.type === 'heatmap'}
 				<FieldControl title="Heatmap Intensity">
 					<div slot="help">

--- a/sites/geohub/src/components/pages/map/layers/header/Legend.svelte
+++ b/sites/geohub/src/components/pages/map/layers/header/Legend.svelte
@@ -171,6 +171,28 @@
 							.colors(color['stops'].length, 'rgba');
 						const style = `height: calc(1px * 24); width: calc(2px * 12); background: linear-gradient(90deg, ${colormap});`;
 						divIcon.style.cssText = style;
+					} else if (color && Array.isArray(color) && ['match', 'step'].includes(color[0])) {
+						const colors: string[] = [];
+						if (color[0] === 'match') {
+							// match
+							for (let i = 3; i < color.length - 1; i = i + 2) {
+								colors.push(color[i]);
+							}
+						} else {
+							// step
+							for (let i = 2; i < color.length - 1; i = i + 2) {
+								colors.push(color[i]);
+							}
+						}
+
+						const colormap = chroma
+							.scale(colors)
+							.mode('lrgb')
+							.padding([0.25, 0])
+							.domain([1, 100])
+							.colors(colors.length, 'rgba');
+						const style = `height: calc(1px * 24); width: calc(2px * 12); background: linear-gradient(90deg, ${colormap});`;
+						divIcon.style.cssText = style;
 					}
 
 					container.appendChild(divIcon);

--- a/sites/geohub/src/lib/helper/getVectorDefaultColor.ts
+++ b/sites/geohub/src/lib/helper/getVectorDefaultColor.ts
@@ -17,6 +17,8 @@ export const getVectorDefaultColor = (
 		} else {
 			color = chroma.random().hex();
 		}
+	} else if (Array.isArray(color)) {
+		color = chroma.random().hex();
 	}
 	return color as string;
 };


### PR DESCRIPTION
@iferencik Please review it for me

## Description


* added new Color classification component to fill layer type. Classification method was moved to popup editor
* due to the above change, fill outline color was also moved to popup since it is minor property
* fixed bug of Legend.svelte to make legend from expression properly
* fixed bug of of getVectorDefaultColor function

![](https://github.com/UNDP-Data/geohub/assets/2639701/96420671-62f1-4274-9849-a91951ca6ed8)

![](https://github.com/UNDP-Data/geohub/assets/2639701/9a0d9f1c-d14a-4d16-8f1d-cb26dde0d7cf)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1244879981) by [Unito](https://www.unito.io)
