### PR TITLE
fix: call `checkShapeFileValidity` in the correct place

### DIFF
--- a/.changeset/twelve-wasps-rescue.md
+++ b/.changeset/twelve-wasps-rescue.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: minor oversight

--- a/sites/geohub/src/routes/(app)/data/upload/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/upload/+page.svelte
@@ -39,7 +39,7 @@
 	$: showErrorMessages = errorMessages.length > 0;
 	$: uploadDisabled = Object.keys(shapefileValidityMapping).length > 0 || filesToUpload.length < 1;
 	$: selectedFilesList = JSON.stringify(filesToUpload.map((file) => file.name));
-	$: checkShapefileValidity(filesToUpload).then((result) => (shapefileValidityMapping = result));
+	// $: checkShapefileValidity(filesToUpload).then((result) => (shapefileValidityMapping = result));
 	$: userIsSignedIn = data.session;
 
 	onMount(() => {
@@ -207,6 +207,7 @@
 			const file = new File([content], `${key}`, { type: 'application/zip' });
 			shapefileZips = [...shapefileZips, file];
 		}
+		checkShapefileValidity(shapefileZips).then((result) => (shapefileValidityMapping = result));
 		files = [...nonShapefiles, ...shapefileZips];
 		shapefileZips = [];
 		return files;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Found I had called `checkShapefileValidity` in the wrong place.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1261173314) by [Unito](https://www.unito.io)
