### PR TITLE
fix: fixed bug of datasets api SQL when users do not sign in

### DIFF
--- a/.changeset/weak-parrots-study.md
+++ b/.changeset/weak-parrots-study.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of datasets api SQL when users do not sign in

--- a/sites/geohub/src/routes/(app)/data/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/+page.svelte
@@ -50,7 +50,9 @@
 
 	const updateCounters = () => {
 		tabs[0].counter = datasets?.pages?.totalCount ?? 0;
-		tabs[1].counter = ingestingDatasets?.length ?? 0;
+		if (tabs.length > 1) {
+			tabs[1].counter = ingestingDatasets?.length ?? 0;
+		}
 	};
 
 	const getActiveTabLabel = (id: string) => {

--- a/sites/geohub/src/routes/api/datasets/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/+server.ts
@@ -150,11 +150,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             ${
 							!is_superuser && user_email
 								? `CASE WHEN p.permission is not null THEN p.permission ELSE null END`
-								: `${
-										is_superuser
-											? Permission.OWNER
-											: 'CASE WHEN p.permission is not null THEN p.permission ELSE null END'
-									}`
+								: `${is_superuser ? Permission.OWNER : 'null'}`
 						} as permission,
             ${
 							user_email


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
There was a bug in dataset api and data page when users do not sign in.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1287729635) by [Unito](https://www.unito.io)
