### PR TITLE
fix: fixed bug of default style edit page for raster unique value datasets

### DIFF
--- a/.changeset/wet-carpets-shake.md
+++ b/.changeset/wet-carpets-shake.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of default style edit page for raster unique value datasets

--- a/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
@@ -67,7 +67,9 @@
 	}
 
 	// let layerMean = Number(bandMetaStats['STATISTICS_MEAN'])
-	let percentile98 = metadata.stats[Object.keys(metadata.stats)[bandIndex]]['percentile_98'];
+	let percentile98 = !layerHasUniqueValues
+		? metadata.stats[Object.keys(metadata.stats)[bandIndex]]['percentile_98']
+		: 0;
 	let legendLabels = {};
 
 	// NOTE: As we are now using a default classification method, there is no need to determine the classification method,
@@ -86,6 +88,9 @@
 
 	if (layerHasUniqueValues) {
 		legendLabels = bandMetaStats['STATISTICS_UNIQUE_VALUES'];
+		if (typeof legendLabels === 'string') {
+			legendLabels = JSON.parse(legendLabels);
+		}
 		$numberOfClassesStore = Object.keys(legendLabels).length;
 	}
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2371

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1259628899) by [Unito](https://www.unito.io)
