### PR TITLE
fix add error handling in isStyleChanged function

### DIFF
--- a/.changeset/fifty-shirts-wonder.md
+++ b/.changeset/fifty-shirts-wonder.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix add error handling in isStyleChanged function

--- a/sites/geohub/src/lib/helper/isStyleChanged.ts
+++ b/sites/geohub/src/lib/helper/isStyleChanged.ts
@@ -12,6 +12,7 @@ const sortObject = (obj) => {
 };
 
 export const isStyleChanged = (style1: StyleSpecification, style2: StyleSpecification) => {
+	if (!style1 || !style2) return false;
 	const currentSources = style1.sources;
 	const savedSources = style2.sources;
 	return !(


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

added error handling to check whether style variables are not undefined

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
