### PR TITLE
fix: removed button-disabled-background-color from undp-bulma setting

### DIFF
--- a/.changeset/chilly-cows-appear.md
+++ b/.changeset/chilly-cows-appear.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/undp-bulma": patch
+---
+
+fix: removed button-disabled-background-color from undp-bulma setting. it has a problem of disabled button color appearance

--- a/packages/undp-bulma/bulma.scss
+++ b/packages/undp-bulma/bulma.scss
@@ -63,7 +63,6 @@ $modal-background-background-color: rgba(247, 247, 247, 0.8);
 // customised button for UNDP
 $button-padding-vertical: 1rem;
 $button-padding-horizontal: 1.5rem;
-$button-disabled-background-color: #d4d6d8;
 
 // 4. Setup your Custom Colors
 $linkedin: #0077b5;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
 it has a problem of disabled button color appearance

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1303519030) by [Unito](https://www.unito.io)
