### PR TITLE
fix: remove add to map button in ingested dataset preview

### DIFF
--- a/.changeset/cool-bats-impress.md
+++ b/.changeset/cool-bats-impress.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: remove add to map button in ingested dataset preview

--- a/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRowDetail.svelte
+++ b/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRowDetail.svelte
@@ -111,7 +111,7 @@
 				</a>
 				<div bind:this={previewContent} class="tooltip p-2 preview">
 					{#if isLoadPreviewMap}
-						<DatasetPreview bind:feature={dataset.feature} height="300px" />
+						<DatasetPreview bind:feature={dataset.feature} height="300px" showButtons={false} />
 					{/if}
 				</div>
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I found add button is shown for preview popup which should not be there

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1329699787) by [Unito](https://www.unito.io)
