### PR TITLE
fix: comment out  extension

### DIFF
--- a/.changeset/brave-deers-speak.md
+++ b/.changeset/brave-deers-speak.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: remove non-necessary files

--- a/sites/geohub/src/lib/config/AppConfig/AcceptedExtensions.ts
+++ b/sites/geohub/src/lib/config/AppConfig/AcceptedExtensions.ts
@@ -46,8 +46,8 @@ export const AccepedExtensions: AcceptedExtension[] = [
 			'ain',
 			'aih',
 			'ixs',
-			'mxs',
-			'atx'
+			'mxs'
+			// 'atx'
 		],
 		href: 'https://gdal.org/drivers/vector/shapefile.html',
 		requiredExtensions: ['shp', 'prj', 'dbf', 'shx'],

--- a/sites/geohub/src/lib/config/AppConfig/AcceptedExtensions.ts
+++ b/sites/geohub/src/lib/config/AppConfig/AcceptedExtensions.ts
@@ -37,16 +37,16 @@ export const AccepedExtensions: AcceptedExtension[] = [
 			'shp',
 			'prj',
 			'dbf',
-			'shx',
-			'cpg',
-			'sbn',
-			'sbx',
-			'fbn',
-			'fbx',
-			'ain',
-			'aih',
-			'ixs',
-			'mxs'
+			'shx'
+			// 'cpg',
+			// 'sbn',
+			// 'sbx',
+			// 'fbn',
+			// 'fbx',
+			// 'ain',
+			// 'aih',
+			// 'ixs',
+			// 'mxs'
 			// 'atx'
 		],
 		href: 'https://gdal.org/drivers/vector/shapefile.html',

--- a/sites/geohub/src/routes/(app)/data/upload/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/upload/+page.svelte
@@ -297,7 +297,7 @@
 
 	const handleFilesSelect = async (e) => {
 		let { acceptedFiles, fileRejections } = e.detail;
-		if (fileRejections.length > 1 || acceptedFiles.length < 1) {
+		if (fileRejections.length > 1 && acceptedFiles.length < 1) {
 			errorMessages = [
 				...errorMessages,
 				'Some files could not be selected. Please ensure that the selected file has the correct extension.'


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Commented out `.atx` extension as it is not needed in geohub and it breaks the functionality of upload file geodatabase that have `.atx` extension
https://docs.fileformat.com/gis/atx/#:~:text=Format%20%2D%20More%20Information-,What%20is%20a%20ATX%20file%3F,attribute%20index%20created%20in%20ArcCatalog.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [ ] Code is up-to-date with the `develop` branch
* [ ] No build errors after `pnpm build`
* [ ] No lint errors after `pnpm lint`
* [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1252137900) by [Unito](https://www.unito.io)
