### PR TITLE
fix: removed icons from tabs, changed font-weight of tabs to bold

### DIFF
--- a/.changeset/pretty-teachers-provide.md
+++ b/.changeset/pretty-teachers-provide.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: removed icons from tabs, changed font-weight of tabs to bold

--- a/sites/geohub/src/components/maplibre/symbol/IconImagePicker.svelte
+++ b/sites/geohub/src/components/maplibre/symbol/IconImagePicker.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import IconImagePickerCard from '$components/maplibre/symbol/IconImagePickerCard.svelte';
+	import Tabs from '$components/util/Tabs.svelte';
 	import { handleEnterKey } from '$lib/helper';
 	import { SPRITEIMAGE_CONTEXT_KEY, type SpriteImageStore } from '$stores';
 	import type { Tab } from '@undp-data/svelte-undp-design';
 	import { createEventDispatcher, getContext, onMount } from 'svelte';
-	import Tabs from '$components/util/Tabs.svelte';
 
 	const spriteImageList: SpriteImageStore = getContext(SPRITEIMAGE_CONTEXT_KEY);
 
@@ -87,6 +87,7 @@
 		bind:tabs
 		bind:activeTab={activeIconGroupId}
 		on:tabChange={(e) => (activeIconGroupId = e.detail)}
+		fontWeight="bold"
 	/>
 	<button class="delete close is-radiusless" on:click={handleClosePopup}></button>
 

--- a/sites/geohub/src/components/pages/map/Content.svelte
+++ b/sites/geohub/src/components/pages/map/Content.svelte
@@ -71,6 +71,7 @@
 		bind:activeTab
 		on:tabChange={handleClickTab}
 		isUppercase={true}
+		fontWeight="bold"
 	/>
 </div>
 

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
@@ -50,9 +50,9 @@
 	const isRgbTile = isRgbRaster(rasterInfo.colorinterp);
 
 	let tabs = [
-		{ label: TabNames.STYLE, icon: 'fa-solid fa-list', id: TabNames.STYLE },
-		{ label: TabNames.TRANSFORM, icon: 'fa-solid fa-shuffle', id: TabNames.TRANSFORM },
-		{ label: TabNames.HISTOGRAM, icon: 'fa-solid fa-shuffle', id: TabNames.HISTOGRAM }
+		{ label: TabNames.STYLE, id: TabNames.STYLE },
+		{ label: TabNames.TRANSFORM, id: TabNames.TRANSFORM },
+		{ label: TabNames.HISTOGRAM, id: TabNames.HISTOGRAM }
 	];
 
 	const getDefaultTab = () => {
@@ -81,7 +81,13 @@
 	};
 </script>
 
-<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} size="is-small" />
+<Tabs
+	bind:tabs
+	bind:activeTab
+	on:tabChange={(e) => (activeTab = e.detail)}
+	size="is-small"
+	fontWeight="bold"
+/>
 
 <div hidden={activeTab !== TabNames.STYLE}>
 	<RasterLegend

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -98,9 +98,9 @@
 	setContext(DEFAULTCOLOR_CONTEXT_KEY_LABEL, defaultColorStoreLabel);
 
 	let tabs = [
-		{ label: TabNames.STYLE, icon: 'fa-solid fa-list', id: TabNames.STYLE },
-		{ label: TabNames.FILTER, icon: 'fa-solid fa-filter', id: TabNames.FILTER },
-		{ label: TabNames.LABEL, icon: 'fa-solid fa-text-height', id: TabNames.LABEL }
+		{ label: TabNames.STYLE, id: TabNames.STYLE },
+		{ label: TabNames.FILTER, id: TabNames.FILTER },
+		{ label: TabNames.LABEL, id: TabNames.LABEL }
 	];
 
 	const getDefaultTab = () => {
@@ -124,7 +124,7 @@
 	};
 </script>
 
-<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} />
+<Tabs bind:tabs bind:activeTab on:tabChange={(e) => (activeTab = e.detail)} fontWeight="bold" />
 
 <div hidden={activeTab !== TabNames.STYLE}>
 	<VectorLegend bind:layerId={layer.id} bind:metadata bind:tags={layer.dataset.properties.tags} />

--- a/sites/geohub/src/components/util/ColorMapPicker.svelte
+++ b/sites/geohub/src/components/util/ColorMapPicker.svelte
@@ -111,6 +111,8 @@
 		bind:tabs
 		bind:activeTab={activeColorMapType}
 		on:tabChange={(e) => (activeColorMapType = e.detail)}
+		size="is-small"
+		fontWeight="bold"
 	/>
 
 	<button class="delete close is-radiusless"></button>

--- a/sites/geohub/src/routes/(app)/data/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/+page.svelte
@@ -29,8 +29,7 @@
 	let tabs = [
 		{
 			id: '#data',
-			label: TabNames.DATA,
-			icon: 'fas fa-database'
+			label: TabNames.DATA
 		}
 	];
 
@@ -39,8 +38,7 @@
 			...tabs,
 			{
 				id: '#mydata',
-				label: TabNames.MYDATA,
-				icon: 'fas fa-user'
+				label: TabNames.MYDATA
 			}
 		];
 	}
@@ -62,8 +60,7 @@
 						on:click={() => (activeTab = tab.label)}
 						on:keydown={handleEnterKey}
 					>
-						<span class="icon is-small"><i class={tab.icon} aria-hidden="true"></i></span>
-						<span>
+						<span class="has-text-weight-bold">
 							{tab.label}
 							{#if tab.label === TabNames.DATA}
 								{@const datasetsCount = datasets?.pages?.totalCount ?? 0}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #2666 

- remvoed icons from all tabs 
- also fixed tab font weight to bold from normal weight like UNDP design tabs

<img width="357" alt="image" src="https://github.com/UNDP-Data/geohub/assets/2639701/59e8b8e2-25be-4d97-a6b3-6065f9267cbb">


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
