### PR TITLE
Revert "fix: introduced tabs in settings page to use unified design with maps/data page."

### DIFF
--- a/.changeset/rude-berries-tell.md
+++ b/.changeset/rude-berries-tell.md
@@ -1,5 +1,0 @@
----
-"geohub": patch
----
-
-fix: introduced tabs in settings page to use unified design with maps/data page.


### PR DESCRIPTION
Reverts UNDP-Data/geohub#2879

introducing accordions looks not good for users. Previous version is better. I am going to revert it.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1303074734) by [Unito](https://www.unito.io)
