### PR TITLE
refactor: Use ContextAPI/store for defaultColor prop for vector style components

### DIFF
--- a/.changeset/two-frogs-admire.md
+++ b/.changeset/two-frogs-admire.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+refactor: Use ContextAPI/store for defaultColor prop for vector style components

--- a/sites/geohub/src/components/maplibre/circle/CircleColor.svelte
+++ b/sites/geohub/src/components/maplibre/circle/CircleColor.svelte
@@ -4,40 +4,10 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'circle-color';
-
-	// const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
-
-	// export let layerId: string;
-	// const propertyName = 'circle-color';
-	// export let defaultColor: string = undefined;
-
-	// const getColor = (): string => {
-	// 	let color = $map.getPaintProperty(layerId, propertyName);
-	// 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// 	// @ts-ignore
-	// 	if (!color || (color && color.type === 'interval') || (color && color.type === 'categorical')) {
-	// 		color = defaultColor;
-	// 	}
-	// 	return color as string;
-	// };
-
-	// let rgba = getColor();
-
-	// onMount(() => {
-	// 	rgba = getColor();
-	// 	map.setPaintProperty(layerId, propertyName, rgba);
-	// });
-
-	// const handleSetColor = (e: CustomEvent) => {
-	// 	rgba = e.detail.color;
-	// 	map.setPaintProperty(layerId, propertyName, rgba);
-	// 	defaultColor = e.detail.color;
-	// };
 </script>
 
 <!-- <MaplibreColorPicker {rgba} on:change={handleSetColor} /> -->
 
-<VectorColorClassification {layerId} {metadata} {defaultColor} {propertyName} />
+<VectorColorClassification {layerId} {metadata} {propertyName} />

--- a/sites/geohub/src/components/maplibre/circle/VectorCircle.svelte
+++ b/sites/geohub/src/components/maplibre/circle/VectorCircle.svelte
@@ -5,7 +5,6 @@
 	import CircleRadius from './CircleRadius.svelte';
 
 	export let layerId: string;
-	export let defaultColor: string = undefined;
 	export let metadata: VectorTileMetadata;
 </script>
 
@@ -19,6 +18,6 @@
 <FieldControl title="Circle color">
 	<div slot="help">Change circle color by using single color or selected property.</div>
 	<div slot="control">
-		<CircleColor {layerId} {metadata} bind:defaultColor />
+		<CircleColor {layerId} {metadata} />
 	</div>
 </FieldControl>

--- a/sites/geohub/src/components/maplibre/fill-extrusion/FillExtrusionColor.svelte
+++ b/sites/geohub/src/components/maplibre/fill-extrusion/FillExtrusionColor.svelte
@@ -4,9 +4,8 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'fill-extrusion-color';
 </script>
 
-<VectorColorClassification {layerId} {metadata} {defaultColor} {propertyName} />
+<VectorColorClassification {layerId} {metadata} {propertyName} />

--- a/sites/geohub/src/components/maplibre/fill-extrusion/VectorFillExtrusion.svelte
+++ b/sites/geohub/src/components/maplibre/fill-extrusion/VectorFillExtrusion.svelte
@@ -4,13 +4,12 @@
 	import FillExtrusionColor from './FillExtrusionColor.svelte';
 
 	export let layerId: string;
-	export let defaultFillColor: string = undefined;
 	export let metadata: VectorTileMetadata;
 </script>
 
 <FieldControl title="3D polygon color">
 	<div slot="help">Change polygon fill color by using single color or selected property.</div>
 	<div slot="control">
-		<FillExtrusionColor {layerId} {metadata} bind:defaultColor={defaultFillColor} />
+		<FillExtrusionColor {layerId} {metadata} />
 	</div>
 </FieldControl>

--- a/sites/geohub/src/components/maplibre/fill/FillColor.svelte
+++ b/sites/geohub/src/components/maplibre/fill/FillColor.svelte
@@ -4,9 +4,8 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'fill-color';
 </script>
 
-<VectorColorClassification {layerId} {metadata} {defaultColor} {propertyName} />
+<VectorColorClassification {layerId} {metadata} {propertyName} />

--- a/sites/geohub/src/components/maplibre/fill/FillOutlineColor.svelte
+++ b/sites/geohub/src/components/maplibre/fill/FillOutlineColor.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
 	import MaplibreColorPicker from '$components/maplibre/MaplibreColorPicker.svelte';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import {
+		DEFAULTCOLOR_CONTEXT_KEY,
+		MAPSTORE_CONTEXT_KEY,
+		type DefaultColorStore,
+		type MapStore
+	} from '$stores';
+	import chroma from 'chroma-js';
 	import { getContext, onMount } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const defaultColorStore: DefaultColorStore = getContext(DEFAULTCOLOR_CONTEXT_KEY);
 
 	export let layerId: string;
 	const propertyName = 'fill-outline-color';
-	export let defaultColor: string = undefined;
+
+	let defaultColor: string;
 
 	const getFillOutlineColor = (): string => {
 		let fillOutlineColor = $map.getPaintProperty(layerId, 'fill-outline-color');
@@ -18,6 +26,10 @@
 			(fillOutlineColor && fillOutlineColor.type === 'interval') ||
 			(fillOutlineColor && fillOutlineColor.type === 'categorical')
 		) {
+			if (!defaultColor) {
+				defaultColor =
+					$defaultColorStore?.length > 0 ? chroma($defaultColorStore).darken(2.5).hex() : '#000';
+			}
 			fillOutlineColor = defaultColor;
 		}
 		return fillOutlineColor as string;

--- a/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
+++ b/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
@@ -4,13 +4,12 @@
 	import type { VectorTileMetadata } from '$lib/types';
 
 	export let layerId: string;
-	export let defaultFillColor: string = undefined;
 	export let metadata: VectorTileMetadata;
 </script>
 
 <FieldControl title="Fill color">
 	<div slot="help">Change polygon fill color by using single color or selected property.</div>
 	<div slot="control">
-		<FillColor {layerId} {metadata} bind:defaultColor={defaultFillColor} />
+		<FillColor {layerId} {metadata} />
 	</div>
 </FieldControl>

--- a/sites/geohub/src/components/maplibre/line/LinePattern.svelte
+++ b/sites/geohub/src/components/maplibre/line/LinePattern.svelte
@@ -4,12 +4,11 @@
 	import { Radios, type Radio } from '@undp-data/svelte-undp-design';
 	import { isEqual, sortBy } from 'lodash-es';
 	import type { LayerSpecification } from 'maplibre-gl';
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	export let layerId: string;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'line-dasharray';
 
@@ -17,7 +16,6 @@
 		.getStyle()
 		.layers.filter((layer: LayerSpecification) => layer.id === layerId)[0];
 
-	let linePatternColorRgba = defaultColor;
 	let lineType = (
 		style?.paint[propertyName]
 			? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -47,13 +45,6 @@
 
 	let linePatterns: Radio[] = setLinePatterns();
 
-	onMount(() => {
-		if (!$map) return;
-		$map.on('line-color:changed', () => {
-			linePatternColorRgba = defaultColor;
-		});
-	});
-
 	const setLineType = () => {
 		if (style?.type !== 'line' || lineType === undefined) return;
 
@@ -67,15 +58,13 @@
 </script>
 
 <div class="line-pattern-view-container" data-testid="line-pattern-view-container">
-	{#key linePatternColorRgba}
-		<Radios
-			bind:radios={linePatterns}
-			bind:value={lineType}
-			allowHtml={true}
-			groupName="line-pattern-{layerId}"
-			isVertical={true}
-		/>
-	{/key}
+	<Radios
+		bind:radios={linePatterns}
+		bind:value={lineType}
+		allowHtml={true}
+		groupName="line-pattern-{layerId}"
+		isVertical={true}
+	/>
 </div>
 
 <style lang="scss">

--- a/sites/geohub/src/components/maplibre/line/LineWidth.svelte
+++ b/sites/geohub/src/components/maplibre/line/LineWidth.svelte
@@ -2,10 +2,13 @@
 	import { page } from '$app/stores';
 	import VectorValueClassification from '$components/maplibre/vector/VectorValueClassification.svelte';
 	import type { VectorTileMetadata } from '$lib/types';
+	import { DEFAULTCOLOR_CONTEXT_KEY, type DefaultColorStore } from '$stores';
+	import { getContext } from 'svelte';
+
+	const defaultColorStore: DefaultColorStore = getContext(DEFAULTCOLOR_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string;
 
 	let defaultLineWidth = $page.data.config.LineWidth;
 	let maxValue = 10;
@@ -23,6 +26,6 @@
 	{stepValue}
 	{propertyName}
 	styleType="paint"
-	legendCssTemplate={`margin-top: 5px; width: 40px; height: {value}px; background-color: ${defaultColor};`}
+	legendCssTemplate={`margin-top: 5px; width: 40px; height: {value}px; background-color: ${$defaultColorStore};`}
 	dataLabel="Line width"
 />

--- a/sites/geohub/src/components/maplibre/line/VectorLine.svelte
+++ b/sites/geohub/src/components/maplibre/line/VectorLine.svelte
@@ -6,7 +6,6 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	let tabs = [
 		{
@@ -46,9 +45,9 @@
 </div>
 
 <div hidden={activeTab !== tabs[0].label}>
-	<LineColor {layerId} bind:defaultColor {metadata} />
+	<LineColor {layerId} {metadata} />
 </div>
 
 <div hidden={activeTab !== tabs[1].label}>
-	<LineWidth {layerId} {metadata} bind:defaultColor />
+	<LineWidth {layerId} {metadata} />
 </div>

--- a/sites/geohub/src/components/maplibre/symbol/IconColor.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconColor.svelte
@@ -4,15 +4,8 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'icon-color';
 </script>
 
-<VectorColorClassification
-	{layerId}
-	{metadata}
-	{defaultColor}
-	{propertyName}
-	onlyNumberFields={false}
-/>
+<VectorColorClassification {layerId} {metadata} {propertyName} onlyNumberFields={false} />

--- a/sites/geohub/src/components/maplibre/symbol/IconImage.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconImage.svelte
@@ -7,14 +7,17 @@
 	import IconImagePicker from '$components/maplibre/symbol/IconImagePicker.svelte';
 	import { clean, getLayerStyle, initTippy } from '$lib/helper';
 	import {
+		DEFAULTCOLOR_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
 		SPRITEIMAGE_CONTEXT_KEY,
+		type DefaultColorStore,
 		type MapStore,
 		type SpriteImageStore
 	} from '$stores';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
+	const defaultColorStore: DefaultColorStore = getContext(DEFAULTCOLOR_CONTEXT_KEY);
 
 	const tippy = initTippy({
 		appendTo: document.body
@@ -22,7 +25,6 @@
 	let tooltipContent: HTMLElement;
 
 	export let layerId: string;
-	export let defaultColor: string = undefined;
 
 	const propertyName = 'icon-image';
 	const style = $map
@@ -62,7 +64,7 @@
 			const icon = $spriteImageList.find((icon) => icon.alt === layerStyle.layout['icon-image']);
 			iconImageSrc = icon.src;
 			if (icon) {
-				const rgba = iconColor ? chroma(iconColor).rgba() : chroma(defaultColor).rgba();
+				const rgba = iconColor ? chroma(iconColor).rgba() : chroma($defaultColorStore).rgba();
 				const cssFilter = hexToCSSFilter(chroma([rgba[0], rgba[1], rgba[2]]).hex());
 				iconImageStyle = `height: 24px; width: 24px; filter: ${cssFilter?.filter}`;
 			}
@@ -80,7 +82,7 @@
 		}
 	};
 
-	$: defaultColor, updateLegend();
+	$: $defaultColorStore, updateLegend();
 </script>
 
 <div class="icon-button" use:tippy={{ content: tooltipContent }}>

--- a/sites/geohub/src/components/maplibre/symbol/IconSize.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconSize.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import VectorValueClassification from '$components/maplibre/vector/VectorValueClassification.svelte';
+	import type { UserConfig } from '$lib/config/DefaultUserConfig';
 	import type { SpriteImage, VectorTileMetadata } from '$lib/types';
 	import {
+		DEFAULTCOLOR_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
 		SPRITEIMAGE_CONTEXT_KEY,
+		type DefaultColorStore,
 		type MapStore,
 		type SpriteImageStore
 	} from '$stores';
@@ -15,12 +18,14 @@
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
+	const defaultColorStore: DefaultColorStore = getContext(DEFAULTCOLOR_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string;
 
-	let defaultLineWidth = $page.data.config.LineWidth;
+	let config: UserConfig = $page.data.config;
+
+	let defaultIconSize = config.IconSize;
 	let maxValue = 5;
 	let minValue = 0;
 	let propertyName = 'icon-size';
@@ -30,7 +35,7 @@
 	let cssIconFilter = '';
 
 	const setCssIconFilter = () => {
-		const rgba = chroma(defaultColor).rgba();
+		const rgba = chroma($defaultColorStore).rgba();
 		cssIconFilter = hexToCSSFilter(chroma([rgba[0], rgba[1], rgba[2]]).hex()).filter;
 	};
 
@@ -46,18 +51,21 @@
 		handleDefaultColorChanged();
 	});
 
-	$: defaultColor, handleDefaultColorChanged();
 	const handleDefaultColorChanged = () => {
 		icon = $spriteImageList.find((icon) => icon.alt === getIconImageName());
 		setCssIconFilter();
 	};
+
+	defaultColorStore.subscribe(() => {
+		handleDefaultColorChanged();
+	});
 </script>
 
 {#if icon}
 	<VectorValueClassification
 		{layerId}
 		{metadata}
-		bind:defaultValue={defaultLineWidth}
+		bind:defaultValue={defaultIconSize}
 		{minValue}
 		{maxValue}
 		{stepValue}

--- a/sites/geohub/src/components/maplibre/symbol/VectorSymbol.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/VectorSymbol.svelte
@@ -2,17 +2,12 @@
 	import IconColor from '$components/maplibre/symbol/IconColor.svelte';
 	import IconImage from '$components/maplibre/symbol/IconImage.svelte';
 	import FieldControl from '$components/util/FieldControl.svelte';
-	import { getVectorDefaultColor, handleEnterKey } from '$lib/helper';
+	import { handleEnterKey } from '$lib/helper';
 	import type { VectorTileMetadata } from '$lib/types';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
-	import { getContext, onMount } from 'svelte';
 	import IconSize from './IconSize.svelte';
-
-	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string = undefined;
 
 	let tabs = [
 		{
@@ -29,16 +24,6 @@
 		}
 	];
 	let activeTab: string = tabs[0].label;
-
-	onMount(() => {
-		setDefaultColor();
-	});
-
-	$: activeTab, setDefaultColor();
-
-	const setDefaultColor = () => {
-		defaultColor = getVectorDefaultColor($map, layerId, 'icon-color');
-	};
 </script>
 
 <div class="tabs is-centered is-toggle">
@@ -69,7 +54,7 @@
 	<FieldControl title="Icon">
 		<div slot="help">Change icon for a vector layer.</div>
 		<div slot="control">
-			<IconImage {layerId} bind:defaultColor />
+			<IconImage {layerId} />
 		</div>
 	</FieldControl>
 </div>
@@ -78,7 +63,7 @@
 	<FieldControl title="Icon color">
 		<div slot="help">Change icon color by using single color or selected property.</div>
 		<div slot="control">
-			<IconColor {layerId} {metadata} bind:defaultColor />
+			<IconColor {layerId} {metadata} />
 		</div>
 	</FieldControl>
 </div>
@@ -87,7 +72,7 @@
 	<FieldControl title="Icon size">
 		<div slot="help">Change icon color by using single color or selected property.</div>
 		<div slot="control">
-			<IconSize {layerId} {metadata} bind:defaultColor />
+			<IconSize {layerId} {metadata} />
 		</div>
 	</FieldControl>
 </div>

--- a/sites/geohub/src/components/maplibre/vector/VectorLegend.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorLegend.svelte
@@ -3,12 +3,10 @@
 	import VectorHeatmap from '$components/maplibre/heatmap/VectorHeatmap.svelte';
 	import VectorLine from '$components/maplibre/line/VectorLine.svelte';
 	import VectorSymbol from '$components/maplibre/symbol/VectorSymbol.svelte';
-	import { getVectorDefaultColor } from '$lib/helper';
 	import type { VectorTileMetadata } from '$lib/types';
 	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
-	import { writable } from 'svelte/store';
 	import VectorCircle from '../circle/VectorCircle.svelte';
 	import VectorFillExtrusion from '../fill-extrusion/VectorFillExtrusion.svelte';
 	import VectorPropertyEditor from './VectorPropertyEditor.svelte';
@@ -18,45 +16,28 @@
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
 
-	const defaultColor = writable<string>('');
-	const defaultLineColor = writable<string>('');
-
 	const style: LayerSpecification = $map
 		.getStyle()
 		.layers.filter((l: LayerSpecification) => l.id === layerId)[0];
-
-	$defaultColor =
-		style?.type === 'symbol'
-			? getVectorDefaultColor($map, layerId, 'icon-color')
-			: style?.type === 'fill'
-			? getVectorDefaultColor($map, layerId, 'fill-color')
-			: style?.type === 'line'
-			? getVectorDefaultColor($map, layerId, 'line-color')
-			: undefined;
-
-	$defaultLineColor =
-		style?.type === 'line'
-			? getVectorDefaultColor($map, layerId, 'line-color', $defaultColor)
-			: undefined;
 </script>
 
 <div class="legend-container">
 	<div class="editor-button">
-		<VectorPropertyEditor bind:layerId bind:defaultColor={$defaultColor} bind:metadata />
+		<VectorPropertyEditor bind:layerId bind:metadata />
 	</div>
 
 	{#if style.type === 'heatmap'}
 		<VectorHeatmap {layerId} />
 	{:else if style.type === 'symbol'}
-		<VectorSymbol {layerId} {metadata} bind:defaultColor={$defaultColor} />
+		<VectorSymbol {layerId} {metadata} />
 	{:else if style.type === 'line'}
-		<VectorLine {layerId} {metadata} bind:defaultColor={$defaultLineColor} />
+		<VectorLine {layerId} {metadata} />
 	{:else if style.type === 'circle'}
-		<VectorCircle {layerId} {metadata} bind:defaultColor={$defaultColor} />
+		<VectorCircle {layerId} {metadata} />
 	{:else if style.type === 'fill'}
-		<VectorPolygon {layerId} {metadata} bind:defaultFillColor={$defaultColor} />
+		<VectorPolygon {layerId} {metadata} />
 	{:else if style.type === 'fill-extrusion'}
-		<VectorFillExtrusion {layerId} {metadata} bind:defaultFillColor={$defaultColor} />
+		<VectorFillExtrusion {layerId} {metadata} />
 	{/if}
 </div>
 

--- a/sites/geohub/src/components/maplibre/vector/VectorPropertyEditor.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorPropertyEditor.svelte
@@ -17,7 +17,6 @@
 	import type { VectorLayerSpecification, VectorTileMetadata } from '$lib/types';
 	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import { Accordion } from '@undp-data/svelte-undp-design';
-	import chroma from 'chroma-js';
 	import type { LayerSpecification } from 'maplibre-gl';
 	import { getContext } from 'svelte';
 
@@ -25,9 +24,6 @@
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
-	export let defaultColor: string;
-
-	let defaultFillOutlineColor: string = defaultColor ? chroma(defaultColor).darken(2.5).hex() : '';
 
 	const style: VectorLayerSpecification = $map
 		.getStyle()
@@ -112,13 +108,13 @@
 			{:else if style.type === 'line'}
 				<FieldControl title="Line Pattern">
 					<div slot="help">Line pattern for drawing.</div>
-					<div slot="control"><LinePattern {layerId} bind:defaultColor /></div>
+					<div slot="control"><LinePattern {layerId} /></div>
 				</FieldControl>
 			{:else if style.type === 'fill'}
 				<FieldControl title="Fill outline color">
 					<div slot="help">Change polygon outline color.</div>
 					<div slot="control">
-						<FillOutlineColor {layerId} bind:defaultColor={defaultFillOutlineColor} />
+						<FillOutlineColor {layerId} />
 					</div>
 				</FieldControl>
 			{:else if style.type === 'heatmap'}

--- a/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
@@ -27,6 +27,7 @@
 	import {
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
 		COLORMAP_NAME_CONTEXT_KEY,
+		DEFAULTCOLOR_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY_2,
@@ -34,6 +35,7 @@
 		SPRITEIMAGE_CONTEXT_KEY,
 		createClassificationMethodStore,
 		createColorMapNameStore,
+		createDefaultColorStore,
 		createMapStore,
 		createNumberOfClassesStore,
 		createRasterRescaleStore,
@@ -117,6 +119,9 @@
 
 	const classificationMethod = createClassificationMethodStore();
 	setContext(CLASSIFICATION_METHOD_CONTEXT_KEY, classificationMethod);
+
+	const defaultColorStore = createDefaultColorStore();
+	setContext(DEFAULTCOLOR_CONTEXT_KEY, defaultColorStore);
 
 	onMount(() => {
 		initialiseMap();

--- a/sites/geohub/src/components/pages/map/layers/header/VisibilityButton.svelte
+++ b/sites/geohub/src/components/pages/map/layers/header/VisibilityButton.svelte
@@ -15,7 +15,7 @@
 	const getVisibility = (): 'visible' | 'none' => {
 		const layerStyle = $map.getStyle().layers.find((l) => l.id === layer.id);
 		let visibility: 'visible' | 'none' = 'visible';
-		if (layerStyle.layout && layerStyle.layout.visibility) {
+		if (layerStyle && layerStyle.layout && layerStyle.layout.visibility) {
 			visibility = layerStyle.layout.visibility;
 		}
 		return visibility;

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -17,11 +17,13 @@
 	import {
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
 		COLORMAP_NAME_CONTEXT_KEY,
+		DEFAULTCOLOR_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY_2,
 		createClassificationMethodStore,
 		createColorMapNameStore,
+		createDefaultColorStore,
 		createNumberOfClassesStore,
 		layerList,
 		type MapStore
@@ -60,6 +62,9 @@
 	const numberOfClassesStore2 = createNumberOfClassesStore();
 	$numberOfClassesStore2 = $page.data.config.NumberOfClasses;
 	setContext(NUMBER_OF_CLASSES_CONTEXT_KEY_2, numberOfClassesStore2);
+
+	const defaultColorStore = createDefaultColorStore();
+	setContext(DEFAULTCOLOR_CONTEXT_KEY, defaultColorStore);
 
 	let activeTab = layer.activeTab ?? TabNames.LEGEND;
 

--- a/sites/geohub/src/lib/helper/getVectorDefaultColor.ts
+++ b/sites/geohub/src/lib/helper/getVectorDefaultColor.ts
@@ -4,7 +4,13 @@ import type { Map } from 'maplibre-gl';
 export const getVectorDefaultColor = (
 	map: Map,
 	layerId: string,
-	property: 'icon-color' | 'fill-color' | 'fill-outline-color' | 'line-color',
+	property:
+		| 'icon-color'
+		| 'fill-color'
+		| 'fill-outline-color'
+		| 'line-color'
+		| 'fill-extrusion-color'
+		| 'circle-color',
 	defaultColor?: string
 ): string => {
 	if (!map.getLayer(layerId)) return;

--- a/sites/geohub/src/stores/defaultColor.ts
+++ b/sites/geohub/src/stores/defaultColor.ts
@@ -1,0 +1,9 @@
+import { writable, type Writable } from 'svelte/store';
+
+export const DEFAULTCOLOR_CONTEXT_KEY = 'maplibre-default-color-store';
+
+export type DefaultColorStore = Writable<string>;
+
+export const createDefaultColorStore = () => {
+	return writable(<string>'');
+};

--- a/sites/geohub/src/stores/index.ts
+++ b/sites/geohub/src/stores/index.ts
@@ -5,3 +5,4 @@ export * from './rasterRescale';
 export * from './numberOfClasses';
 export * from './colorMapName';
 export * from './classificationMethod';
+export * from './defaultColor';


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #2257

now defaultColor prop is using ContextAPI, and it is defined at VectorLayer component and DefaultStyleEditor component.
So, the state of default color will be kept even after switching to different tabs.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1249737049) by [Unito](https://www.unito.io)
