### PR TITLE
fix: don't execute evfb if DISPLAY is already in use

### DIFF
--- a/docker/static-api-entrypoint.sh
+++ b/docker/static-api-entrypoint.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# Start Xvfb
-Xvfb ${DISPLAY} -screen 0 "1024x768x24" &
+# Check if DISPLAY is already in use
+if ! ps aux | grep -q "[X]vfb.*${DISPLAY}"; then
+  echo "Starting Xvfb..."
+  # Start Xvfb
+  Xvfb ${DISPLAY} -screen 0 "1024x768x24" &
+else
+  echo "Xvfb is already running on ${DISPLAY}"
+fi
 
 # Start your node application
 node /app/index.js


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixed bug of entrypoint.sh for docker

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1302074272) by [Unito](https://www.unito.io)
