### PR TITLE
fix: bug of when selecting continent in data tab.

### DIFF
--- a/.changeset/strong-taxis-sip.md
+++ b/.changeset/strong-taxis-sip.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: bug of when selecting continent in data tab.

--- a/sites/geohub/src/components/pages/map/data/DataView.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataView.svelte
@@ -82,6 +82,12 @@
 			bcs.push(category.name);
 			apiUrl.searchParams.set('breadcrumbs', bcs.join(','));
 
+			for (let i = 0; i < breadcrumbs.length; i++) {
+				if (breadcrumbs[i].name === category.name) {
+					breadcrumbs[i] = category;
+				}
+			}
+
 			if (category.url.startsWith('/api/datasets')) {
 				const apiUrl = new URL(
 					`/api/datasets${$page.url.search}${$page.url.hash}`,
@@ -204,13 +210,19 @@
 	};
 
 	const isDatasetLoading = () => {
-		const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1].name;
-		const category = DataCategories.find((c) => c.name === lastBreadcrumb);
+		const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1];
+		let category = DataCategories.find((c) => c.name === lastBreadcrumb.name);
+		if (!category) {
+			category = lastBreadcrumb;
+		}
 
 		if (query?.length > 0) {
 			return true;
 		} else {
-			if (lastBreadcrumb === 'Home' || (category && !category.url.startsWith('/api/datasets'))) {
+			if (
+				lastBreadcrumb.name === 'Home' ||
+				(category && !category.url.startsWith('/api/datasets'))
+			) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixed bug of loading data when selecting a continent in data tab

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1301511296) by [Unito](https://www.unito.io)
