### PR TITLE
fix: fixed bug of tabs not changing. removed nested slot of accordion from LayerTemplate

### DIFF
--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Accordion from '$components/util/Accordion.svelte';
 	import { AccessLevel } from '$lib/config/AppConfig';
 	import { clean, getAccessLevelIcon, getLayerStyle, handleEnterKey, initTippy } from '$lib/helper';
 	import type { Layer, RasterTileMetadata, VectorTileMetadata } from '$lib/types';
@@ -122,36 +121,51 @@
 	};
 </script>
 
-<Accordion bind:isExpanded size="medium">
-	<div slot="header">
-		{#if accessIcon}
-			<i class="{accessIcon} fa-2xl px-2" />
-		{/if}
-
-		<span class="layer-name has-text-weight-bold is-size-6 pl-1">
-			{clean(layer.name)}
-		</span>
-	</div>
-	<div slot="header-menu" class="is-flex is-align-items-center">
-		<VisibilityButton {layer} />
-
-		{#if !$legendReadonly}
-			<div class="dropdown-trigger">
-				<button
-					class="button menu-button menu-button-{layer.id}"
-					use:tippy={{ content: tooltipContent }}
-				>
-					<span class="icon is-small">
-						<i class="fas fa-ellipsis-vertical fa-xl" aria-hidden="true"></i>
-					</span>
-				</button>
+<article class="is-flex is-flex-direction-column border">
+	<div class="header is-flex pl-2 py-4">
+		<div
+			class="layer-header is-flex is-align-items-center pr-2"
+			role="button"
+			tabindex="0"
+			on:keydown={handleEnterKey}
+			on:click={() => {
+				isExpanded = !isExpanded;
+			}}
+		>
+			<div class="toggle-button icon has-text-primary mr-3">
+				<i class="fa-solid fa-chevron-{isExpanded ? 'up' : 'down'} fa-xl"></i>
 			</div>
-		{/if}
+
+			{#if accessIcon}
+				<i class="{accessIcon} fa-2xl px-2" />
+			{/if}
+
+			<span class="layer-name has-text-weight-bold is-size-6 pl-1">
+				{clean(layer.name)}
+			</span>
+		</div>
+
+		<div class="is-flex is-align-items-center">
+			<VisibilityButton {layer} />
+
+			{#if !$legendReadonly}
+				<div class="dropdown-trigger">
+					<button
+						class="button menu-button menu-button-{layer.id}"
+						use:tippy={{ content: tooltipContent }}
+					>
+						<span class="icon is-small">
+							<i class="fas fa-ellipsis-vertical fa-xl" aria-hidden="true"></i>
+						</span>
+					</button>
+				</div>
+			{/if}
+		</div>
 	</div>
-	<div slot="content">
+	<div class="has-text-dark pb-2" hidden={!isExpanded}>
 		<slot />
 	</div>
-</Accordion>
+</article>
 
 {#if !$legendReadonly}
 	<div role="menu" bind:this={tooltipContent}>
@@ -223,9 +237,18 @@
 		border-bottom: 1px #7a7a7a solid;
 	}
 
-	.menu-button {
+	.menu-button,
+	.toggle-button {
 		border: none;
 		background: transparent;
+	}
+
+	.header {
+		max-height: 60px;
+		.layer-header {
+			cursor: pointer;
+			width: 100%;
+		}
 	}
 
 	.layer-name {

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
@@ -11,18 +11,15 @@
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
 		COLORMAP_NAME_CONTEXT_KEY,
 		LAYERLISTSTORE_CONTEXT_KEY,
-		LEGEND_READONLY_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY,
 		RASTERRESCALE_CONTEXT_KEY,
 		createClassificationMethodStore,
 		createColorMapNameStore,
 		createNumberOfClassesStore,
 		createRasterRescaleStore,
-		type LayerListStore,
-		type LegendReadonlyStore
+		type LayerListStore
 	} from '$stores';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
-	import SimpleLayerTemplate from '../SimpleLayerTemplate.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -30,7 +27,6 @@
 	export let isExpanded: boolean;
 
 	const layerListStore: LayerListStore = getContext(LAYERLISTSTORE_CONTEXT_KEY);
-	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 
 	const rescaleStore = createRasterRescaleStore();
 	setContext(RASTERRESCALE_CONTEXT_KEY, rescaleStore);
@@ -81,33 +77,21 @@
 	};
 </script>
 
-{#if !$legendReadonly}
-	<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
-		<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
+<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
+	<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
 
-		<div class="panel-content px-2 pb-2">
-			<div hidden={activeTab !== TabNames.LEGEND}>
-				<RasterLegend
-					bind:layerId={layer.id}
-					bind:metadata={layer.info}
-					bind:tags={layer.dataset.properties.tags}
-				/>
-			</div>
-			{#if !$legendReadonly && !isRgbTile}
-				<div hidden={activeTab !== TabNames.TRANSFORM}>
-					<RasterTransform bind:layer />
-				</div>
-			{/if}
-		</div>
-	</LayerTemplate>
-{:else}
-	<SimpleLayerTemplate {layer}>
-		<div class="panel-content px-2 pb-2" slot="content">
+	<div class="panel-content px-2 pb-2">
+		<div hidden={activeTab !== TabNames.LEGEND}>
 			<RasterLegend
 				bind:layerId={layer.id}
 				bind:metadata={layer.info}
 				bind:tags={layer.dataset.properties.tags}
 			/>
 		</div>
-	</SimpleLayerTemplate>
-{/if}
+		{#if !isRgbTile}
+			<div hidden={activeTab !== TabNames.TRANSFORM}>
+				<RasterTransform bind:layer />
+			</div>
+		{/if}
+	</div>
+</LayerTemplate>

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterSimpleLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterSimpleLayer.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import RasterLegend from '$components/maplibre/raster/RasterLegend.svelte';
+	import { getRandomColormap } from '$lib/helper';
+	import type { Layer } from '$lib/types';
+	import {
+		CLASSIFICATION_METHOD_CONTEXT_KEY,
+		COLORMAP_NAME_CONTEXT_KEY,
+		NUMBER_OF_CLASSES_CONTEXT_KEY,
+		RASTERRESCALE_CONTEXT_KEY,
+		createClassificationMethodStore,
+		createColorMapNameStore,
+		createNumberOfClassesStore,
+		createRasterRescaleStore
+	} from '$stores';
+	import { setContext } from 'svelte';
+	import SimpleLayerTemplate from '../SimpleLayerTemplate.svelte';
+
+	export let layer: Layer;
+
+	const rescaleStore = createRasterRescaleStore();
+	setContext(RASTERRESCALE_CONTEXT_KEY, rescaleStore);
+
+	const numberOfClassesStore = createNumberOfClassesStore();
+	$numberOfClassesStore = $page.data.config.NumberOfClasses;
+	setContext(NUMBER_OF_CLASSES_CONTEXT_KEY, numberOfClassesStore);
+
+	const colorMapNameStore = createColorMapNameStore();
+	$colorMapNameStore = layer.colorMapName ?? getRandomColormap();
+	setContext(COLORMAP_NAME_CONTEXT_KEY, colorMapNameStore);
+
+	const classificationMethod = createClassificationMethodStore();
+	$classificationMethod = layer.classificationMethod ?? $page.data.config.ClassificationMethod;
+	setContext(CLASSIFICATION_METHOD_CONTEXT_KEY, classificationMethod);
+</script>
+
+<SimpleLayerTemplate {layer}>
+	<div class="panel-content px-2 pb-2" slot="content">
+		<RasterLegend
+			bind:layerId={layer.id}
+			bind:metadata={layer.info}
+			bind:tags={layer.dataset.properties.tags}
+		/>
+	</div>
+</SimpleLayerTemplate>

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -2,19 +2,12 @@
 	import { page } from '$app/stores';
 	import VectorLegend from '$components/maplibre/vector/VectorLegend.svelte';
 	import LayerTemplate from '$components/pages/map/layers/LayerTemplate.svelte';
-	import SimpleLayerTemplate from '$components/pages/map/layers/SimpleLayerTemplate.svelte';
 	import VectorFilter from '$components/pages/map/layers/vector/VectorFilter.svelte';
 	import VectorLabelPanel from '$components/pages/map/layers/vector/VectorLabelPanel.svelte';
 	import VectorParamsPanel from '$components/pages/map/layers/vector/VectorParamsPanel.svelte';
 	import Tabs from '$components/util/Tabs.svelte';
 	import { TabNames } from '$lib/config/AppConfig';
-	import {
-		getLayerStyle,
-		getRandomColormap,
-		loadMap,
-		storageKeys,
-		toLocalStorage
-	} from '$lib/helper';
+	import { getRandomColormap, loadMap, storageKeys, toLocalStorage } from '$lib/helper';
 	import type { Layer, VectorTileMetadata } from '$lib/types';
 	import {
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
@@ -23,7 +16,6 @@
 		DEFAULTCOLOR_CONTEXT_KEY,
 		DEFAULTCOLOR_CONTEXT_KEY_LABEL,
 		LAYERLISTSTORE_CONTEXT_KEY,
-		LEGEND_READONLY_CONTEXT_KEY,
 		MAPSTORE_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY,
 		NUMBER_OF_CLASSES_CONTEXT_KEY_2,
@@ -33,16 +25,13 @@
 		createDefaultColorStore,
 		createNumberOfClassesStore,
 		type LayerListStore,
-		type LegendReadonlyStore,
 		type MapStore
 	} from '$stores';
 	import { Loader } from '@undp-data/svelte-undp-design';
 	import { createEventDispatcher, getContext, setContext } from 'svelte';
-	import Legend from '../header/Legend.svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 	const layerListStore: LayerListStore = getContext(LAYERLISTSTORE_CONTEXT_KEY);
-	const legendReadonly: LegendReadonlyStore = getContext(LEGEND_READONLY_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
@@ -50,7 +39,6 @@
 	export let isExpanded: boolean;
 
 	let metadata = layer.info as VectorTileMetadata;
-	let isSimpleLegend = true;
 
 	// colormap for geometry
 	const colorMapNameStore = createColorMapNameStore();
@@ -140,52 +128,32 @@
 	};
 </script>
 
-{#if !$legendReadonly}
-	<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
-		{#await init()}
-			<div class="loader-container">
-				<Loader size="small" />
-			</div>
-		{:then}
-			{#if !$legendReadonly}
-				<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
-			{/if}
+<LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged}>
+	{#await init()}
+		<div class="loader-container">
+			<Loader size="small" />
+		</div>
+	{:then}
+		<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
 
-			<div class="panel-content px-2 pb-2">
-				<div hidden={activeTab !== TabNames.LEGEND}>
-					<VectorLegend bind:layerId={layer.id} bind:metadata />
-				</div>
-				{#if !$legendReadonly}
-					<div hidden={activeTab !== TabNames.FILTER}>
-						<VectorFilter {layer} />
-					</div>
-					<div hidden={activeTab !== TabNames.LABEL}>
-						<VectorLabelPanel {layer} bind:metadata />
-					</div>
-					{#if isFunctionLayer}
-						<div hidden={activeTab !== TabNames.SIMULATION}>
-							<VectorParamsPanel layerId={layer.id} />
-						</div>
-					{/if}
-				{/if}
+		<div class="panel-content px-2 pb-2">
+			<div hidden={activeTab !== TabNames.LEGEND}>
+				<VectorLegend bind:layerId={layer.id} bind:metadata />
 			</div>
-		{/await}
-	</LayerTemplate>
-{:else}
-	{@const layerStyle = getLayerStyle($map, layer.id)}
-	<SimpleLayerTemplate {layer}>
-		<div slot="legend">
-			<Legend layer={layerStyle} bind:isSimpleLegend />
-		</div>
-		<div slot="content">
-			{#if !isSimpleLegend}
-				<div class="panel-content px-2 pb-2">
-					<VectorLegend bind:layerId={layer.id} bind:metadata />
+			<div hidden={activeTab !== TabNames.FILTER}>
+				<VectorFilter {layer} />
+			</div>
+			<div hidden={activeTab !== TabNames.LABEL}>
+				<VectorLabelPanel {layer} bind:metadata />
+			</div>
+			{#if isFunctionLayer}
+				<div hidden={activeTab !== TabNames.SIMULATION}>
+					<VectorParamsPanel layerId={layer.id} />
 				</div>
 			{/if}
 		</div>
-	</SimpleLayerTemplate>
-{/if}
+	{/await}
+</LayerTemplate>
 
 <style lang="scss">
 	.loader-container {

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorSimpleLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorSimpleLayer.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import VectorLegend from '$components/maplibre/vector/VectorLegend.svelte';
+	import SimpleLayerTemplate from '$components/pages/map/layers/SimpleLayerTemplate.svelte';
+	import { getLayerStyle, getRandomColormap } from '$lib/helper';
+	import type { Layer, VectorTileMetadata } from '$lib/types';
+	import {
+		CLASSIFICATION_METHOD_CONTEXT_KEY,
+		COLORMAP_NAME_CONTEXT_KEY,
+		COLORMAP_NAME_CONTEXT_KEY_LABEL,
+		DEFAULTCOLOR_CONTEXT_KEY,
+		DEFAULTCOLOR_CONTEXT_KEY_LABEL,
+		MAPSTORE_CONTEXT_KEY,
+		NUMBER_OF_CLASSES_CONTEXT_KEY,
+		NUMBER_OF_CLASSES_CONTEXT_KEY_2,
+		NUMBER_OF_CLASSES_CONTEXT_KEY_LABEL,
+		createClassificationMethodStore,
+		createColorMapNameStore,
+		createDefaultColorStore,
+		createNumberOfClassesStore,
+		type MapStore
+	} from '$stores';
+	import { getContext, setContext } from 'svelte';
+	import Legend from '../header/Legend.svelte';
+
+	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+
+	export let layer: Layer;
+
+	const layerStyle = getLayerStyle($map, layer.id);
+
+	let metadata = layer.info as VectorTileMetadata;
+	let isSimpleLegend = true;
+
+	// colormap for geometry
+	const colorMapNameStore = createColorMapNameStore();
+	$colorMapNameStore = layer.colorMapName ?? getRandomColormap();
+	setContext(COLORMAP_NAME_CONTEXT_KEY, colorMapNameStore);
+
+	// colormap for label
+	const colorMapNameStoreLabel = createColorMapNameStore();
+	$colorMapNameStoreLabel = layer.colorMapNameLabel ?? getRandomColormap();
+	setContext(COLORMAP_NAME_CONTEXT_KEY_LABEL, colorMapNameStoreLabel);
+
+	const classificationMethod = createClassificationMethodStore();
+	$classificationMethod = layer.classificationMethod ?? $page.data.config.ClassificationMethod;
+	setContext(CLASSIFICATION_METHOD_CONTEXT_KEY, classificationMethod);
+
+	// for color
+	const numberOfClassesStore = createNumberOfClassesStore();
+	$numberOfClassesStore = $page.data.config.NumberOfClasses;
+	setContext(NUMBER_OF_CLASSES_CONTEXT_KEY, numberOfClassesStore);
+
+	// for size/width
+	const numberOfClassesStore2 = createNumberOfClassesStore();
+	$numberOfClassesStore2 = $page.data.config.NumberOfClasses;
+	setContext(NUMBER_OF_CLASSES_CONTEXT_KEY_2, numberOfClassesStore2);
+
+	// for label
+	const numberOfClassesStoreLabel = createNumberOfClassesStore();
+	$numberOfClassesStoreLabel = $page.data.config.NumberOfClasses;
+	setContext(NUMBER_OF_CLASSES_CONTEXT_KEY_LABEL, numberOfClassesStoreLabel);
+
+	// for style color
+	const defaultColorStore = createDefaultColorStore();
+	setContext(DEFAULTCOLOR_CONTEXT_KEY, defaultColorStore);
+
+	// for label color
+	const defaultColorStoreLabel = createDefaultColorStore();
+	setContext(DEFAULTCOLOR_CONTEXT_KEY_LABEL, defaultColorStoreLabel);
+</script>
+
+<SimpleLayerTemplate {layer}>
+	<div slot="legend">
+		<Legend layer={layerStyle} bind:isSimpleLegend />
+	</div>
+	<div slot="content">
+		{#if !isSimpleLegend}
+			<div class="panel-content px-2 pb-2">
+				<VectorLegend bind:layerId={layer.id} bind:metadata />
+			</div>
+		{/if}
+	</div>
+</SimpleLayerTemplate>
+
+<style lang="scss">
+</style>

--- a/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
@@ -49,11 +49,11 @@
 </script>
 
 <script lang="ts">
+	import RasterSimpleLayer from '$components/pages/map/layers/raster/RasterSimpleLayer.svelte';
+	import VectorSimpleLayer from '$components/pages/map/layers/vector/VectorSimpleLayer.svelte';
 	import { getLayerStyle } from '$lib/helper';
 	import { draggable, type DragOptions } from '@neodrag/svelte';
 	import { Loader } from '@undp-data/svelte-undp-design';
-	import RasterLayer from '../layers/raster/RasterLayer.svelte';
-	import VectorLayer from '../layers/vector/VectorLayer.svelte';
 
 	export let map: Map;
 	export let layerList: LayerListStore;
@@ -121,9 +121,9 @@
 				{@const type = getLayerStyle(map, layer.id)?.type}
 				{#if type}
 					{#if type === 'raster'}
-						<RasterLayer {layer} bind:isExpanded={layer.isExpanded} />
+						<RasterSimpleLayer {layer} />
 					{:else}
-						<VectorLayer {layer} bind:isExpanded={layer.isExpanded} />
+						<VectorSimpleLayer {layer} />
 					{/if}
 				{/if}
 			{/each}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2507

I created an Accordion component under util to enable changing icon size, but this affected reactivity of changing tabs. Thus, I removed this Accordion component from LayerTemplate.

Looks like nested slots sometimes lose reactivity in some cases (not sure exactly why this does not work)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1267594033) by [Unito](https://www.unito.io)
