### PR TITLE
fix: fixed font of layer panel. changed tab size for layer panel.

### DIFF
--- a/.changeset/tough-masks-pull.md
+++ b/.changeset/tough-masks-pull.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed font of layer panel. changed tab size for layer panel.

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -367,9 +367,6 @@
 	{#if $showProgressBarStore}
 		<progress class="progress is-small is-primary is-link is-radiusless"></progress>
 	{/if}
-	{#if $editingMenuShownStore}
-		<LayerEdit />
-	{/if}
 </div>
 
 {#if $map}
@@ -392,6 +389,10 @@
 		bind:options={exportOptions}
 		position={config.SidebarPosition === 'left' ? 'top-right' : 'top-left'}
 	/>
+{/if}
+
+{#if $editingMenuShownStore}
+	<LayerEdit />
 {/if}
 
 <style lang="scss">

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
@@ -85,7 +85,7 @@
 	bind:tabs
 	bind:activeTab
 	on:tabChange={(e) => (activeTab = e.detail)}
-	size="is-small"
+	size="is-normal"
 	fontWeight="semibold"
 />
 

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -130,8 +130,8 @@
 	bind:tabs
 	bind:activeTab
 	on:tabChange={(e) => (activeTab = e.detail)}
-	size="is-small"
-	fontWeight="bold"
+	size="is-normal"
+	fontWeight="semibold"
 />
 
 <div class="editor-contents" hidden={activeTab !== TabNames.STYLE}>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description


* font of layer edit panel was different from default. now it is fixed
* changed tab size to normal

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1279928191) by [Unito](https://www.unito.io)
