### PR TITLE
fix: changed tabs in layer edit panel to UNDP tabs

### DIFF
--- a/.changeset/rotten-tigers-lie.md
+++ b/.changeset/rotten-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: changed tabs in layer edit panel to UNDP tabs

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLayer.svelte
@@ -89,7 +89,9 @@
 	bind:activeTab
 	on:tabChange={(e) => (activeTab = e.detail)}
 	size="is-normal"
-	fontWeight="semibold"
+	fontWeight="bold"
+	isUppercase={true}
+	isBoxed={false}
 />
 
 <div class="editor-contents" hidden={activeTab !== TabNames.STYLE}>

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLayer.svelte
@@ -131,7 +131,9 @@
 	bind:activeTab
 	on:tabChange={(e) => (activeTab = e.detail)}
 	size="is-normal"
-	fontWeight="semibold"
+	fontWeight="bold"
+	isUppercase={true}
+	isBoxed={false}
 />
 
 <div class="editor-contents" hidden={activeTab !== TabNames.STYLE}>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2851

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1300472633) by [Unito](https://www.unito.io)
