### PR TITLE
fix: show map menu buttons on top-right always (not affected by the position of sidebar).

### DIFF
--- a/.changeset/tender-scissors-deliver.md
+++ b/.changeset/tender-scissors-deliver.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show map menu buttons on top-right always (not affected by the position of sidebar).

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -4,7 +4,6 @@
 	import MapQueryInfoControl from '$components/pages/map/plugins/MapQueryInfoControl.svelte';
 	import StyleShareControl from '$components/pages/map/plugins/StyleShareControl.svelte';
 	import { AdminControlOptions, MapStyles, TourOptions, attribution } from '$lib/config/AppConfig';
-	import type { UserConfig } from '$lib/config/DefaultUserConfig';
 	import {
 		fromLocalStorage,
 		getSpriteImageList,
@@ -53,8 +52,6 @@
 	const pageDataLoadingStore: PageDataLoadingStore = getContext(PAGE_DATA_LOADING_CONTEXT_KEY);
 	const layerListStore: LayerListStore = getContext(LAYERLISTSTORE_CONTEXT_KEY);
 	const editingMenuShownStore: EditingMenuShownStore = getContext(EDITING_MENU_SHOWN_CONTEXT_KEY);
-
-	let config: UserConfig = $page.data.config;
 
 	let tourOptions: TourGuideOptions;
 	let tourLocalStorageKey = `geohub-map-${$page.url.host}`;
@@ -298,7 +295,7 @@
 				new MaplibreTourControl(tourOptions, {
 					localStorageKey: tourLocalStorageKey
 				}),
-				config.SidebarPosition === 'left' ? 'top-right' : 'top-left'
+				'top-right'
 			);
 
 			layerListStore.subscribe((value) => {
@@ -371,16 +368,8 @@
 </div>
 
 {#if $map}
-	<MapQueryInfoControl
-		bind:map={$map}
-		layerList={layerListStore}
-		position={config.SidebarPosition === 'left' ? 'top-right' : 'top-left'}
-	/>
-	<StyleShareControl
-		bind:map={$map}
-		layerList={layerListStore}
-		position={config.SidebarPosition === 'left' ? 'top-right' : 'top-left'}
-	/>
+	<MapQueryInfoControl bind:map={$map} layerList={layerListStore} position="top-right" />
+	<StyleShareControl bind:map={$map} layerList={layerListStore} position="top-right" />
 	<LayerVisibilitySwitcher bind:map={$map} position="bottom-right" />
 	<MaplibreStaticImageControl
 		bind:map={$map}
@@ -388,7 +377,7 @@
 		style={styleUrl}
 		apiBase={$page.data.staticApiUrl}
 		bind:options={exportOptions}
-		position={config.SidebarPosition === 'left' ? 'top-right' : 'top-left'}
+		position="top-right"
 	/>
 {/if}
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixed position of map buttons because of conflicting with admin tool control.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1304737520) by [Unito](https://www.unito.io)
