### PR TITLE
fix: reverted logo height to original UNDP header version

### DIFF
--- a/.changeset/nine-ants-enjoy.md
+++ b/.changeset/nine-ants-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: previously, we changed logo height to be the same height of header because the logo stuck out affected our sidebar design. But current design can be together with original logo height. Reverted logo height to the original UNDP design header.

--- a/packages/svelte-undp-design/src/lib/css/country-site-header.min.css
+++ b/packages/svelte-undp-design/src/lib/css/country-site-header.min.css
@@ -43,22 +43,18 @@
 }
 @media (min-width: 64em) {
 	.country-header .header .top-left .logo img {
-		height: 7.1875rem;
-		/* height: 122px; */
+		height: 122px;
 	}
 	.country-header .header .top-left .logo img.scrolled {
-		height: 7.1875rem;
-		/* height: 115px; */
+		height: 115px;
 	}
 }
 @media (max-width: 63.9375em) {
 	.country-header .header .top-left .logo img {
-		height: 4.6875rem;
-		/* height: 82px; */
+		height: 82px;
 	}
 	.country-header .header .top-left .logo img.scrolled {
-		height: 4.6875rem;
-		/* height: 75px; */
+		height: 75px;
 	}
 }
 .country-header {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
previously, we changed logo height to be the same height of header because the logo stuck out affected our sidebar design. But current design can be together with original logo height. 

Reverted logo height to the original UNDP design header.

@balagurova what do you think of this reverting? Is that better to be the same logo height of UNDP design?

* current version
![](https://github.com/UNDP-Data/geohub/assets/2639701/921494fe-a135-4327-8b2c-f8e8e87d6ab3)
* reverted version
landing page
![](https://github.com/UNDP-Data/geohub/assets/2639701/4e672822-dd44-4bda-9366-9b5bbea808ee)

with sidebar
![](https://github.com/UNDP-Data/geohub/assets/2639701/7f270e1b-4e4b-492c-8018-121463a39426)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1304013587) by [Unito](https://www.unito.io)
