### PR TITLE
fix: Postgres Function Layer will use source URL by changing function parameters, hence, if the dataset is Function layer, unique UUID is used as source ID. Otherwise, dataset ID is used to share with other layers

### DIFF
--- a/.changeset/tame-cats-whisper.md
+++ b/.changeset/tame-cats-whisper.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: Postgres Function Layer will use source URL by changing function parameters, hence, if the dataset is Function layer, unique UUID is used as source ID. Otherwise, dataset ID is used to share with other layers

--- a/sites/geohub/src/lib/VectorTileData.ts
+++ b/sites/geohub/src/lib/VectorTileData.ts
@@ -33,9 +33,15 @@ export class VectorTileData {
 	) => {
 		const metadata = await this.getMetadata();
 
-		const tileSourceId = this.feature.properties.id;
-		const selectedLayerId = targetLayer ?? metadata.json.vector_layers[0].id;
 		const layerId = uuidv4();
+		const isFunction =
+			this.feature.properties.tags?.find((t) => t.key == 'layertype')?.value === 'function' ??
+			false;
+		// Postgres Function Layer will use source URL by changing function parameters,
+		// hence, if the dataset is Function layer, unique UUID is used as source ID.
+		// Otherwise, dataset ID is used to share with other layers
+		const tileSourceId = isFunction ? layerId : this.feature.properties.id;
+		const selectedLayerId = targetLayer ?? metadata.json.vector_layers[0].id;
 
 		let maplibreLayerType: VectorLayerTypes;
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2561

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1273749863) by [Unito](https://www.unito.io)
