### PR TITLE
Revert "chore(deps): update pramsey/pg_tileserv docker tag to v20240118"

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - RIO_TILER_MAX_THREADS=1
 
   pg_tileserv:
-    image: pramsey/pg_tileserv:20240118
+    image: pramsey/pg_tileserv:20231005
     container_name: pg_tileserv
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Reverts UNDP-Data/geohub#2753

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1288020017) by [Unito](https://www.unito.io)
