### PR TITLE
fix: show created_user correctly in dataset edit page

### DIFF
--- a/.changeset/eleven-beans-accept.md
+++ b/.changeset/eleven-beans-accept.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show created_user correctly in dataset edit page

--- a/sites/geohub/src/routes/(app)/data/[id]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/edit/+page.svelte
@@ -356,7 +356,7 @@
 		{#if !data.isNew}
 			<div class="pb-4">
 				<p>
-					This dataset was initially created by <b>{feature.properties.updated_user}</b> at
+					This dataset was initially created by <b>{feature.properties.created_user}</b> at
 					<b>
 						<Time timestamp={feature.properties.createdat} format="h:mm A, MMMM D, YYYY" />
 					</b>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Please describe what you changed briefly.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1252223066) by [Unito](https://www.unito.io)
