### PR TITLE
fix: add notification ! icon to show data accesibility in data tab accordion if dataset is not public access.

### DIFF
--- a/.changeset/grumpy-poets-exercise.md
+++ b/.changeset/grumpy-poets-exercise.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add notification icon (!) to show data accesibility in data tab accordion if dataset is not public access.

--- a/sites/geohub/src/components/pages/map/data/DataCard.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataCard.svelte
@@ -8,7 +8,8 @@
 	import MiniMap from '$components/util/MiniMap.svelte';
 	import { RasterTileData } from '$lib/RasterTileData';
 	import { VectorTileData } from '$lib/VectorTileData';
-	import { getFirstSymbolLayerId, isRgbRaster, loadMap } from '$lib/helper';
+	import { AccessLevel } from '$lib/config/AppConfig';
+	import { getFirstSymbolLayerId, initTooltipTippy, isRgbRaster, loadMap } from '$lib/helper';
 	import type {
 		DatasetFeature,
 		Layer,
@@ -33,6 +34,8 @@
 	export let feature: DatasetFeature;
 	export let isExpanded: boolean;
 	export let isStarOnly = false;
+
+	const tippyTooltip = initTooltipTippy();
 
 	let nodeRef: HTMLElement;
 	let clientWidth: number;
@@ -222,8 +225,24 @@
 			isShowInfo={true}
 		/>
 	{:else}
+		{@const accessLevel = feature.properties.access_level ?? AccessLevel.PUBLIC}
 		<Accordion title={feature.properties.name} bind:isExpanded>
-			<div slot="buttons">
+			<div class="is-flex is-align-items-center" slot="buttons">
+				{#if accessLevel !== AccessLevel.PUBLIC}
+					<div
+						class="action-button mr-2"
+						use:tippyTooltip={{
+							content: `This dataset has limited data accesibility. It only has ${
+								accessLevel === AccessLevel.PRIVATE ? 'private' : 'organisation'
+							} access.`
+						}}
+					>
+						<span class="icon is-small">
+							<i class="fa-solid fa-circle-exclamation has-text-grey-dark"></i>
+						</span>
+					</div>
+				{/if}
+
 				{#await isGettingMetadata then}
 					{#if tilestatsLayers?.length < 2}
 						{#if !isExpanded}
@@ -311,5 +330,9 @@
 		.map {
 			padding-bottom: 0.5rem;
 		}
+	}
+
+	.action-button {
+		cursor: pointer;
 	}
 </style>

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -1,14 +1,7 @@
 <script lang="ts">
 	import Accordion from '$components/util/Accordion.svelte';
 	import { AccessLevel } from '$lib/config/AppConfig';
-	import {
-		clean,
-		getAccessLevelIcon,
-		getLayerStyle,
-		handleEnterKey,
-		initTippy,
-		initTooltipTippy
-	} from '$lib/helper';
+	import { clean, getLayerStyle, handleEnterKey, initTippy, initTooltipTippy } from '$lib/helper';
 	import type { Layer, RasterTileMetadata, VectorTileMetadata } from '$lib/types';
 	import {
 		EDITING_LAYER_STORE_CONTEXT_KEY,
@@ -47,10 +40,7 @@
 
 	let is_raster = layer.dataset.properties.is_raster;
 
-	const accessIcon = getAccessLevelIcon(
-		layer.dataset.properties.access_level ?? AccessLevel.PUBLIC,
-		true
-	);
+	const accessLevel = layer.dataset.properties.access_level ?? AccessLevel.PUBLIC;
 
 	const tippy = initTippy({
 		placement: 'bottom-end',
@@ -163,10 +153,14 @@
 
 <Accordion title={clean(layer.name)} bind:isExpanded>
 	<div class="is-flex is-align-items-center" slot="buttons">
-		{#if accessIcon}
+		{#if accessLevel !== AccessLevel.PUBLIC}
 			<div
 				class="menu-button p-0 px-1"
-				use:tippyTooltip={{ content: 'This dataset has limited data accesibility' }}
+				use:tippyTooltip={{
+					content: `This dataset has limited data accesibility. It only has ${
+						accessLevel === AccessLevel.PRIVATE ? 'private' : 'organisation'
+					} access.`
+				}}
 			>
 				<span class="icon is-small">
 					<i class="fa-solid fa-circle-exclamation has-text-grey-dark"></i>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2650

![](https://github.com/UNDP-Data/geohub/assets/2639701/1e44bcba-eaba-46b8-8671-c6129dd60b42)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1277193568) by [Unito](https://www.unito.io)
