### PR TITLE
fix: fixed bug of checking STAC asset item type.

### DIFF
--- a/.changeset/rotten-doors-call.md
+++ b/.changeset/rotten-doors-call.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of checking STAC asset item type. it is preferred to use `image/tiff; application=geotiff; profile=cloud-optimized` to check asset type, but we found some of COG from some STAC server, they don't put `profile=cloud-optimized`. So I removed profile from validation. There might be normal GeoTiff coming from STAC server, but we can assume all GeoTiffs are cloud optiomised GeoTiff from STAC.

--- a/packages/geohub-cli/src/util/StacManager.ts
+++ b/packages/geohub-cli/src/util/StacManager.ts
@@ -43,7 +43,10 @@ class StacManager {
 			const item = await this.getItem(itemLink.href);
 			if (!item) continue;
 			const assets = Object.values(item.assets).filter(
-				(asset) => asset.type === 'image/tiff; application=geotiff; profile=cloud-optimized'
+				// it is preferred to use `image/tiff; application=geotiff; profile=cloud-optimized` to check asset type,
+				// but we found some of COG from some STAC server, they don't put `profile=cloud-optimized`.
+				// So I removed profile from validation.
+				(asset) => asset.type?.indexOf('image/tiff; application=geotiff') !== -1
 			);
 			if (assets.length === 0) continue;
 

--- a/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
+++ b/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
@@ -109,7 +109,10 @@
 		const assets = feature.assets;
 		if (Object.keys(assets).length > 0) {
 			assetList = Object.keys(assets).filter(
-				(key) => assets[key].type === 'image/tiff; application=geotiff; profile=cloud-optimized'
+				// it is preferred to use `image/tiff; application=geotiff; profile=cloud-optimized` to check asset type,
+				// but we found some of COG from some STAC server, they don't put `profile=cloud-optimized`.
+				// So I removed profile from validation.
+				(key) => assets[key].type.indexOf('image/tiff; application=geotiff') !== -1
 			);
 			if (assetList.length === 1) {
 				selectedAsset = assetList[0];

--- a/sites/geohub/src/components/util/stac/StacCatalogItem.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogItem.svelte
@@ -385,7 +385,10 @@
 								{/if}
 								{#each Object.keys(itemFeature.assets) as assetName}
 									{@const asset = itemFeature.assets[assetName]}
-									{#if asset.type === 'image/tiff; application=geotiff; profile=cloud-optimized'}
+									<!-- it is preferred to use `image/tiff; application=geotiff; profile=cloud-optimized` to check asset type,
+									but we found some of COG from some STAC server, they don't put `profile=cloud-optimized`.
+									So I removed profile from validation. -->
+									{#if asset.type.indexOf('image/tiff; application=geotiff') !== -1}
 										<option value={assetName}>{asset.title ? asset.title : assetName}</option>
 									{/if}
 								{/each}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fix: fixed bug of checking STAC asset item type. it is preferred to use `image/tiff; application=geotiff; profile=cloud-optimized` to check asset type, but we found some of COG from some STAC server, they don't put `profile=cloud-optimized`. So I removed profile from validation. There might be normal GeoTiff coming from STAC server, but we can assume all GeoTiffs are cloud optiomised GeoTiff from STAC.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1266052152) by [Unito](https://www.unito.io)
