### PR TITLE
feat: made readonly legend more simple

### DIFF
--- a/.changeset/fair-ears-rhyme.md
+++ b/.changeset/fair-ears-rhyme.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+feat: made readonly legend more simple

--- a/sites/geohub/src/components/maplibre/circle/VectorCircle.svelte
+++ b/sites/geohub/src/components/maplibre/circle/VectorCircle.svelte
@@ -11,16 +11,20 @@
 	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 </script>
 
-<FieldControl title="Circle radius">
-	<div slot="help">Apply circle radius to the vector layer.</div>
-	<div slot="control">
-		<CircleRadius {layerId} bind:readonly={$legendReadonly} />
-	</div>
-</FieldControl>
+{#if !$legendReadonly}
+	<FieldControl title="Circle radius">
+		<div slot="help">Apply circle radius to the vector layer.</div>
+		<div slot="control">
+			<CircleRadius {layerId} bind:readonly={$legendReadonly} />
+		</div>
+	</FieldControl>
 
-<FieldControl title="Circle color">
-	<div slot="help">Change circle color by using single color or selected property.</div>
-	<div slot="control">
-		<CircleColor {layerId} {metadata} />
-	</div>
-</FieldControl>
+	<FieldControl title="Circle color">
+		<div slot="help">Change circle color by using single color or selected property.</div>
+		<div slot="control">
+			<CircleColor {layerId} {metadata} />
+		</div>
+	</FieldControl>
+{:else}
+	<CircleColor {layerId} {metadata} />
+{/if}

--- a/sites/geohub/src/components/maplibre/fill-extrusion/VectorFillExtrusion.svelte
+++ b/sites/geohub/src/components/maplibre/fill-extrusion/VectorFillExtrusion.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
 	import FieldControl from '$components/util/FieldControl.svelte';
 	import type { VectorTileMetadata } from '$lib/types';
+	import { LEGEND_READONLY_CONTEXT_KEY, type LegendReadonlyStore } from '$stores';
+	import { getContext } from 'svelte';
 	import FillExtrusionColor from './FillExtrusionColor.svelte';
+
+	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
 </script>
 
-<FieldControl title="3D polygon color">
-	<div slot="help">Change polygon fill color by using single color or selected property.</div>
-	<div slot="control">
-		<FillExtrusionColor {layerId} {metadata} />
-	</div>
-</FieldControl>
+{#if !$legendReadonly}
+	<FieldControl title="3D polygon color">
+		<div slot="help">Change polygon fill color by using single color or selected property.</div>
+		<div slot="control">
+			<FillExtrusionColor {layerId} {metadata} />
+		</div>
+	</FieldControl>
+{:else}
+	<FillExtrusionColor {layerId} {metadata} />
+{/if}

--- a/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
+++ b/sites/geohub/src/components/maplibre/fill/VectorPolygon.svelte
@@ -2,14 +2,22 @@
 	import FillColor from '$components/maplibre/fill/FillColor.svelte';
 	import FieldControl from '$components/util/FieldControl.svelte';
 	import type { VectorTileMetadata } from '$lib/types';
+	import { LEGEND_READONLY_CONTEXT_KEY, type LegendReadonlyStore } from '$stores';
+	import { getContext } from 'svelte';
+
+	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
 </script>
 
-<FieldControl title="Fill color">
-	<div slot="help">Change polygon fill color by using single color or selected property.</div>
-	<div slot="control">
-		<FillColor {layerId} {metadata} />
-	</div>
-</FieldControl>
+{#if !$legendReadonly}
+	<FieldControl title="Fill color">
+		<div slot="help">Change polygon fill color by using single color or selected property.</div>
+		<div slot="control">
+			<FillColor {layerId} {metadata} />
+		</div>
+	</FieldControl>
+{:else}
+	<FillColor {layerId} {metadata} />
+{/if}

--- a/sites/geohub/src/components/maplibre/line/VectorLine.svelte
+++ b/sites/geohub/src/components/maplibre/line/VectorLine.svelte
@@ -3,6 +3,10 @@
 	import LineWidth from '$components/maplibre/line/LineWidth.svelte';
 	import { handleEnterKey } from '$lib/helper';
 	import type { VectorTileMetadata } from '$lib/types';
+	import { LEGEND_READONLY_CONTEXT_KEY, type LegendReadonlyStore } from '$stores';
+	import { getContext } from 'svelte';
+
+	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 
 	export let layerId: string;
 	export let metadata: VectorTileMetadata;
@@ -20,34 +24,38 @@
 	let activeTab: string = tabs[0].label;
 </script>
 
-<div class="tabs is-centered is-toggle">
-	<ul>
-		{#each tabs as tab}
-			<li class={activeTab === tab.label ? 'is-active' : ''}>
-				<!-- svelte-ignore a11y-missing-attribute -->
-				<a
-					class="has-text-weight-bold tab"
-					role="tab"
-					tabindex="0"
-					data-sveltekit-preload-code="off"
-					data-sveltekit-preload-data="off"
-					on:click={() => {
-						activeTab = tab.label;
-					}}
-					on:keydown={handleEnterKey}
-				>
-					<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
-					<span class="is-capitalized">{tab.label}</span>
-				</a>
-			</li>
-		{/each}
-	</ul>
-</div>
+{#if !$legendReadonly}
+	<div class="tabs is-centered is-toggle">
+		<ul>
+			{#each tabs as tab}
+				<li class={activeTab === tab.label ? 'is-active' : ''}>
+					<!-- svelte-ignore a11y-missing-attribute -->
+					<a
+						class="has-text-weight-bold tab"
+						role="tab"
+						tabindex="0"
+						data-sveltekit-preload-code="off"
+						data-sveltekit-preload-data="off"
+						on:click={() => {
+							activeTab = tab.label;
+						}}
+						on:keydown={handleEnterKey}
+					>
+						<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
+						<span class="is-capitalized">{tab.label}</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</div>
 
-<div hidden={activeTab !== tabs[0].label}>
+	<div hidden={activeTab !== tabs[0].label}>
+		<LineColor {layerId} {metadata} />
+	</div>
+
+	<div hidden={activeTab !== tabs[1].label}>
+		<LineWidth {layerId} {metadata} />
+	</div>
+{:else}
 	<LineColor {layerId} {metadata} />
-</div>
-
-<div hidden={activeTab !== tabs[1].label}>
-	<LineWidth {layerId} {metadata} />
-</div>
+{/if}

--- a/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
@@ -140,15 +140,31 @@
 				<p style="max-width: 300px;">
 					This layer is true color dataset. You can adjust parameters to render from the button.
 				</p>
+			{:else if $legendReadonly}
+				<p style="width: 100%">
+					<ColorMapPicker
+						bind:colorMapName={$colorMapNameStore}
+						on:colorMapChanged={handleColorMapChanged}
+						isFullWidth={true}
+					/>
+					{#if $rescaleStore?.length > 1}
+						<div class="is-flex">
+							<span class="has-text-weight-bold is-size-6">{$rescaleStore[0].toFixed(2)}</span>
+							{#if unit}
+								<span class="unit align-center has-text-weight-bold is-size-5">{unit}</span>
+							{/if}
+							<span class="align-right has-text-weight-bold is-size-6"
+								>{$rescaleStore[1].toFixed(2)}</span
+							>
+						</div>
+					{/if}
+				</p>
 			{:else}
 				<FieldControl title="Colormap">
 					<div slot="help">Apply a colormap to classify legend</div>
 					<div slot="control">
 						<div class="field has-addons">
-							<p
-								class="control"
-								style="width: {$legendReadonly ? '100%' : `${colormapPickerWidth}px`}"
-							>
+							<p class="control" style="width: {colormapPickerWidth}px">
 								<ColorMapPicker
 									bind:colorMapName={$colorMapNameStore}
 									on:colorMapChanged={handleColorMapChanged}
@@ -180,6 +196,8 @@
 					</div>
 				</FieldControl>
 			{/if}
+		{:else if $legendReadonly}
+			<RasterClassifyLegend bind:layerId bind:metadata bind:manualClassificationEnabled />
 		{:else}
 			<FieldControl title="Colormap">
 				<div slot="help">Apply a colormap to classify legend</div>

--- a/sites/geohub/src/components/maplibre/symbol/VectorSymbol.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/VectorSymbol.svelte
@@ -30,53 +30,57 @@
 	let activeTab: string = tabs[0].label;
 </script>
 
-<div class="tabs is-centered is-toggle">
-	<ul>
-		{#each tabs as tab}
-			<li class={activeTab === tab.label ? 'is-active' : ''}>
-				<!-- svelte-ignore a11y-missing-attribute -->
-				<a
-					class="has-text-weight-bold"
-					role="tab"
-					tabindex="0"
-					data-sveltekit-preload-code="off"
-					data-sveltekit-preload-data="off"
-					on:click={() => {
-						activeTab = tab.label;
-					}}
-					on:keydown={handleEnterKey}
-				>
-					<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
-					<span class="is-capitalized">{tab.label}</span>
-				</a>
-			</li>
-		{/each}
-	</ul>
-</div>
+{#if !$legendReadonly}
+	<div class="tabs is-centered is-toggle">
+		<ul>
+			{#each tabs as tab}
+				<li class={activeTab === tab.label ? 'is-active' : ''}>
+					<!-- svelte-ignore a11y-missing-attribute -->
+					<a
+						class="has-text-weight-bold"
+						role="tab"
+						tabindex="0"
+						data-sveltekit-preload-code="off"
+						data-sveltekit-preload-data="off"
+						on:click={() => {
+							activeTab = tab.label;
+						}}
+						on:keydown={handleEnterKey}
+					>
+						<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
+						<span class="is-capitalized">{tab.label}</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</div>
 
-<div hidden={activeTab !== tabs[0].label}>
-	<FieldControl title="Icon">
-		<div slot="help">Change icon for a vector layer.</div>
-		<div slot="control">
-			<IconImage {layerId} bind:readonly={$legendReadonly} />
-		</div>
-	</FieldControl>
-</div>
+	<div hidden={activeTab !== tabs[0].label}>
+		<FieldControl title="Icon">
+			<div slot="help">Change icon for a vector layer.</div>
+			<div slot="control">
+				<IconImage {layerId} bind:readonly={$legendReadonly} />
+			</div>
+		</FieldControl>
+	</div>
 
-<div hidden={activeTab !== tabs[1].label}>
-	<FieldControl title="Icon color">
-		<div slot="help">Change icon color by using single color or selected property.</div>
-		<div slot="control">
-			<IconColor {layerId} {metadata} />
-		</div>
-	</FieldControl>
-</div>
+	<div hidden={activeTab !== tabs[1].label}>
+		<FieldControl title="Icon color">
+			<div slot="help">Change icon color by using single color or selected property.</div>
+			<div slot="control">
+				<IconColor {layerId} {metadata} />
+			</div>
+		</FieldControl>
+	</div>
 
-<div hidden={activeTab !== tabs[2].label}>
-	<FieldControl title="Icon size">
-		<div slot="help">Change icon color by using single color or selected property.</div>
-		<div slot="control">
-			<IconSize {layerId} {metadata} />
-		</div>
-	</FieldControl>
-</div>
+	<div hidden={activeTab !== tabs[2].label}>
+		<FieldControl title="Icon size">
+			<div slot="help">Change icon color by using single color or selected property.</div>
+			<div slot="control">
+				<IconSize {layerId} {metadata} />
+			</div>
+		</FieldControl>
+	</div>
+{:else}
+	<IconColor {layerId} {metadata} />
+{/if}

--- a/sites/geohub/src/components/pages/map/layers/SimpleLayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/SimpleLayerTemplate.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { clean } from '$lib/helper';
+	import type { Layer } from '$lib/types';
+	import VisibilityButton from './header/VisibilityButton.svelte';
+
+	export let layer: Layer;
+</script>
+
+<article class="layer is-flex is-flex-direction-column border is-small">
+	<div class="header is-flex pl-2 py-4">
+		<div class="layer-header is-flex is-align-items-center pr-2">
+			<slot name="legend" />
+			<span class="layer-name has-text-weight-bold is-size-6 pl-1">
+				{clean(layer.name)}
+			</span>
+		</div>
+
+		<div class="is-flex is-align-items-center">
+			<VisibilityButton {layer} />
+		</div>
+	</div>
+	<div class="has-text-dark pb-2">
+		<slot name="content" />
+	</div>
+</article>
+
+<style lang="scss">
+	.border {
+		border-bottom: 1px #7a7a7a solid;
+	}
+
+	.layer {
+		width: 300px;
+
+		.header {
+			max-height: 60px;
+			.layer-header {
+				width: 100%;
+
+				.layer-name {
+					align-items: center;
+
+					overflow: hidden;
+					display: -webkit-box;
+					-webkit-box-orient: vertical;
+					-webkit-line-clamp: 2;
+				}
+			}
+		}
+	}
+</style>

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
@@ -22,6 +22,7 @@
 		type LegendReadonlyStore
 	} from '$stores';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
+	import SimpleLayerTemplate from '../SimpleLayerTemplate.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -80,26 +81,33 @@
 	};
 </script>
 
-<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
-	{#if !$legendReadonly}
+{#if !$legendReadonly}
+	<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
 		<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
-	{/if}
 
-	<div class="panel-content px-2 pb-2">
-		<div hidden={activeTab !== TabNames.LEGEND}>
+		<div class="panel-content px-2 pb-2">
+			<div hidden={activeTab !== TabNames.LEGEND}>
+				<RasterLegend
+					bind:layerId={layer.id}
+					bind:metadata={layer.info}
+					bind:tags={layer.dataset.properties.tags}
+				/>
+			</div>
+			{#if !$legendReadonly && !isRgbTile}
+				<div hidden={activeTab !== TabNames.TRANSFORM}>
+					<RasterTransform bind:layer />
+				</div>
+			{/if}
+		</div>
+	</LayerTemplate>
+{:else}
+	<SimpleLayerTemplate {layer}>
+		<div class="panel-content px-2 pb-2" slot="content">
 			<RasterLegend
 				bind:layerId={layer.id}
 				bind:metadata={layer.info}
 				bind:tags={layer.dataset.properties.tags}
 			/>
 		</div>
-		{#if !$legendReadonly && !isRgbTile}
-			<div hidden={activeTab !== TabNames.TRANSFORM}>
-				<RasterTransform bind:layer />
-			</div>
-		{/if}
-	</div>
-</LayerTemplate>
-
-<style lang="scss">
-</style>
+	</SimpleLayerTemplate>
+{/if}

--- a/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
@@ -105,9 +105,6 @@
 	use:draggable={dragOptions}
 >
 	<h2 class="header-title subtitle has-background-light p-2 mb-0">
-		<span class="icon">
-			<i class="fa-solid fa-arrows-up-down-left-right"></i>
-		</span>
 		<span> Legend </span>
 
 		<button
@@ -157,8 +154,8 @@
 
 			.close-button {
 				position: absolute;
-				top: 10px;
-				right: 10px;
+				top: 5px;
+				right: 5px;
 			}
 		}
 
@@ -166,7 +163,7 @@
 			width: fit-content;
 			min-width: 200px;
 			max-width: 350px;
-			max-height: 350px;
+			max-height: 60vh;
 			overflow-y: auto;
 			overflow-x: hidden;
 		}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description


* made readonly legend more simple
* removed accordion from readonly legend
* if not classified legend, just show legend icon before layer name

![](https://github.com/UNDP-Data/geohub/assets/2639701/803defb5-2e5e-41a6-8816-643c402740f6)

![](https://github.com/UNDP-Data/geohub/assets/2639701/8525bc9a-36d8-420f-83e0-b709a433394b)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1267401152) by [Unito](https://www.unito.io)
