### PR TITLE
ci: removed deploy to develop job since AppService was migrated to Docker version intead of Node js server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,39 +126,10 @@ jobs:
 
       - name: Upload build outputs
         uses: actions/upload-artifact@v4
+        if: ${{ github.ref == 'refs/heads/main'}}
         with:
           name: geohub-build-output
           path: release.zip
-
-  deploy_to_develop:
-    name: Build and deploy Node.js app to Development
-    if: ${{ github.ref == 'refs/heads/develop'}}
-    needs: lint_build
-    runs-on: ubuntu-latest
-    environment:
-      name: Development
-      url: https://dev.undpgeohub.org
-
-    steps:
-      - name: checkout code repository
-        uses: actions/checkout@v4
-
-      - name: download build files from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: geohub-build-output
-
-      - name: unzip artifact for deployment
-        run: unzip release.zip
-
-      - name: "Deploy to Azure Web App for undpgeohub-dev"
-        id: deploy-to-webapp-dev
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: "undpgeohub-dev"
-          slot-name: "Production"
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE }}
-          package: ./sites/geohub/build
 
   deploy_to_production:
     name: Build and deploy Node.js app to Production


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I created a new AppService for dev.undpgeohub.org to use our docker image instead of NodeJS server

Migrated all environmental variables including secrets, so it should work 

![](https://github.com/UNDP-Data/geohub/assets/2639701/ee9096e1-483f-413a-8e9b-63bd0b7448b5)

I deleted `deploy_to_develop` job from CI since no longer needed.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1329682246) by [Unito](https://www.unito.io)
