### PR TITLE
fix: new map url in button

### DIFF
--- a/.changeset/ninety-tigers-attack.md
+++ b/.changeset/ninety-tigers-attack.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: url to /maps/edit in `New Map` button in /maps page"

--- a/sites/geohub/src/routes/(app)/maps/+page.svelte
+++ b/sites/geohub/src/routes/(app)/maps/+page.svelte
@@ -52,7 +52,7 @@
 <HeroHeader
 	title="Explore maps"
 	bind:breadcrumbs
-	button={{ title: 'new map', href: '/href/edit', tooltip: 'Create a new map' }}
+	button={{ title: 'new map', href: '/maps/edit', tooltip: 'Create a new map' }}
 />
 
 <div class="mx-6 my-4">


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Fixed url to /maps/edit in `New Map` button in /maps page

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [ ] Code is up-to-date with the `develop` branch
* [ ] No build errors after `pnpm build`
* [ ] No lint errors after `pnpm lint`
* [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1320671746) by [Unito](https://www.unito.io)
