### PR TITLE
feat: added new setting of Development mode in setting page to enable tile boundaries and collision boxes for advanced users.

### DIFF
--- a/.changeset/giant-windows-boil.md
+++ b/.changeset/giant-windows-boil.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+feat: added new setting of Development mode in setting page to enable tile boundaries and collision boxes for advanced users.

--- a/sites/geohub/src/components/pages/map/layers/LayerList.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerList.svelte
@@ -7,6 +7,7 @@
 	import Modal from '$components/util/Modal.svelte';
 	import Notification from '$components/util/Notification.svelte';
 	import { TabNames } from '$lib/config/AppConfig';
+	import type { UserConfig } from '$lib/config/DefaultUserConfig';
 	import { getLayerStyle, initTooltipTippy } from '$lib/helper';
 	import {
 		EDITING_LAYER_STORE_CONTEXT_KEY,
@@ -21,7 +22,7 @@
 		type LegendReadonlyStore,
 		type MapStore
 	} from '$stores';
-	import { getContext, setContext } from 'svelte';
+	import { getContext, onMount, setContext } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 	const layerListStore: LayerListStore = getContext(LAYERLISTSTORE_CONTEXT_KEY);
@@ -34,6 +35,10 @@
 
 	export let contentHeight: number;
 	export let activeTab: TabNames;
+
+	let config: UserConfig = $page.data.config;
+
+	$: isDevMode = $page.url.searchParams.get('dev')?.toLowerCase() === 'true' ? true : false;
 
 	const tippyTooltip = initTooltipTippy();
 	let layerHeaderHeight = 39;
@@ -116,6 +121,17 @@
 		});
 		$layerListStore = [...$layerListStore];
 	};
+
+	const enableDevMode = () => {
+		if (!$map) return;
+		let devmode = isDevMode === true ? true : config.MaplibreDevMode;
+		$map.showTileBoundaries = devmode;
+		$map.showCollisionBoxes = devmode;
+	};
+
+	onMount(() => {
+		enableDevMode();
+	});
 </script>
 
 {#if $layerListStore?.length > 0}

--- a/sites/geohub/src/lib/config/DefaultUserConfig/MaplibreDevMode.ts
+++ b/sites/geohub/src/lib/config/DefaultUserConfig/MaplibreDevMode.ts
@@ -1,0 +1,1 @@
+export const MaplibreDevMode = false;

--- a/sites/geohub/src/lib/config/DefaultUserConfig/index.ts
+++ b/sites/geohub/src/lib/config/DefaultUserConfig/index.ts
@@ -35,6 +35,7 @@ import { DataPageTableViewType } from './DataPageTableViewType';
 import type { SidebarPosition as SidebarPositionType } from '@undp-data/svelte-sidebar';
 import { HomePageMapSearchLimit } from './HomePageMapSearchLimit';
 import { HomePageMapSortingColumn } from './HomePageMapSortingColumn';
+import { MaplibreDevMode } from './MaplibreDevMode';
 
 export interface UserConfig {
 	DatasetSearchLimit: number;
@@ -71,6 +72,7 @@ export interface UserConfig {
 	StacSearchLimit: number;
 	StacDateFilterOption: number;
 	FillExtrusionDefaultPitch: number;
+	MaplibreDevMode: boolean;
 }
 
 export const DefaultUserConfig = {
@@ -107,5 +109,6 @@ export const DefaultUserConfig = {
 	StacMaxCloudCover,
 	StacSearchLimit,
 	StacDateFilterOption,
-	FillExtrusionDefaultPitch
+	FillExtrusionDefaultPitch,
+	MaplibreDevMode
 };

--- a/sites/geohub/src/routes/(app)/settings/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/settings/+page.server.ts
@@ -20,12 +20,14 @@ export const actions = {
 		}
 		const data = await request.formData();
 
-		const settings: { [key: string]: number | string } = {};
+		const settings: { [key: string]: number | string | boolean } = {};
 		Object.keys(DefaultUserConfig).forEach((key) => {
 			const defaultValue = DefaultUserConfig[key];
 			const value = data.get(key)?.toString();
 			if (!value) return;
-			if (parseFloat(defaultValue)) {
+			if (key === 'MaplibreDevMode') {
+				settings[key] = value.toLowerCase() === 'true' ? true : false;
+			} else if (parseFloat(defaultValue)) {
 				settings[key] = parseFloat(value);
 			} else if (parseInt(defaultValue)) {
 				settings[key] = parseInt(value);

--- a/sites/geohub/src/routes/(app)/settings/+page.svelte
+++ b/sites/geohub/src/routes/(app)/settings/+page.svelte
@@ -572,6 +572,26 @@
 					</div>
 				</FieldControl>
 
+				<FieldControl title="Development mode">
+					<div slot="help">
+						If enabled, it shows tile boundaries and collision boxes for advanced users to style
+						layers. You can also enable dev mode if `dev=true` query param is added in map editor
+						page URL.
+					</div>
+					<div slot="control">
+						<div class="field">
+							<input
+								id="enable-dev-mode"
+								type="checkbox"
+								class="switch"
+								bind:checked={userSettings.MaplibreDevMode}
+							/>
+							<label class="pb-1" for="enable-dev-mode">Enable devlopment mode on map editor</label>
+						</div>
+						<input type="hidden" name="MaplibreDevMode" bind:value={userSettings.MaplibreDevMode} />
+					</div>
+				</FieldControl>
+
 				<h2 class="subtitle pt-4">Search Settings</h2>
 				<FieldControl title="Default search Limit">
 					<div slot="help">The number of items to search at data tab in main GeoHub page.</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
![](https://github.com/UNDP-Data/geohub/assets/2639701/e57433cf-53b9-4409-acf9-e27f42f9a421)

or if add `/maps/edit?dev=true` in address bar, it can show tile boundaries and collision boxes

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1306498461) by [Unito](https://www.unito.io)
