### PR TITLE
fix: use different entrypoint.sh for static-api used in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -92,8 +92,13 @@ services:
 
   static_image_api:
     image: undpgeohub.azurecr.io/geohub-static-image-api:develop
+    platform: linux/amd64
     container_name: static_image_api
     restart: unless-stopped
     ports:
       - 9000:3000
+    volumes:
+      ## entrypoint.sh in original one from Docker image does not work with this docker-compose.
+      ## overwrite entrypoint.sh for static api in docker-compose.
+      - ./static-api-entrypoint.sh:/app/entrypoint.sh
     entrypoint: /app/entrypoint.sh

--- a/docker/static-api-entrypoint.sh
+++ b/docker/static-api-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start Xvfb
+Xvfb ${DISPLAY} -screen 0 "1024x768x24" &
+
+# Start your node application
+node /app/index.js


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
found static-api image does not work with docker-compose locally. but it works in our AppService. Decided to use another different entrypoint.sh for docker-compose

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1301944150) by [Unito](https://www.unito.io)
