### PR TITLE
fix: use bulma's help class in filesize warning

### DIFF
--- a/.changeset/clean-vans-drum.md
+++ b/.changeset/clean-vans-drum.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use bulma's `help` to show file size warning

--- a/sites/geohub/src/routes/(app)/data/upload/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/upload/+page.svelte
@@ -646,10 +646,12 @@
 									</div>
 									{#if file.size > FILE_SIZE_THRESHOLD}
 										<div class="mt-2">
-											<Notification type="warning" showCloseButton={true}>
-												Your uploaded file size ({filesize(file.size, { round: 1 })}) is large. You
-												can still can proceed uploading it, but it may take time to ingest.
-											</Notification>
+											<span class="help has-text-warning-dark">
+												<code class="has-text-warning-dark"
+													>{file.name} ({filesize(file.size, { round: 1 })})</code
+												> is too large. You can still can proceed uploading it, but it may take time
+												to ingest.
+											</span>
 										</div>
 									{/if}
 								</td>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
