### PR TITLE
fix: add more margin and background-color for header in data page and map page.

### DIFF
--- a/.changeset/happy-cherries-thank.md
+++ b/.changeset/happy-cherries-thank.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add more margin and background-color for header in data page and map page.

--- a/sites/geohub/src/components/pages/data/datasets/PublishedDataset.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/PublishedDataset.svelte
@@ -62,151 +62,149 @@
 
 <svelte:window bind:innerWidth />
 
-<div class="p-0 py-2">
-	<div class="buttons my-2">
-		<Star
-			bind:id={feature.properties.id}
-			bind:isStar={feature.properties.is_star}
-			bind:no_stars={feature.properties.no_stars}
-			table="datasets"
-			size="normal"
-		/>
+<div class="buttons my-2">
+	<Star
+		bind:id={feature.properties.id}
+		bind:isStar={feature.properties.is_star}
+		bind:no_stars={feature.properties.no_stars}
+		table="datasets"
+		size="normal"
+	/>
 
-		{#if !isStac && feature.properties.permission > Permission.READ}
-			<a class="button" href={getEditMetadataPage(feature.properties.url)}>
-				<span class="icon">
-					<i class="fa-solid fa-pen-to-square" />
-				</span>
-				<span>Edit</span>
-			</a>
-		{/if}
-		{#if feature.properties.permission > Permission.WRITE}
-			<button
-				class="button"
-				on:click={() => {
-					confirmDeleteDialogVisible = true;
-				}}
-				on:keydown={handleEnterKey}
-			>
-				<span class="icon">
-					<i class="fa-solid fa-trash" />
-				</span>
-				<span>Unpublish</span>
-			</button>
-		{/if}
+	{#if !isStac && feature.properties.permission > Permission.READ}
+		<a class="button" href={getEditMetadataPage(feature.properties.url)}>
+			<span class="icon">
+				<i class="fa-solid fa-pen-to-square" />
+			</span>
+			<span>Edit</span>
+		</a>
+	{/if}
+	{#if feature.properties.permission > Permission.WRITE}
+		<button
+			class="button"
+			on:click={() => {
+				confirmDeleteDialogVisible = true;
+			}}
+			on:keydown={handleEnterKey}
+		>
+			<span class="icon">
+				<i class="fa-solid fa-trash" />
+			</span>
+			<span>Unpublish</span>
+		</button>
+	{/if}
+</div>
+
+<div class="is-flex is-flex-direction-column">
+	<div class="field">
+		<!-- svelte-ignore a11y-label-has-associated-control -->
+		<label class="label">Description</label>
+		<div class="control">
+			<!-- eslint-disable svelte/no-at-html-tags -->
+			{@html marked(feature.properties.description)}
+		</div>
 	</div>
-
-	<div class="is-flex is-flex-direction-column">
+	{#if sdgs.length > 0}
 		<div class="field">
 			<!-- svelte-ignore a11y-label-has-associated-control -->
-			<label class="label">Description</label>
+			<label class="label">SDGs</label>
+			<div class="control">
+				<div class="sdg-grid">
+					{#each sdgs as sdg}
+						{@const logo = SdgLogos.find((s) => s.value === parseInt(sdg.value))}
+						<figure
+							class={`image is-48x48 is-flex is-align-items-center`}
+							data-testid="icon-figure"
+						>
+							<img src={logo.icon} alt="SDG {logo.value}" title="SDG {logo.value}" />
+						</figure>
+					{/each}
+				</div>
+			</div>
+		</div>
+	{/if}
+	{#if showLicense}
+		<div class="field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label">License</label>
+			<div class="control">
+				{feature.properties.license?.length > 0 ? feature.properties.license : 'No license'}
+			</div>
+		</div>
+	{/if}
+	<div class="columns is-mobile">
+		<div class="column field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label">Source</label>
 			<div class="control">
 				<!-- eslint-disable svelte/no-at-html-tags -->
-				{@html marked(feature.properties.description)}
+				{@html attribution}
 			</div>
 		</div>
-		{#if sdgs.length > 0}
-			<div class="field">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">SDGs</label>
-				<div class="control">
-					<div class="sdg-grid">
-						{#each sdgs as sdg}
-							{@const logo = SdgLogos.find((s) => s.value === parseInt(sdg.value))}
-							<figure
-								class={`image is-48x48 is-flex is-align-items-center`}
-								data-testid="icon-figure"
-							>
-								<img src={logo.icon} alt="SDG {logo.value}" title="SDG {logo.value}" />
-							</figure>
-						{/each}
-					</div>
-				</div>
-			</div>
-		{/if}
-		{#if showLicense}
-			<div class="field">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">License</label>
-				<div class="control">
-					{feature.properties.license?.length > 0 ? feature.properties.license : 'No license'}
-				</div>
-			</div>
-		{/if}
-		<div class="columns is-mobile">
+		{#if unit}
 			<div class="column field">
 				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Source</label>
+				<label class="label">Unit</label>
 				<div class="control">
-					<!-- eslint-disable svelte/no-at-html-tags -->
-					{@html attribution}
-				</div>
-			</div>
-			{#if unit}
-				<div class="column field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">Unit</label>
-					<div class="control">
-						{unit}
-					</div>
-				</div>
-			{/if}
-		</div>
-		<div class="columns is-mobile">
-			<div class="column field">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Created by</label>
-				<div class="control">
-					{feature.properties.created_user}
-				</div>
-			</div>
-			<div class="column field">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Updated by</label>
-				<div class="control">
-					{feature.properties.updated_user}
-				</div>
-			</div>
-		</div>
-		{#if showDatatime}
-			<div class="columns is-mobile is-flex">
-				<div class="column field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">Created at</label>
-					<div class="control">
-						<Time timestamp={feature.properties.createdat} format="HH:mm, MM/DD/YYYY" />
-					</div>
-				</div>
-				<div class="column field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">Updated at</label>
-					<div class="control">
-						<Time timestamp={feature.properties.updatedat} format="HH:mm, MM/DD/YYYY" />
-					</div>
-				</div>
-			</div>
-		{/if}
-		{#if downloadUrl}
-			{@const filePath = new URL(downloadUrl).pathname.split('/')}
-			<div class="field">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Dataset</label>
-				<div class="control">
-					{#await getFileSize(downloadUrl) then bytes}
-						<div class="is-flex is-align-content-center">
-							<DefaultLink
-								href={downloadUrl}
-								title={`${filePath[filePath.length - 1].split('.')[1].toUpperCase()} ${bytes}`}
-								target=""
-							>
-								<i slot="content" class="fas fa-download has-text-primary pl-2"></i>
-							</DefaultLink>
-						</div>
-					{/await}
+					{unit}
 				</div>
 			</div>
 		{/if}
 	</div>
+	<div class="columns is-mobile">
+		<div class="column field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label">Created by</label>
+			<div class="control">
+				{feature.properties.created_user}
+			</div>
+		</div>
+		<div class="column field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label">Updated by</label>
+			<div class="control">
+				{feature.properties.updated_user}
+			</div>
+		</div>
+	</div>
+	{#if showDatatime}
+		<div class="columns is-mobile is-flex">
+			<div class="column field">
+				<!-- svelte-ignore a11y-label-has-associated-control -->
+				<label class="label">Created at</label>
+				<div class="control">
+					<Time timestamp={feature.properties.createdat} format="HH:mm, MM/DD/YYYY" />
+				</div>
+			</div>
+			<div class="column field">
+				<!-- svelte-ignore a11y-label-has-associated-control -->
+				<label class="label">Updated at</label>
+				<div class="control">
+					<Time timestamp={feature.properties.updatedat} format="HH:mm, MM/DD/YYYY" />
+				</div>
+			</div>
+		</div>
+	{/if}
+	{#if downloadUrl}
+		{@const filePath = new URL(downloadUrl).pathname.split('/')}
+		<div class="field">
+			<!-- svelte-ignore a11y-label-has-associated-control -->
+			<label class="label">Dataset</label>
+			<div class="control">
+				{#await getFileSize(downloadUrl) then bytes}
+					<div class="is-flex is-align-content-center">
+						<DefaultLink
+							href={downloadUrl}
+							title={`${filePath[filePath.length - 1].split('.')[1].toUpperCase()} ${bytes}`}
+							target=""
+						>
+							<i slot="content" class="fas fa-download has-text-primary pl-2"></i>
+						</DefaultLink>
+					</div>
+				{/await}
+			</div>
+		</div>
+	{/if}
 </div>
 
 <PublishedDatasetDeleteDialog

--- a/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
@@ -139,17 +139,15 @@
 	});
 </script>
 
-<div class="m-4">
+<div class="has-background-light px-6 pt-4">
 	<div class="py-4"><BackToPreviousPage defaultLink="/data" /></div>
 
-	<div class="is-flex">
-		<p class="title is-3 px-2 m-0">
-			{#if accessIcon}
-				<i class="{accessIcon} p-1 pr-2" />
-			{/if}
-			{feature.properties.name}
-		</p>
-	</div>
+	<p class="title is-3 px-2 mt-6 mb-4">
+		{#if accessIcon}
+			<i class="{accessIcon} p-1 pr-2" />
+		{/if}
+		{feature.properties.name}
+	</p>
 
 	<div class="is-fullwidth">
 		<Tabs
@@ -163,7 +161,8 @@
 			fontWeight="semibold"
 		/>
 	</div>
-
+</div>
+<div class="mx-6 my-4">
 	<div hidden={activeTab !== `#${TabNames.INFO}`}>
 		<PublishedDataset bind:feature showDatatime={true} showLicense={true} />
 	</div>

--- a/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
@@ -158,7 +158,7 @@
 			bind:tabs
 			bind:activeTab
 			isUppercase={true}
-			fontWeight="semibold"
+			fontWeight="bold"
 		/>
 	</div>
 </div>

--- a/sites/geohub/src/routes/(map)/maps/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(map)/maps/[id]/+page.svelte
@@ -187,45 +187,15 @@
 	};
 </script>
 
-<div class="p-4">
-	<div class="pb-4"><BackToPreviousPage defaultLink="/" /></div>
+<div class="has-background-light px-6 pt-4">
+	<div class="py-4"><BackToPreviousPage defaultLink="/" /></div>
 
-	<h1 class="title is-flex is-align-items-center">
+	<p class="title is-3 px-2 mt-6 mb-4">
 		{#if mapStyle.access_level < AccessLevel.PUBLIC}
 			<i class="{getAccessLevelIcon(mapStyle.access_level)} p-1 pr-2" />
 		{/if}
 		{mapStyle.name}
-	</h1>
-
-	<div class="is-flex">
-		<div class="buttons">
-			<Star
-				bind:id={mapStyle.id}
-				bind:isStar={mapStyle.is_star}
-				bind:no_stars={mapStyle.no_stars}
-				table="style"
-				size="normal"
-			/>
-
-			{#if $page.data.session && ((mapStyle.permission && mapStyle.permission === Permission.OWNER) || $page.data.session.user.is_superuser)}
-				<button class="button" on:click={() => (confirmDeleteDialogVisible = true)}>
-					<span class="icon">
-						<i class="fa-solid fa-trash"></i>
-					</span>
-					<span>Delete</span>
-				</button>
-			{/if}
-		</div>
-
-		<div class="align-right">
-			<a class="button is-primary" href={mapEditLink}>
-				<span class="icon">
-					<i class="fa-solid fa-map"></i>
-				</span>
-				<span> Open </span>
-			</a>
-		</div>
-	</div>
+	</p>
 
 	<div class="is-fullwidth">
 		<Tabs
@@ -236,10 +206,12 @@
 			bind:tabs
 			bind:activeTab
 			isUppercase={true}
-			fontWeight="semibold"
+			fontWeight="bold"
 		/>
 	</div>
+</div>
 
+<div class="mx-6 my-4">
 	<div hidden={activeTab !== `#${TabNames.INFO}`}>
 		<div class="p-2">
 			<table class="table is-striped is-narrow is-hoverable is-fullwidth">
@@ -276,7 +248,37 @@
 	</div>
 
 	<div hidden={activeTab !== `#${TabNames.PREVIEW}`}>
-		<div class="map mt-2" bind:this={mapContainer}>
+		<div class="is-flex">
+			<div class="buttons">
+				<Star
+					bind:id={mapStyle.id}
+					bind:isStar={mapStyle.is_star}
+					bind:no_stars={mapStyle.no_stars}
+					table="style"
+					size="normal"
+				/>
+
+				{#if $page.data.session && ((mapStyle.permission && mapStyle.permission === Permission.OWNER) || $page.data.session.user.is_superuser)}
+					<button class="button" on:click={() => (confirmDeleteDialogVisible = true)}>
+						<span class="icon">
+							<i class="fa-solid fa-trash"></i>
+						</span>
+						<span>Delete</span>
+					</button>
+				{/if}
+			</div>
+
+			<div class="align-right">
+				<a class="button is-primary" href={mapEditLink}>
+					<span class="icon">
+						<i class="fa-solid fa-map"></i>
+					</span>
+					<span> Open </span>
+				</a>
+			</div>
+		</div>
+
+		<div class="map" bind:this={mapContainer}>
 			{#if $mapStore}
 				<MapQueryInfoControl bind:map={$mapStore} bind:layerList={layerListStore} />
 				<MaplibreLegendControl bind:map={$mapStore} bind:layerList={layerListStore} />


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2798

* use same design of header for data page and map page with back ground color and same margin.
* for map page, moved operation buttons to under preview tab (maybe star and delete can be under Info tab, but I just kept all buttons together)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1295924608) by [Unito](https://www.unito.io)
