### PR TITLE
fix: redirect to map edit page from stac explorer

### DIFF
--- a/.changeset/grumpy-eagles-turn.md
+++ b/.changeset/grumpy-eagles-turn.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: redirect to map edit page from stac explorer

--- a/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
@@ -124,7 +124,7 @@
 		toLocalStorage(layerListStorageKey, storageLayerList);
 
 		// move to /map page
-		const url = `/map${storageMapStyleId ? `/${storageMapStyleId}` : ''}`;
+		const url = `/map${storageMapStyleId ? `/${storageMapStyleId}` : '/edit'}`;
 		goto(url, { invalidateAll: true });
 	};
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
forgot to update endpoint for map edit page

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1307252870) by [Unito](https://www.unito.io)
