### PR TITLE
fix: skip if layer is not there in style.json when use query tool

### DIFF
--- a/.changeset/smart-dryers-protect.md
+++ b/.changeset/smart-dryers-protect.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: skip if layer is not there in style.json when use query tool

--- a/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
@@ -101,6 +101,7 @@
 
 		for (const layer of $layerList) {
 			const layerStyle = getLayerStyle(map, layer.id);
+			if (!layerStyle) continue;
 			const visibility = layerStyle.layout?.visibility ?? 'visible';
 			if (visibility === 'none') continue;
 			if (layerStyle.type === 'raster') {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fix: skip if layer is not there in style.json when use query tool

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1303965411) by [Unito](https://www.unito.io)
