### PR TITLE
fix: improved new simulation component UI

### DIFF
--- a/.changeset/thirty-flies-fix.md
+++ b/.changeset/thirty-flies-fix.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: improved new simulation component UI

--- a/sites/geohub/src/components/maplibre/vector/VectorParamsPanel.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorParamsPanel.svelte
@@ -112,7 +112,7 @@
 		/>
 	{/each}
 	{#if isParameterChanged}
-		<button on:click={reset} class="button is-light is-small is-uppercase">Reset all</button>
+		<button on:click={reset} class="button is-light is-small is-uppercase mt-2">Reset all</button>
 	{/if}
 {:catch error}
 	Failed to load parameters for {layerId}

--- a/sites/geohub/src/components/maplibre/vector/VectorSimulationArgument.svelte
+++ b/sites/geohub/src/components/maplibre/vector/VectorSimulationArgument.svelte
@@ -72,24 +72,55 @@
 	>
 		<div class="stroke"></div>
 
-		<span class="icon mr-2 {isHovered || isExpanded || isActive ? 'has-text-info' : ''}">
-			<i class="fas {argument.icon} "></i>
+		<span
+			class="icon is-medium mr-2 {isActive
+				? 'has-text-link'
+				: isHovered || isExpanded
+					? 'has-text-info'
+					: ''}"
+		>
+			<i class="fas {argument.icon} fa-lg"></i>
 		</span>
-		<span class="name mr-2 {isHovered || isExpanded || isActive ? 'has-text-info' : ''}"
-			>{argument.label}</span
+		<span
+			class="name mr-2 {isActive
+				? 'has-text-link'
+				: isHovered || isExpanded
+					? 'has-text-info'
+					: ''}">{argument.label}</span
 		>
 
-		<span class="tag is-light {isHovered || isExpanded || isActive ? 'is-info' : ''}  ml-auto">
-			{#if value > 0}
-				+
-			{:else if value < 0}
-				-
-			{/if}
-			{value >= 0 ? value : value * -1}
-			{argument.units}
+		<span class="tag has-addons ml-auto p-0">
+			<span
+				class="tag px-1 is-light {isActive ? 'is-link' : isHovered || isExpanded ? 'is-info' : ''} "
+			>
+				{#if value > 0}
+					+
+				{:else if value < 0}
+					-
+				{/if}
+				{value >= 0 ? value : value * -1}
+				{argument.units}
+			</span>
 			{#if argument.value !== value}
-				<button class="delete is-small" on:click={handleClear}></button>
+				<!-- svelte-ignore a11y-interactive-supports-focus -->
+				<!-- svelte-ignore a11y-missing-attribute -->
+				<!-- svelte-ignore a11y-missing-content -->
+				<a
+					class="tag is-delete is-light {isActive
+						? 'is-link'
+						: isHovered || isExpanded
+							? 'is-info'
+							: ''}"
+					on:click={handleClear}
+					on:keydown={handleEnterKey}
+					role="button"
+					data-sveltekit-preload-data="off"
+					data-sveltekit-preload-code="off"
+				></a>
 			{/if}
+			<!-- {#if argument.value !== value}
+				<button class="delete is-small" on:click={handleClear}></button>
+			{/if} -->
 		</span>
 	</div>
 
@@ -125,15 +156,23 @@
 		border: 1px solid #d4d6d8;
 		border-left: 3px solid #55606e;
 
-		&.is-active,
 		&.expanded,
 		&.hover {
 			border-left: 3px solid hsl(204, 86%, 53%);
+		}
+		&.is-active {
+			border-left: 3px solid #006eb5;
 		}
 
 		.argument {
 			position: relative;
 			cursor: pointer;
+
+			min-height: 56px;
+
+			.name {
+				line-height: 1.2rem;
+			}
 		}
 
 		.expanded-container {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2719 

1. set 1.2rem for line-height
1. set 56px for min-height of header. add `is-medium` for icon class with `fa-lg` (container size 2rem, icon size 1.33rem) in bulma
  * https://bulma.io/documentation/elements/icon/#sizes
![](https://github.com/UNDP-Data/geohub/assets/2639701/faffabe4-8642-4fca-ba7e-47661c850fd9)

Two lines parameter name
![](https://github.com/UNDP-Data/geohub/assets/2639701/0fca6810-9001-403d-9bbf-3f4c5c72dad3)

1. add 0.5rem (8px) of margin-top for reset button
![](https://github.com/UNDP-Data/geohub/assets/2639701/ad194dc7-6180-4cf4-baee-8063675a4170)
1. use `is-link` (UNDP blue color) for active color, use `is-info` for hover/expanded color
![](https://github.com/UNDP-Data/geohub/assets/2639701/74259a6d-c957-4272-aa7e-9f0c8babf34a)
1. use same color of x button
![](https://github.com/UNDP-Data/geohub/assets/2639701/ee79ff15-c86d-412a-9246-64420201da3f)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1282513787) by [Unito](https://www.unito.io)
