### PR TITLE
fix: show accessibility icon on card at maps and data page

### DIFF
--- a/.changeset/brave-steaks-breathe.md
+++ b/.changeset/brave-steaks-breathe.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: add icon option to show fa icon next to tag at Card and CardWithImage component

--- a/.changeset/metal-drinks-float.md
+++ b/.changeset/metal-drinks-float.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show accessibility icon on card at maps and data page

--- a/packages/svelte-undp-design/src/lib/Card/Card.stories.ts
+++ b/packages/svelte-undp-design/src/lib/Card/Card.stories.ts
@@ -40,6 +40,10 @@ const meta = {
 			options: ['global', 'yellow', 'green', 'red', 'blue'],
 			description: 'accent color. global, yellow, red, blue, green is available',
 			defaultValue: 'global'
+		},
+		icon: {
+			type: 'string',
+			description: 'Optional. Fontawesome icon class name.'
 		}
 	}
 } satisfies Meta<Card>;
@@ -57,5 +61,18 @@ export const Primary: Story = {
 		description:
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus mollis pharetra ex, a laoreet purus vulputate eget.',
 		accent: 'global'
+	}
+};
+
+export const TitleWithIcon: Story = {
+	args: {
+		linkName: 'READ MORE',
+		url: '#',
+		title: 'Title of the post goes here and it’s two lines',
+		tag: 'CONTENT TAG',
+		description:
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus mollis pharetra ex, a laoreet purus vulputate eget.',
+		accent: 'global',
+		icon: 'fas fa-home'
 	}
 };

--- a/packages/svelte-undp-design/src/lib/Card/Card.svelte
+++ b/packages/svelte-undp-design/src/lib/Card/Card.svelte
@@ -13,6 +13,7 @@
 
 	export let isEmphasize = false;
 	export let accent: 'global' | 'yellow' | 'red' | 'green' | 'blue' = 'global';
+	export let icon = '';
 
 	const handleClicked = () => {
 		dispatch('selected');
@@ -22,11 +23,18 @@
 <div
 	class="content-card undp-card {isEmphasize ? 'card-emphasize' : ''} {accent === 'global'
 		? ''
-		: `accent-${accent}`} {tag ? '' : 'hide-border-top'}"
+		: `accent-${accent}`} {tag || icon ? '' : 'hide-border-top'}"
 >
 	<a href={url} on:click={handleClicked}>
-		{#if tag}
-			<h6 class="" data-viewport="false">{tag}</h6>
+		{#if tag || icon}
+			<h6 class="" data-viewport="false">
+				{#if icon}
+					<i class={icon}></i>
+				{/if}
+				{#if tag}
+					{tag}
+				{/if}
+			</h6>
 		{/if}
 		<div class="content-caption">
 			<h5 class="" data-viewport="false">

--- a/packages/svelte-undp-design/src/lib/CardWithImage/CardWithImage.stories.ts
+++ b/packages/svelte-undp-design/src/lib/CardWithImage/CardWithImage.stories.ts
@@ -43,6 +43,10 @@ const meta = {
 			options: ['global', 'yellow', 'green', 'red', 'blue'],
 			description: 'accent color. global, yellow, red, blue, green is available',
 			defaultValue: 'global'
+		},
+		icon: {
+			type: 'string',
+			description: 'Optional. Fontawesome icon class name.'
 		}
 	}
 } satisfies Meta<CardWithImage>;
@@ -61,5 +65,19 @@ export const Primary: Story = {
 		accent: 'global',
 		width: 250,
 		height: 150
+	}
+};
+
+export const TitleWithIcon: Story = {
+	args: {
+		linkName: 'READ MORE',
+		url: '#',
+		title: 'Title of the post goes here and it’s two lines',
+		tag: 'CONTENT TAG',
+		image: '/media/card-thumbnail.jpg',
+		accent: 'global',
+		width: 250,
+		height: 150,
+		icon: 'fas fa-user'
 	}
 };

--- a/packages/svelte-undp-design/src/lib/CardWithImage/CardWithImage.svelte
+++ b/packages/svelte-undp-design/src/lib/CardWithImage/CardWithImage.svelte
@@ -8,6 +8,7 @@
 	export let title: string;
 	export let image: string;
 	export let accent: 'global' | 'yellow' | 'red' | 'green' | 'blue' = 'global';
+	export let icon = '';
 
 	export let width: number;
 	export let height: number;
@@ -16,13 +17,20 @@
 </script>
 
 <div
-	class="content-card {accent === 'global' ? '' : `accent-${accent}`} {tag
+	class="content-card {accent === 'global' ? '' : `accent-${accent}`} {tag || icon
 		? ''
 		: 'hide-border-top'}"
 >
 	<a href={url}>
-		{#if tag}
-			<h6 class="" data-viewport="false">{tag}</h6>
+		{#if tag || icon}
+			<h6 class="" data-viewport="false">
+				{#if icon}
+					<i class={icon}></i>
+				{/if}
+				{#if tag}
+					{tag}
+				{/if}
+			</h6>
 		{/if}
 		<div class="image">
 			<img

--- a/sites/geohub/src/components/pages/data/datasets/CardView.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/CardView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { AccessLevel } from '$lib/config/AppConfig';
+	import { getAccessLevelIcon } from '$lib/helper';
 	import type { DatasetFeature } from '$lib/types';
 	import { Card, CardWithImage } from '@undp-data/svelte-undp-design';
 
@@ -38,6 +39,7 @@
 				: 'yellow'}
 	/>
 {:else}
+	{@const accessIcon = getAccessLevelIcon(feature.properties.access_level, true)}
 	<CardWithImage
 		title={feature.properties.name}
 		url="/data/{feature.properties.id}"
@@ -50,5 +52,6 @@
 			: feature.properties.access_level === AccessLevel.ORGANIZATION
 				? 'blue'
 				: 'yellow'}
+		icon={accessIcon}
 	/>
 {/if}

--- a/sites/geohub/src/components/pages/home/MapStyleCardList.svelte
+++ b/sites/geohub/src/components/pages/home/MapStyleCardList.svelte
@@ -9,6 +9,7 @@
 		MapSortingColumns,
 		SearchDebounceTime
 	} from '$lib/config/AppConfig';
+	import { getAccessLevelIcon } from '$lib/helper';
 	import type { MapsData } from '$lib/types';
 	import { Notification } from '@undp-data/svelte-undp-components';
 	import { CardWithImage, Loader, Pagination, SearchExpand } from '@undp-data/svelte-undp-design';
@@ -222,11 +223,13 @@
 				{@const mapLink = style.links.find((l) => l.rel === 'map')?.href}
 				{@const styleLink = style.links.find((l) => l.rel === 'static-auto')?.href}
 				{@const accessLevel = style.access_level}
+				{@const accessIcon = getAccessLevelIcon(accessLevel, true)}
+
 				<div class="column is-one-third-tablet is-one-quarter-desktop is-full-mobile">
 					<CardWithImage
 						title={style.name}
 						url={mapLink}
-						tag=""
+						tag="Map"
 						image={styleLink.replace('{width}', '298').replace('{height}', '180')}
 						width={298}
 						height={180}
@@ -236,6 +239,7 @@
 							: accessLevel === AccessLevel.ORGANIZATION
 								? 'blue'
 								: 'yellow'}
+						icon={accessIcon}
 					/>
 				</div>
 			{/each}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Now users can see data/map access level in card view

![](https://github.com/UNDP-Data/geohub/assets/2639701/7b02a64f-0f66-4b32-8a3d-2f2d6aed8e80)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1321346301) by [Unito](https://www.unito.io)
