### PR TITLE
refactor: Use context api with store for header height

### DIFF
--- a/.changeset/wise-bobcats-wave.md
+++ b/.changeset/wise-bobcats-wave.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+refactor: Use context api with store for header height

--- a/sites/geohub/src/components/header/Header.svelte
+++ b/sites/geohub/src/components/header/Header.svelte
@@ -3,9 +3,12 @@
 	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import UserAccount from '$components/header/UserAccount.svelte';
 	import { HeaderItems } from '$lib/config/AppConfig';
+	import { HEADER_HEIGHT_CONTEXT_KEY, type HeaderHeightStore } from '$stores';
 	import { Header, type HeaderLink } from '@undp-data/svelte-undp-design';
+	import { getContext } from 'svelte';
 
-	export let headerHeight: number;
+	let headerHeightStore: HeaderHeightStore = getContext(HEADER_HEIGHT_CONTEXT_KEY);
+
 	export let isPositionFixed = true;
 	let showMobileMenu = false;
 
@@ -30,7 +33,7 @@
 		siteTitle="GeoHub"
 		url="/"
 		logoUrl="/assets/undp-images/undp-logo-blue.svg"
-		bind:height={headerHeight}
+		bind:height={$headerHeightStore}
 		{isPositionFixed}
 		bind:links
 		bind:showMobileMenu

--- a/sites/geohub/src/components/pages/home/MapHero.svelte
+++ b/sites/geohub/src/components/pages/home/MapHero.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { MapAnimation } from '$lib/config/AppConfig';
+	import { HEADER_HEIGHT_CONTEXT_KEY, type HeaderHeightStore } from '$stores';
 	import { AttributionControl, Map } from 'maplibre-gl';
 	import 'maplibre-gl/dist/maplibre-gl.css';
 	import { getContext, onMount } from 'svelte';
-	import type { Writable } from 'svelte/store';
 
 	let container: HTMLDivElement;
 	let innerHeight = 1000;
@@ -13,9 +13,9 @@
 	export let excludeHeaderHeight = true;
 	export let styleId: number;
 
-	let headerHeight: Writable<number> = getContext('headerHeight');
+	let headerHeightStore: HeaderHeightStore = getContext(HEADER_HEIGHT_CONTEXT_KEY);
 
-	$: mapHeight = excludeHeaderHeight ? innerHeight - $headerHeight : innerHeight;
+	$: mapHeight = excludeHeaderHeight ? innerHeight - $headerHeightStore : innerHeight;
 
 	onMount(() => {
 		map = new Map({

--- a/sites/geohub/src/components/pages/map/data/StacExplorerButton.svelte
+++ b/sites/geohub/src/components/pages/map/data/StacExplorerButton.svelte
@@ -2,19 +2,23 @@
 	import StacExplorer from '$components/util/StacExplorer.svelte';
 	import { handleEnterKey } from '$lib/helper';
 	import type { DatasetFeature } from '$lib/types';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import {
+		HEADER_HEIGHT_CONTEXT_KEY,
+		MAPSTORE_CONTEXT_KEY,
+		type HeaderHeightStore,
+		type MapStore
+	} from '$stores';
 	import { Loader } from '@undp-data/svelte-undp-design';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import type { Writable } from 'svelte/store';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
-	let headerHeight: Writable<number> = getContext('header-height');
+	let headerHeightStore: HeaderHeightStore = getContext(HEADER_HEIGHT_CONTEXT_KEY);
 	let innerHeight: number;
 
-	$: mapHeight = innerHeight - $headerHeight;
+	$: mapHeight = innerHeight - $headerHeightStore;
 
 	export let feature: DatasetFeature;
 

--- a/sites/geohub/src/routes/(app)/+layout@.svelte
+++ b/sites/geohub/src/routes/(app)/+layout@.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-	import BackToTop from '$components/util/BackToTop.svelte';
 	import Header from '$components/header/Header.svelte';
+	import BackToTop from '$components/util/BackToTop.svelte';
 	import { FooterItems } from '$lib/config/AppConfig';
+	import { HEADER_HEIGHT_CONTEXT_KEY, createHeaderHeightStore } from '$stores';
 	import { Footer } from '@undp-data/svelte-undp-design';
 	import { setContext } from 'svelte';
-	import { writable } from 'svelte/store';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
 
-	let headerHeight = writable<number>(115);
-
-	setContext('headerHeight', headerHeight);
+	const headerHeightStore = createHeaderHeightStore();
+	setContext(HEADER_HEIGHT_CONTEXT_KEY, headerHeightStore);
 
 	let footerItems = FooterItems;
 
@@ -23,10 +22,10 @@
 </script>
 
 <div class="header">
-	<Header bind:headerHeight={$headerHeight} />
+	<Header />
 </div>
 
-<div style="margin-top: {$headerHeight}px">
+<div style="margin-top: {$headerHeightStore}px">
 	<slot />
 </div>
 

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Header from '$components/header/Header.svelte';
 	import { AdminControlOptions, MapStyles } from '$lib/config/AppConfig';
+	import { HEADER_HEIGHT_CONTEXT_KEY, createHeaderHeightStore } from '$stores';
 	import MaplibreCgazAdminControl from '@undp-data/cgaz-admin-tool';
 	import '@undp-data/cgaz-admin-tool/dist/maplibre-cgaz-admin-control.css';
 	import StyleSwicher from '@undp-data/style-switcher';
@@ -13,7 +14,7 @@
 		ScaleControl
 	} from 'maplibre-gl';
 	import 'maplibre-gl/dist/maplibre-gl.css';
-	import { onMount } from 'svelte';
+	import { onMount, setContext } from 'svelte';
 	import type { PageData } from './$types';
 	import Charts from './components/Charts.svelte';
 	import DownloadData from './components/DownloadData.svelte';
@@ -27,12 +28,14 @@
 
 	export let data: PageData;
 
+	const headerHeightStore = createHeaderHeightStore();
+	setContext(HEADER_HEIGHT_CONTEXT_KEY, headerHeightStore);
+
 	const azureUrl = data.azureUrl;
 	setAzureUrl(azureUrl);
 
-	let headerHeight: number;
 	let innerHeight: number;
-	$: splitHeight = innerHeight - headerHeight;
+	$: splitHeight = innerHeight - $headerHeightStore;
 
 	let styles = MapStyles;
 
@@ -163,9 +166,9 @@
 
 <svelte:window bind:innerHeight />
 
-<Header bind:headerHeight isPositionFixed={true} />
+<Header isPositionFixed={true} />
 
-<div style="margin-top: {headerHeight}px">
+<div style="margin-top: {$headerHeightStore}px">
 	<MenuControl
 		bind:map={$mapStore}
 		position={'top-left'}

--- a/sites/geohub/src/routes/(map)/map/+layout.svelte
+++ b/sites/geohub/src/routes/(map)/map/+layout.svelte
@@ -2,28 +2,29 @@
 	import { browser } from '$app/environment';
 	import { beforeNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
-	import Content from '$components/pages/map/Content.svelte';
 	import Header from '$components/header/Header.svelte';
+	import Content from '$components/pages/map/Content.svelte';
 	import Notification from '$components/util/Notification.svelte';
 	import { fromLocalStorage, isStyleChanged, storageKeys, toLocalStorage } from '$lib/helper';
 	import type { DashboardMapStyle, Layer, SidebarPosition } from '$lib/types';
 	import {
+		HEADER_HEIGHT_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
+		SPRITEIMAGE_CONTEXT_KEY,
+		createHeaderHeightStore,
 		createMapStore,
-		layerList,
-		type SpriteImageStore,
 		createSpriteImageStore,
-		SPRITEIMAGE_CONTEXT_KEY
+		layerList,
+		type SpriteImageStore
 	} from '$stores';
 	import { MenuControl } from '@watergis/svelte-maplibre-menu';
 	import { SvelteToast } from '@zerodevx/svelte-toast';
 	import type { StyleSpecification } from 'maplibre-gl';
 	import { setContext } from 'svelte';
-	import { writable } from 'svelte/store';
 	import { fade } from 'svelte/transition';
 
-	let headerHeight = writable<number>(0);
-	setContext('header-height', headerHeight);
+	const headerHeightStore = createHeaderHeightStore();
+	setContext(HEADER_HEIGHT_CONTEXT_KEY, headerHeightStore);
 
 	const map = createMapStore();
 	setContext(MAPSTORE_CONTEXT_KEY, map);
@@ -41,7 +42,7 @@
 	let sideBarPosition: SidebarPosition = $page.data.config.SidebarPosition;
 	let sidebarOnLeft = sideBarPosition === 'left' ? true : false;
 
-	$: splitHeight = innerHeight - $headerHeight;
+	$: splitHeight = innerHeight - $headerHeightStore;
 
 	const layerListStorageKey = storageKeys.layerList($page.url.host);
 	const mapStyleStorageKey = storageKeys.mapStyle($page.url.host);
@@ -141,9 +142,9 @@
 
 <svelte:window bind:innerWidth bind:innerHeight />
 
-<Header bind:headerHeight={$headerHeight} isPositionFixed={true} />
+<Header isPositionFixed={true} />
 
-<div style="margin-top: {$headerHeight}px">
+<div style="margin-top: {$headerHeightStore}px">
 	<MenuControl
 		bind:map={$map}
 		position={sidebarOnLeft ? 'top-left' : 'top-right'}

--- a/sites/geohub/src/stores/headerHeight.ts
+++ b/sites/geohub/src/stores/headerHeight.ts
@@ -1,0 +1,9 @@
+import { writable, type Writable } from 'svelte/store';
+
+export const HEADER_HEIGHT_CONTEXT_KEY = 'header-height-store';
+
+export type HeaderHeightStore = Writable<number>;
+
+export const createHeaderHeightStore = () => {
+	return writable(<number>0);
+};

--- a/sites/geohub/src/stores/index.ts
+++ b/sites/geohub/src/stores/index.ts
@@ -6,3 +6,4 @@ export * from './numberOfClasses';
 export * from './colorMapName';
 export * from './classificationMethod';
 export * from './defaultColor';
+export * from './headerHeight';


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I found context key of `header-height` was hard coded, and now uses constant variables and function from stores folder across different pages.

setContext at +layout.svelte which uses Header component

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1249759009) by [Unito](https://www.unito.io)
