### PR TITLE
fix: remove layers from saved map style.json if signed/unsigned in user does not have permission to access to the dataset

### DIFF
--- a/.changeset/serious-students-build.md
+++ b/.changeset/serious-students-build.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: remove layers from saved map style.json if signed/unsigned in user does not have permission to access to the dataset. In this case, a warning message is shown inside the layer accordion to tell users does not have permission to access.

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -138,6 +138,7 @@
 							const id = l.dataset.properties.id;
 							const stacType = l.dataset.properties.tags.find((t) => t.key === 'stacType')?.value;
 							if (['cog', 'mosaicjson'].includes(stacType)) continue;
+							if (!initiaMapStyle.layers.find((l) => l.id === id)) continue;
 							const datasetUrl = `${$page.url.origin}/api/datasets/${id}`;
 							const res = await fetch(datasetUrl);
 							if (res.ok) {

--- a/sites/geohub/src/components/pages/map/layers/LayerList.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerList.svelte
@@ -254,9 +254,9 @@
 	{/if}
 
 	{#each $layerListStore as layer (layer.id)}
-		{@const type = getLayerStyle($map, layer.id)?.type}
-		{#if type}
-			{#if ['raster', 'hillshade'].includes(type)}
+		{@const props = layer.dataset?.properties}
+		{#if props}
+			{#if props.is_raster}
 				<RasterSimpleLayer
 					{layer}
 					bind:isExpanded={layer.isExpanded}

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -37,6 +37,7 @@
 	let isDeleteDialogVisible = false;
 
 	const accessLevel = layer.dataset.properties.access_level ?? AccessLevel.PUBLIC;
+	const existLayerInMap = $map.getStyle().layers.find((l) => l.id === layer.id) ? true : false;
 
 	const tippy = initTippy({
 		placement: 'bottom-end',
@@ -183,30 +184,32 @@
 			</div>
 		{/if}
 
-		{#if showEditButton}
-			<button
-				class="button menu-button hidden-mobile p-0 px-2 ml-1"
-				on:click={handleEditLayer}
-				use:tippyTooltip={{ content: 'Edit the settings on how the layer is visualised.' }}
-			>
-				<span class="icon is-small">
-					<i class="fa-solid fa-sliders has-text-grey-dark"></i>
-				</span>
-			</button>
+		{#if existLayerInMap}
+			{#if showEditButton}
+				<button
+					class="button menu-button hidden-mobile p-0 px-2 ml-1"
+					on:click={handleEditLayer}
+					use:tippyTooltip={{ content: 'Edit the settings on how the layer is visualised.' }}
+				>
+					<span class="icon is-small">
+						<i class="fa-solid fa-sliders has-text-grey-dark"></i>
+					</span>
+				</button>
+			{/if}
+
+			<VisibilityButton {layer} />
+
+			<div class="dropdown-trigger">
+				<button
+					class="button menu-button menu-button-{layer.id} p-0 px-2 ml-1"
+					use:tippy={{ content: tooltipContent }}
+				>
+					<span class="icon is-small">
+						<i class="fas fa-ellipsis has-text-grey-dark" aria-hidden="true"></i>
+					</span>
+				</button>
+			</div>
 		{/if}
-
-		<VisibilityButton {layer} />
-
-		<div class="dropdown-trigger">
-			<button
-				class="button menu-button menu-button-{layer.id} p-0 px-2 ml-1"
-				use:tippy={{ content: tooltipContent }}
-			>
-				<span class="icon is-small">
-					<i class="fas fa-ellipsis has-text-grey-dark" aria-hidden="true"></i>
-				</span>
-			</button>
-		</div>
 	</div>
 	<div slot="content">
 		{#key isLayerChanged}
@@ -215,63 +218,65 @@
 	</div>
 </Accordion>
 
-<div role="menu" bind:this={tooltipContent}>
-	<div class="dropdown-content">
-		<!-- svelte-ignore a11y-missing-attribute -->
-		<a
-			class="dropdown-item"
-			role="button"
-			tabindex="0"
-			on:click={handleZoomToLayer}
-			on:keydown={handleEnterKey}
-		>
-			<span class="icon-text">
-				<span class="icon">
-					<i class="fa-solid fa-magnifying-glass-plus"></i>
-				</span>
-				<span>Zoom to layer</span>
-			</span>
-		</a>
-
-		<!-- svelte-ignore a11y-missing-attribute -->
-		<a
-			class="dropdown-item"
-			role="button"
-			tabindex="0"
-			on:click={handleShowOnlyThisLayer}
-			on:keydown={handleEnterKey}
-		>
-			<span class="icon-text">
-				<span class="icon">
-					<i class="fa-solid fa-eye"></i>
-				</span>
-				<span>Show only this layer</span>
-			</span>
-		</a>
-		{#if showEditButton}
+{#if existLayerInMap}
+	<div role="menu" bind:this={tooltipContent}>
+		<div class="dropdown-content">
 			<!-- svelte-ignore a11y-missing-attribute -->
 			<a
 				class="dropdown-item"
 				role="button"
 				tabindex="0"
-				on:click={() => {
-					clickMenuButton();
-					isDeleteDialogVisible = true;
-				}}
+				on:click={handleZoomToLayer}
 				on:keydown={handleEnterKey}
 			>
 				<span class="icon-text">
 					<span class="icon">
-						<i class="fa-solid fa-trash"></i>
+						<i class="fa-solid fa-magnifying-glass-plus"></i>
 					</span>
-					<span>Delete layer</span>
+					<span>Zoom to layer</span>
 				</span>
 			</a>
-		{/if}
+
+			<!-- svelte-ignore a11y-missing-attribute -->
+			<a
+				class="dropdown-item"
+				role="button"
+				tabindex="0"
+				on:click={handleShowOnlyThisLayer}
+				on:keydown={handleEnterKey}
+			>
+				<span class="icon-text">
+					<span class="icon">
+						<i class="fa-solid fa-eye"></i>
+					</span>
+					<span>Show only this layer</span>
+				</span>
+			</a>
+			{#if showEditButton}
+				<!-- svelte-ignore a11y-missing-attribute -->
+				<a
+					class="dropdown-item"
+					role="button"
+					tabindex="0"
+					on:click={() => {
+						clickMenuButton();
+						isDeleteDialogVisible = true;
+					}}
+					on:keydown={handleEnterKey}
+				>
+					<span class="icon-text">
+						<span class="icon">
+							<i class="fa-solid fa-trash"></i>
+						</span>
+						<span>Delete layer</span>
+					</span>
+				</a>
+			{/if}
+		</div>
 	</div>
-</div>
-{#if showEditButton}
-	<DeleteMenu bind:layer bind:isVisible={isDeleteDialogVisible} on:delete={handleDeleted} />
+	{#if showEditButton}
+		<DeleteMenu bind:layer bind:isVisible={isDeleteDialogVisible} on:delete={handleDeleted} />
+	{/if}
 {/if}
 
 <style lang="scss">

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterSimpleLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterSimpleLayer.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import RasterSimpleLegend from '$components/maplibre/raster/RasterSimpleLegend.svelte';
 	import LayerTemplate from '$components/pages/map/layers/LayerTemplate.svelte';
+	import Notification from '$components/util/Notification.svelte';
 	import type { Layer } from '$lib/types';
-	import { createEventDispatcher } from 'svelte';
+	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import { createEventDispatcher, getContext } from 'svelte';
+
+	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
@@ -13,15 +17,23 @@
 	const handleToggleChanged = (e) => {
 		dispatch('toggled', e.detail);
 	};
+
+	const existLayerInMap = $map.getStyle().layers.find((l) => l.id === layer.id) ? true : false;
 </script>
 
 <LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged} bind:showEditButton>
 	<div slot="content">
-		<RasterSimpleLegend
-			bind:layerId={layer.id}
-			bind:metadata={layer.info}
-			bind:tags={layer.dataset.properties.tags}
-			bind:links={layer.dataset.properties.links}
-		/>
+		{#if existLayerInMap}
+			<RasterSimpleLegend
+				bind:layerId={layer.id}
+				bind:metadata={layer.info}
+				bind:tags={layer.dataset.properties.tags}
+				bind:links={layer.dataset.properties.links}
+			/>
+		{:else}
+			<Notification type="warning" showCloseButton={false}>
+				You have no permission to access this dataset
+			</Notification>
+		{/if}
 	</div>
 </LayerTemplate>

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorSimpleLayer.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorSimpleLayer.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import VectorLegend from '$components/maplibre/vector/VectorLegend.svelte';
 	import LayerTemplate from '$components/pages/map/layers/LayerTemplate.svelte';
+	import Notification from '$components/util/Notification.svelte';
 	import type { Layer, VectorTileMetadata } from '$lib/types';
-	import { createEventDispatcher } from 'svelte';
+	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import { createEventDispatcher, getContext } from 'svelte';
+
+	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
 
@@ -15,11 +19,23 @@
 	const handleToggleChanged = (e) => {
 		dispatch('toggled', e.detail);
 	};
+
+	const existLayerInMap = $map.getStyle().layers.find((l) => l.id === layer.id) ? true : false;
 </script>
 
 <LayerTemplate {layer} bind:isExpanded on:toggled={handleToggleChanged} bind:showEditButton>
 	<div slot="content">
-		<VectorLegend bind:layerId={layer.id} bind:metadata bind:tags={layer.dataset.properties.tags} />
+		{#if existLayerInMap}
+			<VectorLegend
+				bind:layerId={layer.id}
+				bind:metadata
+				bind:tags={layer.dataset.properties.tags}
+			/>
+		{:else}
+			<Notification type="warning" showCloseButton={false}>
+				You have no permission to access this dataset
+			</Notification>
+		{/if}
 	</div>
 </LayerTemplate>
 

--- a/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
 	import {
-		LEGEND_READONLY_CONTEXT_KEY,
 		createLegendReadonlyStore,
+		LEGEND_READONLY_CONTEXT_KEY,
 		type LayerListStore,
 		type LegendReadonlyStore
 	} from '$stores';
@@ -52,7 +52,7 @@
 	import RasterSimpleLayer from '$components/pages/map/layers/raster/RasterSimpleLayer.svelte';
 	import VectorSimpleLayer from '$components/pages/map/layers/vector/VectorSimpleLayer.svelte';
 	import FloatingPanel from '$components/util/FloatingPanel.svelte';
-	import { getLayerStyle, initTooltipTippy } from '$lib/helper';
+	import { initTooltipTippy } from '$lib/helper';
 	import { draggable, type DragOptions } from '@neodrag/svelte';
 
 	export let map: Map;
@@ -223,9 +223,9 @@
 
 			<div class="legend-contents py-2">
 				{#each $layerList as layer (layer.id)}
-					{@const type = getLayerStyle(map, layer.id)?.type}
-					{#if type}
-						{#if type === 'raster'}
+					{@const props = layer.dataset?.properties}
+					{#if props}
+						{#if props.is_raster}
 							<RasterSimpleLayer
 								{layer}
 								bind:isExpanded={layer.isExpanded}

--- a/sites/geohub/src/routes/(auth)/auth/signIn/+page.ts
+++ b/sites/geohub/src/routes/(auth)/auth/signIn/+page.ts
@@ -1,6 +1,6 @@
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ url }) => {
 	const title = 'Sign In | GeoHub';
 	const content = 'Sign In';
 
@@ -21,7 +21,7 @@ export const load: PageLoad = async () => {
 		}
 	];
 
-	const res = await fetch('/auth/providers');
+	const res = await fetch(`${url.origin}/auth/providers`);
 	const authProviders: { [key: string]: unknown } = await res.json();
 	const availableNames = Object.keys(authProviders);
 	providers = providers.filter((p) => availableNames.includes(p.id));


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #2832

* fix: remove layers from saved map style.json if signed/unsigned in user does not have permission to access to the dataset. In this case, a warning message is shown inside the layer accordion to tell users does not have permission to access.
* remove layers/sources which user does not have permission to access at /api/style/{id} endpoint
* but it still remain layer in `style.layers` array, so frontend can know user has no access to the dataset.

it shows warning message like below.

![](https://github.com/UNDP-Data/geohub/assets/2639701/17141998-5252-4abf-aa72-0a83b5c44cf4)

![](https://github.com/UNDP-Data/geohub/assets/2639701/67272b7e-6ed8-40c3-acc0-8ead759d95f0)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1303837205) by [Unito](https://www.unito.io)
