### PR TITLE
fix: set button padding and disabled background color in undp-bulma button style

### DIFF
--- a/.changeset/shaggy-geese-glow.md
+++ b/.changeset/shaggy-geese-glow.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/undp-bulma": patch
+---
+
+fix: set button padding and disabled background color in undp-bulma button style

--- a/packages/undp-bulma/bulma.scss
+++ b/packages/undp-bulma/bulma.scss
@@ -60,6 +60,11 @@ $table-head-cell-border-width: 0;
 // customised modal for UNDP
 $modal-background-background-color: rgba(247, 247, 247, 0.8);
 
+// customised button for UNDP
+$button-padding-vertical: 1rem;
+$button-padding-horizontal: 1.5rem;
+$button-disabled-background-color: #d4d6d8;
+
 // 4. Setup your Custom Colors
 $linkedin: #0077b5;
 $linkedin-invert: findColorInvert($linkedin);

--- a/packages/undp-bulma/src/main.ts
+++ b/packages/undp-bulma/src/main.ts
@@ -6,6 +6,8 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
 
   <button class="button is-link">Secondary color Button</button>
 
+  <button class="button is-primary" disabled>Disabled color Button</button>
+
   <br>
   <br>
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
set same padding of UNDP button for bulma

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1303176942) by [Unito](https://www.unito.io)
