### PR TITLE
feat: add GUI to set user permission for a dataset

### DIFF
--- a/.changeset/cuddly-knives-dance.md
+++ b/.changeset/cuddly-knives-dance.md
@@ -1,0 +1,5 @@
+---
+"geohub": minor
+---
+
+feat: add GUI to set user permission for a dataset

--- a/.changeset/cuddly-knives-dance.md
+++ b/.changeset/cuddly-knives-dance.md
@@ -2,4 +2,5 @@
 "geohub": minor
 ---
 
-feat: add GUI to set user permission for a dataset
+- feat: add GUI to set user permission for a dataset
+- feat: allows read permission users to invite other users as READ permission.

--- a/sites/geohub/src/components/pages/data/datasets/PublishedDatasetOperations.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/PublishedDatasetOperations.svelte
@@ -51,12 +51,14 @@
 	};
 </script>
 
-{#if feature.properties.permission > Permission.READ}
+{#if feature.properties.permission && feature.properties.permission >= Permission.READ}
 	<div class="dropdown-trigger">
 		<button
 			class="button menu-button menu-button-{feature.properties.id}"
 			use:tippy={{ content: tooltipContent }}
-			disabled={feature.properties.permission < Permission.WRITE}
+			disabled={!(
+				feature.properties.permission && feature.properties.permission >= Permission.READ
+			)}
 		>
 			<span class="icon is-small">
 				<i class="fas fa-ellipsis-vertical" aria-hidden="true"></i>
@@ -84,7 +86,7 @@
 					<span>Set default style</span>
 				</a>
 			{/if}
-			{#if feature.properties.permission > Permission.READ && !isStac}
+			{#if feature.properties.permission >= Permission.READ && !isStac}
 				<a
 					class="dropdown-item"
 					role="button"

--- a/sites/geohub/src/components/pages/data/datasets/PublishedDatasetOperations.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/PublishedDatasetOperations.svelte
@@ -84,6 +84,19 @@
 					<span>Set default style</span>
 				</a>
 			{/if}
+			{#if feature.properties.permission > Permission.READ && !isStac}
+				<a
+					class="dropdown-item"
+					role="button"
+					tabindex="0"
+					href="/data/{feature.properties.id}/permission"
+				>
+					<span class="icon">
+						<i class="fa-solid fa-user-lock"></i>
+					</span>
+					<span>Set user permission</span>
+				</a>
+			{/if}
 			{#if feature.properties.permission > Permission.WRITE}
 				<!-- svelte-ignore a11y-missing-attribute -->
 				<a

--- a/sites/geohub/src/components/pages/data/datasets/PublishedDatasetRow.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/PublishedDatasetRow.svelte
@@ -50,11 +50,11 @@
 			href={feature.properties.links.find((l) => l.rel === 'dataset').href}
 		>
 			<div class="dataset_name is-flex">
-				<span>
+				<span class="mr-2">
 					{feature.properties.name}
 				</span>
 				{#if accessIcon}
-					<span class="icon pl-2">
+					<span class="icon ml-auto">
 						<i class={accessIcon} />
 					</span>
 				{/if}

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -1,0 +1,501 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import FieldControl from '$components/util/FieldControl.svelte';
+	import Notification from '$components/util/Notification.svelte';
+	import { Permission } from '$lib/config/AppConfig';
+	import type { DatasetPermission } from '$lib/server/DatasetPermissionManager';
+	import type { DatasetFeature } from '$lib/types';
+	import { handleEnterKey } from '@undp-data/svelte-geohub-static-image-controls';
+	import { Checkbox, Loader } from '@undp-data/svelte-undp-design';
+	import { debounce } from 'lodash-es';
+	import { onMount } from 'svelte';
+	import Time from 'svelte-time/src/Time.svelte';
+	import { fade } from 'svelte/transition';
+
+	export let dataset: DatasetFeature;
+
+	let permissions: DatasetPermission[] = [];
+
+	let isUpadating = false;
+	let showEditDialog = false;
+	let showAddDialog = false;
+	let showDeleteDialog = false;
+	let targetUserPermission: DatasetPermission;
+	let errorMessage = '';
+
+	let signedInUser = $page.data.session.user;
+
+	let user_email = '';
+	let user_permission: Permission;
+	let isSendMessage = true;
+	let messageBody = '';
+
+	$: user_email, validateEmail(user_email);
+	let isValidEmail = false;
+	let existUser = false;
+
+	const getUserPermissions = async () => {
+		const res = await fetch(`/api/datasets/${dataset.properties.id}/permission`);
+		permissions = await res.json();
+	};
+
+	const getPermissionLabel = (permission: Permission) => {
+		let label = '';
+		switch (permission) {
+			case Permission.OWNER:
+				label = 'owner';
+				break;
+			case Permission.WRITE:
+				label = 'editor';
+				break;
+			case Permission.READ:
+				label = 'viewer';
+				break;
+			default:
+				label = 'unknown';
+				break;
+		}
+		return label;
+	};
+
+	const getPermissionList = () => {
+		const currentUserPermission = permissions.find(
+			(p) => p.user_email === signedInUser.email
+		)?.permission;
+		if (signedInUser.is_superuser || currentUserPermission === Permission.OWNER) {
+			return [Permission.READ, Permission.WRITE, Permission.OWNER];
+		} else {
+			return [Permission.READ, Permission.WRITE];
+		}
+	};
+
+	const handleOpenAddOrEditDialog = (isAdd = true) => {
+		showAddDialog = false;
+		showEditDialog = false;
+		showDeleteDialog = false;
+		errorMessage = '';
+
+		user_email = '';
+		user_permission = isAdd ? Permission.READ : targetUserPermission.permission;
+		isSendMessage = true;
+		if (isAdd) {
+			messageBody = `I am inviting you to the dataset (${dataset.properties.name}) at UNDP GeoHub. 
+The dataset can be accessed at ${$page.url.origin}/data/${dataset.properties.id}
+
+Regards,
+${signedInUser.name}`;
+			showAddDialog = true;
+		} else {
+			messageBody = `I changed your permission to the dataset (${dataset.properties.name}) at UNDP GeoHub. 
+The dataset can be accessed at ${$page.url.origin}/data/${dataset.properties.id}
+
+Regards,
+${signedInUser.name}`;
+			showEditDialog = true;
+		}
+	};
+
+	const handleOpenDeleteDialog = (datasetPermission: DatasetPermission) => {
+		showAddDialog = false;
+		showEditDialog = false;
+		targetUserPermission = datasetPermission;
+		errorMessage = '';
+		showDeleteDialog = true;
+	};
+
+	const handleAddPermission = async () => {
+		try {
+			isUpadating = true;
+
+			const body = {
+				dataset_id: dataset.properties.id,
+				user_email: user_email,
+				permission: user_permission
+			};
+
+			const res = await fetch(`/api/datasets/${dataset.properties.id}/permission`, {
+				method: 'POST',
+				body: JSON.stringify(body)
+			});
+			if (res.ok) {
+				await getUserPermissions();
+				showAddDialog = false;
+			} else {
+				const err = await res.json();
+				errorMessage = err.message;
+			}
+		} finally {
+			isUpadating = false;
+		}
+	};
+
+	const handleEditPermission = async () => {
+		try {
+			isUpadating = true;
+
+			const body = {
+				dataset_id: targetUserPermission.dataset_id,
+				user_email: targetUserPermission.user_email,
+				permission: user_permission,
+				createdat: targetUserPermission.createdat
+			};
+
+			const res = await fetch(`/api/datasets/${dataset.properties.id}/permission`, {
+				method: 'PUT',
+				body: JSON.stringify(body)
+			});
+			if (res.ok) {
+				await getUserPermissions();
+				showEditDialog = false;
+			} else {
+				const err = await res.json();
+				errorMessage = err.message;
+			}
+		} finally {
+			isUpadating = false;
+		}
+	};
+
+	const handleDeletePermission = async () => {
+		try {
+			isUpadating = true;
+
+			const res = await fetch(
+				`/api/datasets/${dataset.properties.id}/permission?user_email=${targetUserPermission.user_email}`,
+				{
+					method: 'DELETE'
+				}
+			);
+			if (res.ok) {
+				await getUserPermissions();
+				showDeleteDialog = false;
+			} else {
+				const err = await res.json();
+				errorMessage = err.message;
+			}
+		} finally {
+			isUpadating = false;
+		}
+	};
+
+	const validateEmail = debounce((email: string) => {
+		if (!email) return false;
+		const validRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+		existUser = permissions.find((p) => p.user_email === email) ? true : false;
+		isValidEmail = email.match(validRegex) ? (existUser ? false : true) : false;
+	}, 300);
+
+	onMount(async () => {
+		await getUserPermissions();
+	});
+</script>
+
+<div class="table-container mt-2">
+	{#if permissions.length === 0}
+		<div class="is-flex is-justify-content-center">
+			<Loader size="medium" />
+		</div>
+	{:else}
+		<table class="table is-hoverable is-fullwidth mb-2">
+			<thead>
+				<tr>
+					<th>Email</th>
+					<th>Permission</th>
+					<th>Last modified</th>
+					<th></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each permissions as permission}
+					<tr class="border-bottom">
+						<td>
+							{permission.user_email}
+							{#if permission.user_email === signedInUser.email}
+								(you)
+							{/if}
+						</td>
+						<td>
+							<p class="is-capitalized">
+								{getPermissionLabel(permission.permission)}
+							</p>
+						</td>
+						<td>
+							{#if permission.updatedat}
+								<Time timestamp={permission.updatedat} format="HH:mm, MM/DD/YYYY" />
+							{:else}
+								<Time timestamp={permission.createdat} format="HH:mm, MM/DD/YYYY" />
+							{/if}
+						</td>
+						<td>
+							{#if permission.user_email !== signedInUser.email}
+								{#if permissions.filter((p) => p.permission === Permission.OWNER && p.user_email !== permission.user_email)?.length > 0}
+									<p class="is-flex">
+										<button
+											class="operation-button button"
+											on:click={() => {
+												targetUserPermission = permission;
+												handleOpenAddOrEditDialog(false);
+											}}
+										>
+											<span class="icon is-small">
+												<i class="fa-solid fa-pen"></i>
+											</span>
+										</button>
+										<button
+											class="operation-button button"
+											on:click={() => {
+												handleOpenDeleteDialog(permission);
+											}}
+										>
+											<span class="icon is-small">
+												<i class="fa-solid fa-trash"></i>
+											</span>
+										</button>
+									</p>
+								{/if}
+							{/if}
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+
+		<button
+			class="button is-primary is-uppercase has-text-weight-semibold"
+			on:click={() => {
+				handleOpenAddOrEditDialog(true);
+			}}>Add user</button
+		>
+	{/if}
+</div>
+
+{#if showAddDialog}
+	<div class="modal {showAddDialog ? 'is-active' : ''}" transition:fade|global>
+		<div
+			class="modal-background"
+			role="none"
+			on:click={() => {
+				showAddDialog = false;
+			}}
+			on:keydown={handleEnterKey}
+		/>
+
+		<div class="modal-card">
+			<header class="modal-card-head">
+				<p class="modal-card-title">Add User</p>
+				<button
+					class="delete"
+					aria-label="close"
+					title="Close"
+					on:click={() => {
+						showAddDialog = false;
+					}}
+				/>
+			</header>
+			<section class="modal-card-body is-size-6 has-text-weight-normal">
+				<FieldControl title="email address" showHelp={false}>
+					<div slot="control">
+						<div class="control has-icons-left has-icons-right">
+							<input
+								class="input {!isValidEmail ? 'is-danger' : 'is-success'}"
+								type="email"
+								bind:value={user_email}
+							/>
+							<span class="icon is-small is-left">
+								<i class="fas fa-envelope"></i>
+							</span>
+							{#if isValidEmail}
+								<span class="icon is-small is-right">
+									<i class="fas fa-check"></i>
+								</span>
+							{/if}
+						</div>
+						{#key existUser}
+							{#if existUser}
+								<p class="help is-danger">This email was already registered.</p>
+							{/if}
+						{/key}
+					</div>
+				</FieldControl>
+
+				<FieldControl title="specify role" showHelp={false}>
+					<div class="select is-fullwidth" slot="control">
+						<select class="is-capitalized" bind:value={user_permission}>
+							{#each getPermissionList() as p}
+								<option value={p}>{getPermissionLabel(p)}</option>
+							{/each}
+						</select>
+					</div>
+				</FieldControl>
+
+				<div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
+
+				{#if isSendMessage}
+					<FieldControl title="add a message" showHelp={false}>
+						<div slot="control">
+							<textarea
+								class="textarea has-fixed-size"
+								placeholder="Add a message to user"
+								bind:value={messageBody}
+							></textarea>
+						</div>
+					</FieldControl>
+				{/if}
+				{#if errorMessage}
+					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
+				{/if}
+			</section>
+			<footer class="modal-card-foot">
+				<button
+					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
+					disabled={!(
+						isValidEmail &&
+						(!isSendMessage || (isSendMessage && messageBody.length > 0))
+					)}
+					on:click={handleAddPermission}
+				>
+					Add
+				</button>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+{#if showEditDialog}
+	<div class="modal {showEditDialog ? 'is-active' : ''}" transition:fade|global>
+		<div
+			class="modal-background"
+			role="none"
+			on:click={() => {
+				showEditDialog = false;
+			}}
+			on:keydown={handleEnterKey}
+		/>
+
+		<div class="modal-card">
+			<header class="modal-card-head">
+				<p class="modal-card-title">Edit User</p>
+				<button
+					class="delete"
+					aria-label="close"
+					title="Close"
+					on:click={() => {
+						showEditDialog = false;
+					}}
+				/>
+			</header>
+			<section class="modal-card-body is-size-6 has-text-weight-normal">
+				<FieldControl title="email address" showHelp={false}>
+					<div class="control has-icons-left" slot="control">
+						<input
+							class="input"
+							type="email"
+							bind:value={targetUserPermission.user_email}
+							readonly
+						/>
+						<span class="icon is-small is-left">
+							<i class="fas fa-envelope"></i>
+						</span>
+					</div>
+				</FieldControl>
+
+				<FieldControl title="specify role" showHelp={false}>
+					<div class="select is-fullwidth" slot="control">
+						<select class="is-capitalized" bind:value={user_permission}>
+							{#each getPermissionList() as p}
+								<option value={p}>{getPermissionLabel(p)}</option>
+							{/each}
+						</select>
+					</div>
+				</FieldControl>
+
+				<div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
+
+				{#if isSendMessage}
+					<FieldControl title="add a message" showHelp={false}>
+						<div slot="control">
+							<textarea
+								class="textarea has-fixed-size"
+								placeholder="Add a message to user"
+								bind:value={messageBody}
+							></textarea>
+						</div>
+					</FieldControl>
+				{/if}
+				{#if errorMessage}
+					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
+				{/if}
+			</section>
+			<footer class="modal-card-foot">
+				<button
+					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
+					disabled={!(
+						(!isSendMessage || (isSendMessage && messageBody.length > 0)) &&
+						permissions.find((p) => p.user_email === targetUserPermission.user_email)
+							?.permission !== user_permission
+					)}
+					on:click={handleEditPermission}
+				>
+					Edit
+				</button>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+{#if showDeleteDialog}
+	<div class="modal {showDeleteDialog ? 'is-active' : ''}" transition:fade|global>
+		<div
+			class="modal-background"
+			role="none"
+			on:click={() => {
+				showDeleteDialog = false;
+			}}
+			on:keydown={handleEnterKey}
+		/>
+		<div class="modal-card">
+			<header class="modal-card-head">
+				<p class="modal-card-title">Are you sure deleting this user's permission?</p>
+				<button
+					class="delete"
+					aria-label="close"
+					title="Close"
+					on:click={() => {
+						showDeleteDialog = false;
+					}}
+				/>
+			</header>
+			<section class="modal-card-body is-size-6 has-text-weight-normal">
+				<div class="has-text-weight-medium mt-2 mx-1">
+					This action <b>cannot</b> be undone.
+					<br />
+					This will delete
+					<b>{targetUserPermission?.user_email}</b>'s permission from this dataset of {dataset
+						.properties.name}.
+				</div>
+				{#if errorMessage}
+					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
+				{/if}
+			</section>
+			<footer class="modal-card-foot">
+				<button
+					class="button is-primary is-fullwidth {isUpadating ? 'is-loading' : ''}"
+					on:click={handleDeletePermission}
+				>
+					I understand the consequences, delete this dataset
+				</button>
+			</footer>
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	.border-bottom {
+		border-bottom: 1px solid #d4d6d8;
+	}
+
+	.operation-button {
+		border: none;
+		background: transparent;
+	}
+</style>

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -294,8 +294,7 @@ ${signedInUser.name}`;
 		/>
 
 		<div class="modal-card">
-			<header class="modal-card-head">
-				<p class="modal-card-title">Add User</p>
+			<section class="modal-card-body">
 				<button
 					class="delete"
 					aria-label="close"
@@ -304,8 +303,7 @@ ${signedInUser.name}`;
 						showAddDialog = false;
 					}}
 				/>
-			</header>
-			<section class="modal-card-body is-size-6 has-text-weight-normal">
+				<p class="title is-5">Add User</p>
 				<FieldControl title="email address" showHelp={false}>
 					<div slot="control">
 						<div class="control has-icons-left has-icons-right">
@@ -357,8 +355,7 @@ ${signedInUser.name}`;
 				{#if errorMessage}
 					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
 				{/if}
-			</section>
-			<footer class="modal-card-foot">
+
 				<button
 					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
 					disabled={!(
@@ -369,7 +366,7 @@ ${signedInUser.name}`;
 				>
 					Add
 				</button>
-			</footer>
+			</section>
 		</div>
 	</div>
 {/if}
@@ -386,8 +383,7 @@ ${signedInUser.name}`;
 		/>
 
 		<div class="modal-card">
-			<header class="modal-card-head">
-				<p class="modal-card-title">Edit User</p>
+			<section class="modal-card-body">
 				<button
 					class="delete"
 					aria-label="close"
@@ -396,8 +392,7 @@ ${signedInUser.name}`;
 						showEditDialog = false;
 					}}
 				/>
-			</header>
-			<section class="modal-card-body is-size-6 has-text-weight-normal">
+				<p class="title is-5">Edit User</p>
 				<FieldControl title="email address" showHelp={false}>
 					<div class="control has-icons-left" slot="control">
 						<input
@@ -438,8 +433,7 @@ ${signedInUser.name}`;
 				{#if errorMessage}
 					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
 				{/if}
-			</section>
-			<footer class="modal-card-foot">
+
 				<button
 					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
 					disabled={!(
@@ -451,7 +445,7 @@ ${signedInUser.name}`;
 				>
 					Edit
 				</button>
-			</footer>
+			</section>
 		</div>
 	</div>
 {/if}
@@ -467,8 +461,7 @@ ${signedInUser.name}`;
 			on:keydown={handleEnterKey}
 		/>
 		<div class="modal-card">
-			<header class="modal-card-head">
-				<p class="modal-card-title">Are you sure deleting this user's permission?</p>
+			<section class="modal-card-body">
 				<button
 					class="delete"
 					aria-label="close"
@@ -477,9 +470,8 @@ ${signedInUser.name}`;
 						showDeleteDialog = false;
 					}}
 				/>
-			</header>
-			<section class="modal-card-body is-size-6 has-text-weight-normal">
-				<div class="has-text-weight-medium mt-2 mx-1">
+				<p class="title is-5">Are you sure deleting this user's permission?</p>
+				<div class="has-text-weight-medium">
 					This action <b>cannot</b> be undone.
 					<br />
 					This will delete
@@ -489,15 +481,14 @@ ${signedInUser.name}`;
 				{#if errorMessage}
 					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
 				{/if}
-			</section>
-			<footer class="modal-card-foot">
+
 				<button
-					class="button is-primary is-fullwidth {isUpadating ? 'is-loading' : ''}"
+					class="button is-primary is-fullwidth {isUpadating ? 'is-loading' : ''} mt-2"
 					on:click={handleDeletePermission}
 				>
 					I understand the consequences, delete this dataset
 				</button>
-			</footer>
+			</section>
 		</div>
 	</div>
 {/if}
@@ -525,5 +516,15 @@ ${signedInUser.name}`;
 	.operation-button {
 		border: none;
 		background: transparent;
+	}
+
+	.modal-card {
+		.modal-card-body {
+			.delete {
+				position: absolute;
+				top: 1rem;
+				right: 1rem;
+			}
+		}
 	}
 </style>

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -274,7 +274,7 @@ ${signedInUser.name}`;
 		</table>
 
 		<button
-			class="button is-primary is-uppercase has-text-weight-semibold"
+			class="button is-primary is-uppercase has-text-weight-bold"
 			on:click={() => {
 				handleOpenAddOrEditDialog(true);
 			}}>Add user</button
@@ -357,7 +357,9 @@ ${signedInUser.name}`;
 				{/if}
 
 				<button
-					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
+					class="button is-primary is-uppercase has-text-weight-bold {isUpadating
+						? 'is-loading'
+						: ''} "
 					disabled={!(
 						isValidEmail &&
 						(!isSendMessage || (isSendMessage && messageBody.length > 0))
@@ -435,7 +437,9 @@ ${signedInUser.name}`;
 				{/if}
 
 				<button
-					class="button is-primary {isUpadating ? 'is-loading' : ''} is-uppercase"
+					class="button is-primary is-uppercase has-text-weight-bold {isUpadating
+						? 'is-loading'
+						: ''} "
 					disabled={!(
 						(!isSendMessage || (isSendMessage && messageBody.length > 0)) &&
 						permissions.find((p) => p.user_email === targetUserPermission.user_email)
@@ -483,10 +487,12 @@ ${signedInUser.name}`;
 				{/if}
 
 				<button
-					class="button is-primary is-fullwidth {isUpadating ? 'is-loading' : ''} mt-2"
+					class="button is-primary is-uppercase has-text-weight-bold {isUpadating
+						? 'is-loading'
+						: ''} mt-2"
 					on:click={handleDeletePermission}
 				>
-					I understand the consequences, delete this dataset
+					delete this user
 				</button>
 			</section>
 		</div>

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -296,7 +296,7 @@ ${signedInUser.name}`;
 		<div class="modal-card">
 			<section class="modal-card-body">
 				<button
-					class="delete"
+					class="delete is-large"
 					aria-label="close"
 					title="Close"
 					on:click={() => {
@@ -387,7 +387,7 @@ ${signedInUser.name}`;
 		<div class="modal-card">
 			<section class="modal-card-body">
 				<button
-					class="delete"
+					class="delete is-large"
 					aria-label="close"
 					title="Close"
 					on:click={() => {
@@ -467,7 +467,7 @@ ${signedInUser.name}`;
 		<div class="modal-card">
 			<section class="modal-card-body">
 				<button
-					class="delete"
+					class="delete is-large"
 					aria-label="close"
 					title="Close"
 					on:click={() => {

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -6,7 +6,7 @@
 	import type { DatasetPermission } from '$lib/server/DatasetPermissionManager';
 	import type { DatasetFeature } from '$lib/types';
 	import { handleEnterKey } from '@undp-data/svelte-geohub-static-image-controls';
-	import { Checkbox, Loader } from '@undp-data/svelte-undp-design';
+	import { Loader } from '@undp-data/svelte-undp-design';
 	import { debounce } from 'lodash-es';
 	import { onMount } from 'svelte';
 	import Time from 'svelte-time/src/Time.svelte';
@@ -339,7 +339,7 @@ ${signedInUser.name}`;
 					</div>
 				</FieldControl>
 
-				<div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
+				<!-- <div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
 
 				{#if isSendMessage}
 					<FieldControl title="add a message" showHelp={false}>
@@ -354,7 +354,7 @@ ${signedInUser.name}`;
 				{/if}
 				{#if errorMessage}
 					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
-				{/if}
+				{/if} -->
 
 				<button
 					class="button is-primary is-uppercase has-text-weight-bold {isUpadating
@@ -419,7 +419,7 @@ ${signedInUser.name}`;
 					</div>
 				</FieldControl>
 
-				<div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
+				<!-- <div class="mb-2"><Checkbox label="Send a message" bind:checked={isSendMessage} /></div>
 
 				{#if isSendMessage}
 					<FieldControl title="add a message" showHelp={false}>
@@ -434,7 +434,7 @@ ${signedInUser.name}`;
 				{/if}
 				{#if errorMessage}
 					<Notification type="danger" showCloseButton={false}>{errorMessage}</Notification>
-				{/if}
+				{/if} -->
 
 				<button
 					class="button is-primary is-uppercase has-text-weight-bold {isUpadating

--- a/sites/geohub/src/components/util/FieldControl.svelte
+++ b/sites/geohub/src/components/util/FieldControl.svelte
@@ -5,8 +5,8 @@
 </script>
 
 <div class="field">
-	<label class="label is-normal is-flex is-align-items-center is-capitalized">
-		{title}
+	<label class="label is-normal is-flex is-align-items-center">
+		<span class="first-char-capitalized">{title}</span>
 		{#if showHelp}
 			<div class="ml-2 help">
 				<Help>
@@ -19,3 +19,12 @@
 		<slot name="control" />
 	</div>
 </div>
+
+<style lang="scss">
+	.first-char-capitalized {
+		text-transform: lowercase;
+	}
+	.first-char-capitalized::first-letter {
+		text-transform: capitalize;
+	}
+</style>

--- a/sites/geohub/src/lib/server/DatasetPermissionManager.ts
+++ b/sites/geohub/src/lib/server/DatasetPermissionManager.ts
@@ -130,12 +130,12 @@ export class DatasetPermissionManager {
 
 			// no permission is registered yet, it allows to register
 			if (!(permissions.length === 0 && !signedUserPermission)) {
-				// only users with owner/write permission can register.
-				if (!(signedUserPermission && signedUserPermission > Permission.READ)) {
+				// only users with owner/write/read permission can register.
+				if (!(signedUserPermission && signedUserPermission >= Permission.READ)) {
 					error(403, { message: `You have no permission to register this user's permission.` });
 				}
 
-				// users with write permission cannot register owner permission to a user.
+				// users cannot register permission which is higher than their own permission to a user.
 				if (signedUserPermission < dataset_permission.permission) {
 					error(403, { message: `You have no permission to register this user's permission.` });
 				}
@@ -166,13 +166,13 @@ export class DatasetPermissionManager {
 				error(403, { message: 'You cannot update your own permission' });
 			}
 
-			// only users with owner/write permission can update.
+			// only users with owner/write/read permission can update.
 			const signedUserPermission = await this.getBySignedUser(client);
-			if (!(signedUserPermission && signedUserPermission > Permission.READ)) {
+			if (!(signedUserPermission && signedUserPermission >= Permission.READ)) {
 				error(403, { message: `You have no permission to register this user's permission.` });
 			}
 
-			// users with write permission cannot register owner permission to a user.
+			// users cannot update permission which is higher than their own permission to a user.
 			if (signedUserPermission < dataset_permission.permission) {
 				error(403, { message: `You have no permission to register this user's permission.` });
 			}
@@ -204,13 +204,13 @@ export class DatasetPermissionManager {
 				error(403, { message: 'You cannot delete your own permission' });
 			}
 
-			// only users with owner/write permission can delete.
+			// only users with owner/write/read permission can delete.
 			const permission = await this.getBySignedUser(client);
-			if (!(permission && permission > Permission.READ)) {
+			if (!(permission && permission >= Permission.READ)) {
 				error(403, { message: `You have no permission to delete this user's permission.` });
 			}
 
-			// users with write permission cannot delete owner.
+			// users users cannot delete permission which is higher than their own permission to a user.
 			const targetPermission = await this.getByUser(client, user_email);
 			if (permission < Permission.OWNER && targetPermission === Permission.OWNER) {
 				error(403, { message: `You have no permission to delete this user's permission.` });

--- a/sites/geohub/src/routes/(app)/data/[id]/permission/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/[id]/permission/+page.server.ts
@@ -1,0 +1,32 @@
+import type { PageServerLoad } from './$types';
+import type { DatasetFeature } from '$lib/types';
+import { error } from '@sveltejs/kit';
+import { Permission } from '$lib/config/AppConfig';
+
+export const load: PageServerLoad = async ({ fetch, params, parent }) => {
+	const { session } = await parent();
+	if (!session) {
+		error(403, { message: 'No permission to access' });
+	}
+	const id = params.id;
+
+	const res = await fetch(`/api/datasets/${id}`);
+	if (!res.ok) {
+		if (res.status === 403) {
+			error(res.status, { message: 'No permission to access' });
+		} else if (res.status === 404) {
+			error(res.status, { message: 'No dataset found' });
+		} else {
+			error(res.status, { message: res.statusText });
+		}
+	}
+	const feature: DatasetFeature = await res.json();
+
+	if (feature.properties.permission < Permission.WRITE) {
+		error(403, { message: 'No permission to access' });
+	}
+
+	return {
+		feature
+	};
+};

--- a/sites/geohub/src/routes/(app)/data/[id]/permission/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/[id]/permission/+page.server.ts
@@ -22,7 +22,7 @@ export const load: PageServerLoad = async ({ fetch, params, parent }) => {
 	}
 	const feature: DatasetFeature = await res.json();
 
-	if (feature.properties.permission < Permission.WRITE) {
+	if (!(feature.properties.permission >= Permission.READ)) {
 		error(403, { message: 'No permission to access' });
 	}
 

--- a/sites/geohub/src/routes/(app)/data/[id]/permission/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/permission/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import UserPermission from '$components/pages/data/datasets/UserPermission.svelte';
+	import BackToPreviousPage from '$components/util/BackToPreviousPage.svelte';
+	import { getAccessLevelIcon } from '$lib/helper';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const accessIcon = getAccessLevelIcon(data.feature.properties.access_level, true);
+</script>
+
+<div class="m-4 py-5">
+	<div class="is-flex">
+		<p class="title is-3 px-2 m-0">
+			{#if accessIcon}
+				<i class="{accessIcon} p-1 pr-2" />
+			{/if}
+			{data.feature.properties.name}
+		</p>
+	</div>
+
+	<div class="mt-2"><BackToPreviousPage defaultLink="/data/{data.feature.properties.id}" /></div>
+
+	<UserPermission bind:dataset={data.feature} />
+</div>

--- a/sites/geohub/src/routes/(app)/data/[id]/permission/+page.ts
+++ b/sites/geohub/src/routes/(app)/data/[id]/permission/+page.ts
@@ -1,0 +1,15 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ data }) => {
+	const { feature } = data;
+	const title = `Permission | ${feature.properties.name} | Data | GeoHub`;
+	const content = `User permission for ${feature.properties.name}`;
+	const site_description = feature.properties.description;
+
+	return {
+		title,
+		content,
+		site_description,
+		feature
+	};
+};

--- a/sites/geohub/static/api/swagger/spec.yaml
+++ b/sites/geohub/static/api/swagger/spec.yaml
@@ -317,11 +317,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DatasetPermission'
-      description: |-
+      description: |
         Register user permission for a dataset
 
-        - only users with owner/write permission can register.
+        - only users with owner/write/read permission can register.
         - users with write permission cannot register owner permission to a user.
+        - users with read permission can register read permission to a user.
       tags:
         - datasets
       requestBody:
@@ -348,8 +349,9 @@ paths:
         Update user permission for a dataset
 
         - signed user cannot update their own permission
-        - only users with owner/write permission can update.
+        - only users with owner/write/read permission can update.
         - users with write permission cannot update owner permission to a user.
+        - users with read permission cannot update owner/write permission to a user.
       security:
         - Azure AD authentication: []
       requestBody:
@@ -375,8 +377,9 @@ paths:
         Delete user permission for a dataset
 
         - cannot delete signed in user themselves
-        - only users with owner/write permission can delete.
+        - only users with owner/write/read permission can delete.
         - users with write permission cannot delete owner.
+        - users with read permission cannot delete owner/write
         - if only a user is registered, cannot delete user. at least a user needs to be registered
       security:
         - Azure AD authentication: []


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
closes #2701

* added new dropdown menu `set user permission` at dataset page
* created new page `dataset/{id}/permission` to add/edit/delete` user permission
* allows READ permission users to invite users to dataset as new viewer permission
* I commented source code of email message textbox.

TODO

* [ ] need to setup Azure Communication Service for email notification
* [ ] need to change permission API to send email if send email checkbox is ticked.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1285139894) by [Unito](https://www.unito.io)
