### PR TITLE
fix: make spaces between menu buttons in layer tab a bit wider

### DIFF
--- a/.changeset/old-trees-double.md
+++ b/.changeset/old-trees-double.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: make spaces between menu buttons in layer tab a bit wider

--- a/sites/geohub/src/components/pages/map/layers/LayerList.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerList.svelte
@@ -126,7 +126,7 @@
 		<div class="layer-header-buttons buttons mb-0">
 			{#key $layerListStore}
 				<button
-					class="button m-0 px-3"
+					class="button m-0 px-4"
 					disabled={expandAllDisabled()}
 					on:click={handleExpandAll}
 					use:tippyTooltip={{ content: 'Expand all layers' }}
@@ -161,7 +161,7 @@
 				</button>
 
 				<button
-					class="button m-0 px-3"
+					class="button m-0 px-4"
 					disabled={collapseAllDisabled()}
 					use:tippyTooltip={{ content: 'Collapse all layers' }}
 					on:click={handleCollapseAll}
@@ -200,7 +200,7 @@
 				{/if}
 
 				<button
-					class="button m-0 px-3"
+					class="button m-0 px-4"
 					disabled={$layerListStore?.length === 0}
 					use:tippyTooltip={{ content: 'Delete all layers' }}
 					on:click={openDeleteDialog}

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -168,15 +168,10 @@
 	isSelected={$editingLayerStore?.id === layer.id}
 	showHoveredColor={true}
 >
-	<div
-		class="button-grid {accessLevel === AccessLevel.PUBLIC
-			? 'hide-access-buton'
-			: ''} {existLayerInMap ? '' : 'hide-menu'}  {showEditButton ? '' : 'hide-edit'} mr-1"
-		slot="buttons"
-	>
+	<div class="is-flex is-align-items-center" slot="buttons">
 		{#if accessLevel !== AccessLevel.PUBLIC}
 			<div
-				class="button menu-button p-0"
+				class="button menu-button px-3 py-0"
 				use:tippyTooltip={{
 					content: `This dataset has limited data accesibility. It only has ${
 						accessLevel === AccessLevel.PRIVATE ? 'private' : 'organisation'
@@ -192,7 +187,7 @@
 		{#if existLayerInMap}
 			{#if showEditButton}
 				<button
-					class="button menu-button hidden-mobile p-0"
+					class="button menu-button hidden-mobile px-3 py-0"
 					on:click={handleEditLayer}
 					use:tippyTooltip={{ content: 'Edit the settings on how the layer is visualised.' }}
 				>
@@ -206,7 +201,7 @@
 
 			<div class="dropdown-trigger">
 				<button
-					class="button menu-button menu-button-{layer.id} p-0"
+					class="button menu-button menu-button-{layer.id} px-3 py-0"
 					use:tippy={{ content: tooltipContent }}
 				>
 					<span class="icon is-small">
@@ -285,44 +280,6 @@
 {/if}
 
 <style lang="scss">
-	.button-grid {
-		display: grid;
-		gap: 1.5rem;
-		grid-template-columns: repeat(4, 1fr);
-
-		@media (max-width: 48em) {
-			grid-template-columns: repeat(3, 1fr);
-		}
-
-		&.hide-edit {
-			grid-template-columns: repeat(3, 1fr);
-			@media (max-width: 48em) {
-				grid-template-columns: repeat(2, 1fr);
-			}
-		}
-
-		&.hide-access-buton {
-			grid-template-columns: repeat(3, 1fr);
-			@media (max-width: 48em) {
-				grid-template-columns: repeat(2, 1fr);
-			}
-
-			&.hide-edit {
-				grid-template-columns: repeat(2, 1fr);
-				@media (max-width: 48em) {
-					grid-template-columns: repeat(1, 1fr);
-				}
-			}
-		}
-
-		&.hide-menu {
-			grid-template-columns: repeat(1, 1fr);
-
-			&.hide-access-buton {
-				display: none;
-			}
-		}
-	}
 	.menu-button {
 		border: none;
 		background: transparent;

--- a/sites/geohub/src/components/pages/map/layers/header/VisibilityButton.svelte
+++ b/sites/geohub/src/components/pages/map/layers/header/VisibilityButton.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <button
-	class="button menu-button p-0"
+	class="button menu-button px-3 py-0"
 	on:click={toggleVisibility}
 	use:tippyTooltip={{ content: 'Change the layer visibility' }}
 >

--- a/sites/geohub/src/components/pages/map/layers/order/LayerOrderPanelButton.svelte
+++ b/sites/geohub/src/components/pages/map/layers/order/LayerOrderPanelButton.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <button
-	class="button m-0 px-3"
+	class="button m-0 px-4"
 	disabled={$layerListStore?.length < 2}
 	use:tippy={{ content: tooltipContent }}
 	use:tippyTooltip={{ content: 'Change layer order' }}

--- a/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MaplibreLegendControl.svelte
@@ -145,11 +145,11 @@
 				show = false;
 			}}
 		>
-			<div class="is-flex is-align-items-center layer-header pt-2">
+			<div class="is-flex is-align-items-center layer-header pt-2 px-4">
 				<div class="layer-header-buttons buttons">
 					{#key $layerList}
 						<button
-							class="button m-0 px-3"
+							class="button m-0 px-4"
 							disabled={expandAllDisabled()}
 							on:click={handleExpandAll}
 							use:tippyTooltip={{ content: 'Expand all layers' }}
@@ -184,7 +184,7 @@
 						</button>
 
 						<button
-							class="button m-0 px-3"
+							class="button m-0 px-4"
 							disabled={collapseAllDisabled()}
 							use:tippyTooltip={{ content: 'Collapse all layers' }}
 							on:click={handleCollapseAll}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #2925

I believe this bug was caused by this change on undp-bulma about paddings of button.

https://github.com/UNDP-Data/geohub/pull/2882

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
