### PR TITLE
fix: show band description after band name in raster band selectbox if applicable

### DIFF
--- a/.changeset/light-monkeys-crash.md
+++ b/.changeset/light-monkeys-crash.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show band description after band name in raster band selectbox if applicable

--- a/sites/geohub/src/components/pages/data/datasets/RasterBandSelectbox.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/RasterBandSelectbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isRgbRaster } from '$lib/helper';
-	import type { RasterTileMetadata } from '$lib/types';
+	import type { BandMetadata, RasterTileMetadata } from '$lib/types';
 	import { createEventDispatcher } from 'svelte';
 
 	const dispatch = createEventDispatcher();
@@ -31,17 +31,33 @@
 	if (metadata.band_metadata.length > 0) {
 		bands = metadata.band_metadata.map((meta) => meta[0]) as string[];
 	}
+
+	const getBandDescription = (index: number) => {
+		const bandName = bands[index];
+		let description =
+			bandsDetail?.length > 0 && bandsDetail[index]
+				? bandsDetail[index].description ?? bandsDetail[index].name
+				: '';
+
+		if (!description) {
+			const bandmetas = metadata.band_metadata.map((meta) => meta[1]) as BandMetadata[];
+			description = bandmetas[index].Description ?? '';
+		}
+
+		if (!description) {
+			const descriptions = metadata.band_descriptions.map((b) => b[1]);
+			description = descriptions[index] ?? '';
+		}
+
+		return description ? `${bandName.toUpperCase()} - ${description}` : bandName.toUpperCase();
+	};
 </script>
 
 {#if !isRgbTile && bands?.length > 0}
 	<div class="select is-fullwidth">
 		<select bind:value={selectedBand} {disabled}>
 			{#each bands as band, index}
-				{@const name =
-					bandsDetail?.length > 0 && bandsDetail[index]
-						? bandsDetail[index].description ?? bandsDetail[index].name
-						: `${band}`}
-				<option class="is-capitalized" value={band}>{name}</option>
+				<option value={band}>{getBandDescription(index)}</option>
 			{/each}
 		</select>
 	</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3034

some band description is quite long, so I decided to keep band name, and show band description after band name if available.

![](https://github.com/UNDP-Data/geohub/assets/2639701/041cd61a-692e-4a5a-a496-5c7400f6c148)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1317590906) by [Unito](https://www.unito.io)
