### PR TITLE
fix: hide sort button if only a layer is added

### DIFF
--- a/.changeset/funny-schools-jam.md
+++ b/.changeset/funny-schools-jam.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: hide sort button if only a layer is added

--- a/sites/geohub/src/components/pages/map/layers/LayerList.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerList.svelte
@@ -110,7 +110,7 @@
 		class="is-flex is-align-items-center layer-header px-2 pt-2"
 		bind:clientHeight={layerHeaderHeight}
 	>
-		<div class="layer-header-buttons">
+		<div class="layer-header-buttons buttons">
 			{#key $layerListStore}
 				<button
 					class="button has-tooltip-arrow has-tooltip-left"
@@ -146,7 +146,9 @@
 					</span>
 				</button>
 
-				<LayerOrderPanelButton />
+				{#if $layerListStore?.length > 1}
+					<LayerOrderPanelButton />
+				{/if}
 			{/key}
 		</div>
 	</div>
@@ -196,9 +198,6 @@
 
 		.layer-header-buttons {
 			margin-left: auto;
-			display: grid;
-			grid-template-columns: repeat(4, 1fr);
-			gap: 5px;
 			width: fit-content;
 
 			.delete-all-icon {

--- a/sites/geohub/src/components/util/PanelButton.svelte
+++ b/sites/geohub/src/components/util/PanelButton.svelte
@@ -51,7 +51,6 @@
 
 	.panel-control {
 		position: relative;
-		margin-left: 0.2rem;
 
 		.panel {
 			cursor: default;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2451

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1265788050) by [Unito](https://www.unito.io)
