### PR TITLE
fix: switch /maps/id page to CSR

### DIFF
--- a/.changeset/twenty-doors-admire.md
+++ b/.changeset/twenty-doors-admire.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: switch /maps/id page to CSR

--- a/sites/geohub/src/routes/(map)/maps/[id]/+page.ts
+++ b/sites/geohub/src/routes/(map)/maps/[id]/+page.ts
@@ -11,3 +11,6 @@ export const load: PageLoad = async ({ data }) => {
 		style
 	};
 };
+
+export const csr = true;
+export const ssr = false;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2453

I think #2453 was caused by we mix CSR and SSR in same line of endpoints

* /maps - CSR
* /maps/{id} - SSR
* /maps/{id}/edit - CSR

I guess SSR between CSR pages does not work in sveltekit in some reasons (not sure why). Hope at least this PR can fix issue in production (I could not confirm now because it is not reproducable in localhost).

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1264989257) by [Unito](https://www.unito.io)
