### PR TITLE
fix: show algorithm's title and description at accordion title and help at layer editor

### DIFF
--- a/.changeset/neat-planes-repeat.md
+++ b/.changeset/neat-planes-repeat.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show algorithm's title and description at accordion title and help at layer editor

--- a/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegend.svelte
@@ -59,10 +59,8 @@
 	{#if algorithmId}
 		{#await getAlgorithm(algorithmId) then algo}
 			{#if algo?.parameters && Object.keys(algo?.parameters).length > 0}
-				<Accordion
-					title="{algorithmId.toUpperCase()} customization"
-					bind:isExpanded={expanded['algorithm']}
-				>
+				{@const title = algo.title ?? algorithmId.toUpperCase()}
+				<Accordion title="{title} customization" bind:isExpanded={expanded['algorithm']}>
 					<div slot="content">
 						<RasterAlgorithms
 							bind:layerId
@@ -72,7 +70,12 @@
 						/>
 					</div>
 					<div slot="buttons">
-						<Help>Customize parameters for the selected algorithm</Help>
+						<Help>
+							Customize parameters for {title} algorithm
+							{#if algo.description}
+								- {algo.description}
+							{/if}
+						</Help>
 					</div>
 				</Accordion>
 			{/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
found no title and description were shown in accordion

![](https://github.com/UNDP-Data/geohub/assets/2639701/164852aa-3ad1-496f-b96a-aa2e9065ea71)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1325084087) by [Unito](https://www.unito.io)
