### PR TITLE
 fix: close ModalTemplate by espace key if close button is shown in dialog.

### DIFF
--- a/.changeset/tender-flies-shake.md
+++ b/.changeset/tender-flies-shake.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: close ModalTemplate by espace key if close button is shown in dialog.

--- a/packages/svelte-undp-components/src/lib/components/ModalTemplate.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ModalTemplate.svelte
@@ -10,7 +10,17 @@
 	const close = () => {
 		show = false;
 	};
+
+	const handleEnterEscape = (e: KeyboardEvent) => {
+		if (!showClose) return;
+		// close dialog if close button is shown
+		if (e.key === 'Escape') {
+			close();
+		}
+	};
 </script>
+
+<svelte:window on:keydown={handleEnterEscape} />
 
 <div class="modal {show ? 'is-active' : ''}" transition:fade|global>
 	<div class="modal-background" role="none" on:click={close} on:keydown={handleEnterKey} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,19 +1044,16 @@ importers:
         version: 1.4.0(svelte@4.2.12)
       svelte-check:
         specifier: ^3.6.2
-        version: 3.6.7(@babel/core@7.24.0)(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)
+        version: 3.6.7(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)
       svelte-htm:
         specifier: ^1.2.0
         version: 1.2.0(svelte@4.2.12)
       svelte-infinite-scroll:
         specifier: ^2.0.1
         version: 2.0.1
-      svelte-keydown:
-        specifier: ^0.6.0
-        version: 0.6.0
       svelte-preprocess:
         specifier: ^5.1.3
-        version: 5.1.3(@babel/core@7.24.0)(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)(typescript@5.4.2)
+        version: 5.1.3(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)(typescript@5.4.2)
       svelte-range-slider-pips:
         specifier: ^2.2.3
         version: 2.3.1
@@ -12287,6 +12284,33 @@ packages:
       - sugarss
     dev: true
 
+  /svelte-check@3.6.7(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12):
+    resolution: {integrity: sha512-tKEjemK9FYCySAseCaIt+ps5o0XRvLC7ECjyJXXtO7vOQhR9E6JavgoUbGP1PCulD2OTcB/fi9RjV3nyF1AROw==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      import-fresh: 3.3.0
+      picocolors: 1.0.0
+      sade: 1.8.1
+      svelte: 4.2.12
+      svelte-preprocess: 5.1.3(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)(typescript@5.4.2)
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
   /svelte-copy@1.4.1(svelte@4.2.12):
     resolution: {integrity: sha512-ixNNlTfIQWYnQzE0pdMYVCS/2jzMhXm41jmtSvk8EK2Dh+B5sDFEz2xYYo4fVtwtK0dLW5M5ZH/Rs5Jah0r6dw==}
     peerDependencies:
@@ -12358,10 +12382,6 @@ packages:
     resolution: {integrity: sha512-goTHCfOHRDCs8C5MeSuIc6LlAQ8zVQ+M4Y3LyvrDjx5rqSSxSrdCuQwIyWYNcO6j6/mnqRro3QB64ClBzfn+Wg==}
     dev: true
 
-  /svelte-keydown@0.6.0:
-    resolution: {integrity: sha512-X5YBpz2SZY7ReMfbjqfsq4wFBuNM0Epi2/VS9LbxYYDHfJBSP/F5sx8D1hZz3amVLlc0JP8OLzIGsQAv6LJpIA==}
-    dev: true
-
   /svelte-preprocess@5.1.3(@babel/core@7.24.0)(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)(typescript@5.4.2):
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
     engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
@@ -12401,6 +12421,55 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.24.0
+      '@types/pug': 2.0.10
+      detect-indent: 6.1.0
+      magic-string: 0.30.8
+      postcss: 8.4.36
+      sass: 1.72.0
+      sorcery: 0.11.0
+      strip-indent: 3.0.0
+      svelte: 4.2.12
+      typescript: 5.4.2
+    dev: true
+
+  /svelte-preprocess@5.1.3(postcss@8.4.36)(sass@1.72.0)(svelte@4.2.12)(typescript@5.4.2):
+    resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
+    engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.8

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -103,7 +103,6 @@
 		"svelte-check": "^3.6.2",
 		"svelte-htm": "^1.2.0",
 		"svelte-infinite-scroll": "^2.0.1",
-		"svelte-keydown": "^0.6.0",
 		"svelte-preprocess": "^5.1.3",
 		"svelte-range-slider-pips": "^2.2.3",
 		"svelte-step-wizard": "^0.0.2",

--- a/sites/geohub/src/components/pages/map/layers/header/DeleteMenu.svelte
+++ b/sites/geohub/src/components/pages/map/layers/header/DeleteMenu.svelte
@@ -9,7 +9,6 @@
 	} from '$stores';
 	import { ModalNotification, clean } from '@undp-data/svelte-undp-components';
 	import { createEventDispatcher, getContext } from 'svelte';
-	import Keydown from 'svelte-keydown';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 	const layerListStore: LayerListStore = getContext(LAYERLISTSTORE_CONTEXT_KEY);
@@ -53,8 +52,6 @@
 		isVisible = false;
 	};
 </script>
-
-<Keydown paused={!isVisible} on:Escape={() => (isVisible = false)} />
 
 <ModalNotification
 	bind:dialogOpen={isVisible}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I removed `svelte-keydown` and moved that functionality to `ModalTemplate` component to close dialog by escape key. But if close button is not shown in dialog, no close event will be occurred.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others (refactoring)
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1324948835) by [Unito](https://www.unito.io)
