### PR TITLE
feat: allow users to open layer editor with different layer without closing existing editor panel. Also, change border color for hovering layers and change background-color for selected layer to edit style.

### DIFF
--- a/.changeset/nasty-sloths-call.md
+++ b/.changeset/nasty-sloths-call.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+feat: allow users to open layer editor with different layer without closing existing editor panel.

--- a/.changeset/nasty-sloths-call.md
+++ b/.changeset/nasty-sloths-call.md
@@ -2,4 +2,4 @@
 "geohub": patch
 ---
 
-feat: allow users to open layer editor with different layer without closing existing editor panel.
+feat: allow users to open layer editor with different layer without closing existing editor panel. Also, change border color for hovering layers and change background-color for selected layer to edit style.

--- a/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
@@ -124,7 +124,7 @@
 	};
 
 	let expanded: { [key: string]: boolean } = {
-		colormap: true
+		color: true
 	};
 	// to allow only an accordion to be expanded
 	let expandedDatasetId: string;

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -159,7 +159,11 @@
 	};
 </script>
 
-<Accordion title={clean(layer.name)} bind:isExpanded>
+<Accordion
+	title={clean(layer.name)}
+	bind:isExpanded
+	isSelected={$editingLayerStore?.id === layer.id}
+>
 	<div class="is-flex is-align-items-center" slot="buttons">
 		{#if accessLevel !== AccessLevel.PUBLIC}
 			<div

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -163,6 +163,7 @@
 	title={clean(layer.name)}
 	bind:isExpanded
 	isSelected={$editingLayerStore?.id === layer.id}
+	showHoveredColor={true}
 >
 	<div class="is-flex is-align-items-center" slot="buttons">
 		{#if accessLevel !== AccessLevel.PUBLIC}

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -131,14 +131,25 @@
 	}, 300);
 
 	const handleEditLayer = () => {
-		$editingMenuShownStore = !$editingMenuShownStore;
+		if ($editingMenuShownStore === true && $editingLayerStore?.id !== layer.id) {
+			// open layer editor with different layer
+			if ($editingLayerStore) {
+				editingLayerStore.set(undefined);
+			}
 
-		if (!$editingMenuShownStore) {
-			$map.off('styledata', handleLayerStyleChanged);
-			editingLayerStore.set(undefined);
-		} else {
 			editingLayerStore.set(layer);
 			$map.on('styledata', handleLayerStyleChanged);
+		} else {
+			// open new layer editor or close it
+			$editingMenuShownStore = !$editingMenuShownStore;
+
+			if (!$editingMenuShownStore) {
+				$map.off('styledata', handleLayerStyleChanged);
+				editingLayerStore.set(undefined);
+			} else {
+				editingLayerStore.set(layer);
+				$map.on('styledata', handleLayerStyleChanged);
+			}
 		}
 	};
 
@@ -169,7 +180,6 @@
 			<button
 				class="button menu-button hidden-mobile p-0 px-2 ml-1"
 				on:click={handleEditLayer}
-				disabled={($editingLayerStore && $editingLayerStore.id !== layer.id) ?? false}
 				use:tippyTooltip={{ content: 'Edit the settings on how the layer is visualised.' }}
 			>
 				<span class="icon is-small">
@@ -259,10 +269,6 @@
 {/if}
 
 <style lang="scss">
-	.border {
-		border-bottom: 1px #d4d6d8 solid;
-	}
-
 	.menu-button {
 		border: none;
 		background: transparent;

--- a/sites/geohub/src/components/util/Accordion.svelte
+++ b/sites/geohub/src/components/util/Accordion.svelte
@@ -6,8 +6,11 @@
 
 	export let title: string;
 	export let isExpanded: boolean;
+	export let isSelected = false;
 
 	const tippyTooltip = initTooltipTippy();
+
+	let isHovered = false;
 
 	$: isExpanded, handleToggleChanged();
 	const handleToggleChanged = () => {
@@ -17,65 +20,91 @@
 	};
 </script>
 
-<div class="header is-flex is-align-items-center py-4 {isExpanded ? '' : 'border'}">
-	<span
-		class="accordion-title is-size-6 mr-3"
-		use:tippyTooltip={{ content: title }}
-		role="button"
-		tabindex="0"
-		on:keydown={handleEnterKey}
-		on:click={() => {
-			isExpanded = !isExpanded;
-		}}
-	>
-		<span class="mr-2">
-			<i
-				class="fa-solid fa-chevron-down toggle-icon {isExpanded ? 'active' : ''} has-text-primary"
-			/>
+<div
+	class="accordion p-1 {isSelected ? 'selected' : `${isHovered ? 'border-primary' : 'border'}`}"
+	role="menuitem"
+	tabindex="-1"
+	on:mouseenter={() => {
+		isHovered = true;
+	}}
+	on:mouseleave={() => {
+		isHovered = false;
+	}}
+>
+	<div class="header is-flex is-align-items-center py-4">
+		<span
+			class="accordion-title is-size-6 mr-3"
+			use:tippyTooltip={{ content: title }}
+			role="button"
+			tabindex="0"
+			on:keydown={handleEnterKey}
+			on:click={() => {
+				isExpanded = !isExpanded;
+			}}
+		>
+			<span class="mr-2">
+				<i
+					class="fa-solid fa-chevron-down toggle-icon {isExpanded ? 'active' : ''} has-text-primary"
+				/>
+			</span>
+			<span class="has-text-grey-dark">{clean(title)}</span>
 		</span>
-		<span class="has-text-grey-dark">{clean(title)}</span>
-	</span>
 
-	<slot name="buttons" />
-</div>
+		<slot name="buttons" />
+	</div>
 
-<div class="border pb-2" hidden={!isExpanded}>
-	<slot name="content" />
+	<div class="content pb-2" hidden={!isExpanded}>
+		<slot name="content" />
+	</div>
 </div>
 
 <style lang="scss">
-	.border {
-		border-bottom: 1px #d4d6d8 solid;
-	}
+	$primary: #d12800;
 
-	.header {
-		max-height: 60px;
+	.accordion {
+		.header {
+			max-height: 60px;
 
-		.accordion-title {
-			cursor: pointer;
-			width: 100%;
+			.accordion-title {
+				cursor: pointer;
+				width: 100%;
 
-			text-overflow: ellipsis;
-			overflow: hidden;
-			white-space: nowrap;
-			word-break: break-all;
+				text-overflow: ellipsis;
+				overflow: hidden;
+				white-space: nowrap;
+				word-break: break-all;
+			}
+
+			.toggle-icon {
+				-webkit-transition: all 0.3s ease;
+				-moz-transition: all 0.3s ease;
+				-ms-transition: all 0.3s ease;
+				-o-transition: all 0.3s ease;
+				transition: all 0.3s ease;
+
+				&.active {
+					transform: rotate(-180deg);
+					-webkit-transform: rotate(-180deg);
+					-moz-transform: rotate(-180deg);
+					-ms-transform: rotate(-180deg);
+					-o-transform: rotate(-180deg);
+					transition: rotateZ(-180deg);
+				}
+			}
 		}
 
-		.toggle-icon {
-			-webkit-transition: all 0.3s ease;
-			-moz-transition: all 0.3s ease;
-			-ms-transition: all 0.3s ease;
-			-o-transition: all 0.3s ease;
-			transition: all 0.3s ease;
+		&.selected {
+			background-color: hsl(347, 90%, 96%);
+		}
 
-			&.active {
-				transform: rotate(-180deg);
-				-webkit-transform: rotate(-180deg);
-				-moz-transform: rotate(-180deg);
-				-ms-transform: rotate(-180deg);
-				-o-transform: rotate(-180deg);
-				transition: rotateZ(-180deg);
-			}
+		&.border {
+			border-bottom: 1px #d4d6d8 solid;
+		}
+		&.border-primary {
+			border-right: 1px $primary solid;
+			border-left: 1px $primary solid;
+			border-bottom: 1px $primary solid;
+			border-top: 1px $primary solid;
 		}
 	}
 </style>

--- a/sites/geohub/src/components/util/Accordion.svelte
+++ b/sites/geohub/src/components/util/Accordion.svelte
@@ -7,6 +7,7 @@
 	export let title: string;
 	export let isExpanded: boolean;
 	export let isSelected = false;
+	export let showHoveredColor = false;
 
 	const tippyTooltip = initTooltipTippy();
 
@@ -21,7 +22,13 @@
 </script>
 
 <div
-	class="accordion p-1 {isSelected ? 'selected' : `${isHovered ? 'border-primary' : 'border'}`}"
+	class="accordion p-1 {`${
+		showHoveredColor
+			? `${
+					isSelected ? 'has-background-danger-light' : `${isHovered ? 'border-primary' : 'border'}`
+				}`
+			: ''
+	}`}"
 	role="menuitem"
 	tabindex="-1"
 	on:mouseenter={() => {
@@ -91,10 +98,6 @@
 					transition: rotateZ(-180deg);
 				}
 			}
-		}
-
-		&.selected {
-			background-color: hsl(347, 90%, 96%);
 		}
 
 		&.border {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #2667

for hovering

<img width="446" alt="image" src="https://github.com/UNDP-Data/geohub/assets/2639701/a548655d-b104-4daa-b686-f809faad881d">

for selecting a layer to edit

<img width="1061" alt="image" src="https://github.com/UNDP-Data/geohub/assets/2639701/e16eb5bf-56b9-4682-8007-55cc6ebd33b5">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
