### PR TITLE
fix: add same margin-left and margin-right for data tab, layer tab

### DIFF
--- a/.changeset/spicy-zoos-yawn.md
+++ b/.changeset/spicy-zoos-yawn.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add same margin-left and margin-right for data tab, layer tab

--- a/sites/geohub/src/components/pages/map/Content.svelte
+++ b/sites/geohub/src/components/pages/map/Content.svelte
@@ -81,10 +81,10 @@
 {/if}
 
 {#if $pageDataLoadingStore !== true}
-	<div hidden={activeTab !== TabNames.DATA}>
+	<div hidden={activeTab !== TabNames.DATA} class="mx-4">
 		<DataView bind:contentHeight />
 	</div>
-	<div hidden={activeTab !== TabNames.LAYERS}>
+	<div hidden={activeTab !== TabNames.LAYERS} class="mx-4">
 		<LayerList bind:contentHeight bind:activeTab />
 	</div>
 {/if}

--- a/sites/geohub/src/components/pages/map/data/DataView.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataView.svelte
@@ -194,7 +194,7 @@
 	};
 </script>
 
-<div class="container mx-4" bind:clientHeight={optionsHeight}>
+<div bind:clientHeight={optionsHeight}>
 	<TextFilter
 		placeholder="Type keywords to search data"
 		bind:map={$map}
@@ -240,7 +240,7 @@
 	{/if}
 </div>
 <div
-	class="container data-view-container mx-4 pb-5"
+	class="container data-view-container pb-5"
 	style="height: {totalHeight}px;"
 	bind:this={containerDivElement}
 >

--- a/sites/geohub/src/components/pages/map/layers/LayerList.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerList.svelte
@@ -110,7 +110,7 @@
 
 {#if $layerListStore?.length > 0}
 	<div
-		class="is-flex is-align-items-center layer-header px-2 pt-2"
+		class="is-flex is-align-items-center layer-header pt-2"
 		bind:clientHeight={layerHeaderHeight}
 	>
 		<div class="layer-header-buttons buttons mb-0">
@@ -227,7 +227,7 @@
 		</div>
 	</div>
 {/if}
-<div class="layer-list p-2" style="height: {totalHeight}px;">
+<div class="layer-list pb-4" style="height: {totalHeight}px;">
 	{#if $layerListStore?.length === 0}
 		<div class="p-2">
 			<Notification type="info" showCloseButton={false}>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2638

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1277101329) by [Unito](https://www.unito.io)
