### PR TITLE
fix: renamed title of colormap accordion

### DIFF
--- a/.changeset/witty-jokes-listen.md
+++ b/.changeset/witty-jokes-listen.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: rename raster color accordion name from Colormap to Color. Also renamed the contents of type selectbox

--- a/sites/geohub/src/components/maplibre/raster/ClassificationSwitch.svelte
+++ b/sites/geohub/src/components/maplibre/raster/ClassificationSwitch.svelte
@@ -19,7 +19,7 @@
 
 <div class="select is-fullwidth">
 	<select bind:value={legendType} on:change={handleChanged}>
-		<option value={LegendType.LINEAR}>Use a linear colormap</option>
-		<option value={LegendType.CATEGORISED}>Use advanced classification</option>
+		<option value={LegendType.LINEAR}>Simple</option>
+		<option value={LegendType.CATEGORISED}>Categories</option>
 	</select>
 </div>

--- a/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
@@ -170,7 +170,7 @@
 					{#if !layerHasUniqueValues}
 						<FieldControl title="Type">
 							<div slot="help">
-								Switch classification type either a simple linear colormap or advanced manual
+								Switch classification type either a simple linear colormap or categorized
 								classification.
 							</div>
 							<div slot="control">

--- a/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
@@ -165,7 +165,7 @@
 		{/await}
 	{:else}
 		{#if !isRgbTile}
-			<Accordion title="Colormap" bind:isExpanded={expanded['colormap']}>
+			<Accordion title="Color" bind:isExpanded={expanded['color']}>
 				<div slot="content">
 					{#if !layerHasUniqueValues}
 						<FieldControl title="Type">
@@ -207,7 +207,7 @@
 					{/if}
 				</div>
 				<div slot="buttons">
-					<Help>Apply a colormap to classify legend</Help>
+					<Help>Apply a colormap to visualise the raster dataset</Help>
 				</div>
 			</Accordion>
 		{/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2662

renamed like the below screenshot

![](https://github.com/UNDP-Data/geohub/assets/2639701/6ca45d5c-52a9-474d-aedf-13fa8b845b15)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1278138209) by [Unito](https://www.unito.io)
