### PR TITLE
fix: reset the state of visibility of hillshade layer when the basemap is changed

### DIFF
--- a/.changeset/flat-eagles-watch.md
+++ b/.changeset/flat-eagles-watch.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: keep state of hillshade layer visibility if basemap is changed

--- a/.changeset/flat-eagles-watch.md
+++ b/.changeset/flat-eagles-watch.md
@@ -2,4 +2,4 @@
 "geohub": patch
 ---
 
-fix: keep state of hillshade layer visibility if basemap is changed
+fix: reset state of hillshade layer visibility if basemap is changed

--- a/sites/geohub/src/components/pages/map/plugins/LayerVisibilitySwitcher.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/LayerVisibilitySwitcher.svelte
@@ -16,13 +16,10 @@
 	let isVisible = false;
 	let isLoading = false;
 
-	let isAerialStyle = false;
-
 	$: isVisible, setVisibility();
 
 	const setVisibility = () => {
 		if (!map?.isStyleLoaded()) return;
-		isAerialStyle = map.getStyle().sources['bing'] ? true : false;
 		if (isVisible) {
 			map.setLayoutProperty(target, 'visibility', 'visible');
 		} else {
@@ -47,16 +44,16 @@
 		}
 	};
 
-	map.on('styledata', function () {
-		if (!(map && map.loaded())) return;
-		const newStyle = map.getStyle().sources['bing'] ? true : false;
-		if (newStyle !== isAerialStyle) {
-			if (!isVisible) {
-				isVisible = true;
-			}
-			isAerialStyle = newStyle;
+	const handleStyleChanged = () => {
+		if (!map) return;
+
+		const currentVisibility = isLayerVisible();
+		if (currentVisibility !== isVisible) {
+			setVisibility();
 		}
-	});
+	};
+	map.on('sourcedata', handleStyleChanged);
+	map.on('styledata', handleStyleChanged);
 
 	let visiblilityButton: HTMLButtonElement;
 

--- a/sites/geohub/src/components/pages/map/plugins/LayerVisibilitySwitcher.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/LayerVisibilitySwitcher.svelte
@@ -49,7 +49,7 @@
 
 		const currentVisibility = isLayerVisible();
 		if (currentVisibility !== isVisible) {
-			setVisibility();
+			isVisible = currentVisibility;
 		}
 	};
 	map.on('sourcedata', handleStyleChanged);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

closes #2369

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
