### PR TITLE
refactor: removed unused colorMapNameLabel property from layer class

### DIFF
--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -19,7 +19,6 @@
 	import {
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
 		COLORMAP_NAME_CONTEXT_KEY,
-		COLORMAP_NAME_CONTEXT_KEY_LABEL,
 		DEFAULTCOLOR_CONTEXT_KEY,
 		DEFAULTCOLOR_CONTEXT_KEY_LABEL,
 		LAYERLISTSTORE_CONTEXT_KEY,
@@ -58,14 +57,6 @@
 	setContext(COLORMAP_NAME_CONTEXT_KEY, colorMapNameStore);
 	colorMapNameStore.subscribe((value) => {
 		layerListStore.setColorMapName(layer.id, value);
-	});
-
-	// colormap for label
-	const colorMapNameStoreLabel = createColorMapNameStore();
-	$colorMapNameStoreLabel = layer.colorMapNameLabel ?? getRandomColormap();
-	setContext(COLORMAP_NAME_CONTEXT_KEY_LABEL, colorMapNameStoreLabel);
-	colorMapNameStoreLabel.subscribe((value) => {
-		layerListStore.setColorMapNameLabel(layer.id, value);
 	});
 
 	const classificationMethod = createClassificationMethodStore();

--- a/sites/geohub/src/lib/types/Layer.ts
+++ b/sites/geohub/src/lib/types/Layer.ts
@@ -11,7 +11,6 @@ export interface Layer {
 	parentId?: string;
 	dataset?: DatasetFeature;
 	colorMapName?: string;
-	colorMapNameLabel?: string;
 	classificationMethod?: ClassificationMethodTypes;
 	activeTab?: TabNames;
 	isExpanded?: boolean;

--- a/sites/geohub/src/stores/layerList.ts
+++ b/sites/geohub/src/stores/layerList.ts
@@ -20,16 +20,6 @@ export function createLayerListStore() {
 		});
 	};
 
-	const setColorMapNameLabel = (layerId: string, colorMapName: string) => {
-		update((state) => {
-			const layer = state.find((l) => l.id === layerId);
-			if (layer) {
-				layer.colorMapNameLabel = colorMapName;
-			}
-			return state;
-		});
-	};
-
 	const setClassificationMethod = (
 		layerId: string,
 		classificationMethod: ClassificationMethodTypes
@@ -68,7 +58,6 @@ export function createLayerListStore() {
 		update,
 		set,
 		setColorMapName,
-		setColorMapNameLabel,
 		setClassificationMethod,
 		setActiveTab,
 		setIsExpanded


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I found there is an unused property in layer interface

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1267455404) by [Unito](https://www.unito.io)
