### PR TITLE
fix:  property contains multiple bboxes for some collection, use max …

### DIFF
--- a/.changeset/giant-apples-float.md
+++ b/.changeset/giant-apples-float.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: `extent.spatial.bbox` property contains multiple bboxes for some collection, use max extent combined from all extents in stac api explorer.

--- a/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
+++ b/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
@@ -122,7 +122,7 @@
 		}
 
 		await stacInstance.getStacCollection();
-		const extent = stacInstance.stacCollection.extent.spatial.bbox[0];
+		const extent = stacInstance.getMaxExtent();
 		const lng = center[0];
 		const lat = center[1];
 		if (!(lng > extent[0] && lng < extent[2] && lat > extent[1] && lat < extent[3])) {

--- a/sites/geohub/src/lib/stac/EarthSearchStac.ts
+++ b/sites/geohub/src/lib/stac/EarthSearchStac.ts
@@ -178,7 +178,7 @@ export default class EarthSearchStac implements StacTemplate {
 		const providers: Tag[] = this.stacCollection.providers?.map((p) => {
 			return { key: 'provider', value: p.name };
 		});
-		const bbox = this.stacCollection.extent.spatial.bbox[0];
+		const bbox = this.getMaxExtent();
 
 		const collectionUrl = this.stacCollection.links.find((l) => l.rel === 'items').href;
 
@@ -214,5 +214,29 @@ export default class EarthSearchStac implements StacTemplate {
 			}
 		};
 		return feature;
+	};
+
+	public getMaxExtent = () => {
+		const bboxes = this.stacCollection.extent.spatial.bbox;
+		let minx: number;
+		let miny: number;
+		let maxx: number;
+		let maxy: number;
+		bboxes.forEach((bbox) => {
+			if (!minx || bbox[0] < minx) {
+				minx = bbox[0];
+			}
+			if (!miny || bbox[1] < miny) {
+				miny = bbox[1];
+			}
+			if (!maxx || bbox[2] > maxx) {
+				maxx = bbox[2];
+			}
+			if (!maxy || bbox[3] > maxy) {
+				maxy = bbox[3];
+			}
+		});
+
+		return [minx, miny, maxx, maxy];
 	};
 }

--- a/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
+++ b/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
@@ -268,7 +268,8 @@ export default class MicrosoftPlanetaryStac implements StacTemplate {
 		const providers: Tag[] = this.stacCollection.providers?.map((p) => {
 			return { key: 'provider', value: p.name };
 		});
-		const bbox = this.stacCollection.extent.spatial.bbox[0];
+
+		const bbox = this.getMaxExtent();
 
 		const collectionUrl = this.stacCollection.links.find((l) => l.rel === 'items').href;
 
@@ -416,5 +417,29 @@ export default class MicrosoftPlanetaryStac implements StacTemplate {
 		const expiryDate = new Date(expiry);
 		const isExpired = currentTime > expiryDate;
 		return isExpired;
+	};
+
+	public getMaxExtent = () => {
+		const bboxes = this.stacCollection.extent.spatial.bbox;
+		let minx: number;
+		let miny: number;
+		let maxx: number;
+		let maxy: number;
+		bboxes.forEach((bbox) => {
+			if (!minx || bbox[0] < minx) {
+				minx = bbox[0];
+			}
+			if (!miny || bbox[1] < miny) {
+				miny = bbox[1];
+			}
+			if (!maxx || bbox[2] > maxx) {
+				maxx = bbox[2];
+			}
+			if (!maxy || bbox[3] > maxy) {
+				maxy = bbox[3];
+			}
+		});
+
+		return [minx, miny, maxx, maxy];
 	};
 }

--- a/sites/geohub/src/lib/stac/StacTemplate.ts
+++ b/sites/geohub/src/lib/stac/StacTemplate.ts
@@ -106,4 +106,11 @@ export interface StacTemplate {
 	 * @returns DatasetFeature object
 	 */
 	generateCollectionDatasetFeature: () => Promise<DatasetFeature>;
+
+	/**
+	 * Compute max extent for stac collection
+	 * `extent.spatial.bbox` property contains multiple bboxes for some collection, this function will combine all bboxes to compute max extent.
+	 * @returns Max extent for stac collection
+	 */
+	getMaxExtent: () => number[];
 }


### PR DESCRIPTION
…extent combined from all extents in stac api explorer.

Thank you for submitting a pull request!

## Description
after merging this, HREA stac collection can be used in GeoHub

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1273739384) by [Unito](https://www.unito.io)
