### PR TITLE
fix: Updated menu plugin. Now xmark button on the map was moved into the top-right corner of sidebar container inside

### DIFF
--- a/.changeset/shaggy-poets-move.md
+++ b/.changeset/shaggy-poets-move.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: Updated menu plugin. Now xmark button on the map was moved into the top-right corner of sidebar container inside

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,8 +587,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(svelte@4.2.7)
       '@watergis/svelte-maplibre-menu':
-        specifier: ^2.1.1
-        version: 2.1.1(svelte@4.2.7)
+        specifier: ^2.1.2
+        version: 2.1.2(svelte@4.2.7)
       '@zerodevx/svelte-toast':
         specifier: ^0.9.5
         version: 0.9.5(svelte@4.2.7)
@@ -5739,8 +5739,8 @@ packages:
       svelte-fa: 3.0.4
     dev: false
 
-  /@watergis/svelte-maplibre-menu@2.1.1(svelte@4.2.7):
-    resolution: {integrity: sha512-tQQ//lmzBCeyhCXEkv3gK+OSrQ+dzsH/xQUCo5pfGyToCys07yjBpPLxDH2sYGUAKFYtcw3J4pnkj8LRZxMEqA==}
+  /@watergis/svelte-maplibre-menu@2.1.2(svelte@4.2.7):
+    resolution: {integrity: sha512-vE7pHmhdD4QjZBxqB70nzO9k+R6B5GZ6NhDq01pvfERWGSYfzWVTlweDoV2KWmUogAyMFVWREddFVc/kGeRteg==}
     peerDependencies:
       svelte: ^4.0.0
     dependencies:

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -63,7 +63,7 @@
 		"@watergis/legend-symbol": "^0.2.3",
 		"@watergis/maplibre-gl-export": "^3.0.1",
 		"@watergis/maplibre-gl-tour": "^1.0.2",
-		"@watergis/svelte-maplibre-menu": "^2.1.1",
+		"@watergis/svelte-maplibre-menu": "^2.1.2",
 		"@zerodevx/svelte-toast": "^0.9.5",
 		"bignumber.js": "^9.1.2",
 		"bulma": "^0.9.4",

--- a/sites/geohub/src/lib/config/AppConfig/TourOptions.ts
+++ b/sites/geohub/src/lib/config/AppConfig/TourOptions.ts
@@ -88,7 +88,7 @@ export const TourOptions: TourGuideOptions = {
 			content: `
             You can show or hide sidebar container by toggling this button.
             `,
-			target: '.maplibregl-ctrl-menu',
+			target: '.split-container .close-icon',
 			order: 9
 		},
 		{


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
because xmark button on the map has no clear relationship with sidebar closing, I updated menu plugin to move xmark button to inside the sidebar container.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1259853210) by [Unito](https://www.unito.io)
