### PR TITLE
fix: show colormap legend in fullwidth for color card in colormap picker

### DIFF
--- a/.changeset/chilled-buckets-breathe.md
+++ b/.changeset/chilled-buckets-breathe.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: show colormap legend in fullwidth for color card in colormap picker

--- a/packages/svelte-undp-components/src/lib/components/ColorMapPicker.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ColorMapPicker.svelte
@@ -105,7 +105,13 @@
 </div>
 
 <div bind:this={tooltipContent} data-testid="color-map-picker" class="tooltip p-2">
-	<Tabs bind:tabs bind:activeTab={activeColorMapType} size="is-small" fontWeight="semibold" />
+	<Tabs
+		bind:tabs
+		bind:activeTab={activeColorMapType}
+		size="is-small"
+		fontWeight="semibold"
+		isCapitalized={true}
+	/>
 
 	<button class="delete close is-radiusless"></button>
 

--- a/packages/svelte-undp-components/src/lib/components/ColorMapPickerCard.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ColorMapPickerCard.svelte
@@ -91,7 +91,7 @@
 		}
 
 		if (isCardStyle) {
-			style = `height: calc(1px * 30); width: calc(2px * 30); background: linear-gradient(90deg, ${colorMap});`;
+			style = `height: calc(1px * 30); width: 100%; background: linear-gradient(90deg, ${colorMap});`;
 		} else {
 			style = `height: 15px; width:250px; background: linear-gradient(90deg, ${colorMap}); cursor: default !important;`;
 		}
@@ -120,12 +120,11 @@
 	};
 </script>
 
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-<div class="card" data-testid="color-map-picker-card-container" tabindex="0">
+<div class="card" data-testid="color-map-picker-card-container">
 	<div class="card-content">
 		<div class="media">
-			<figure
-				class={`image ${isCardStyle ? 'is-2by1' : ''} ${isSelected ? '' : 'is-clickable'}`}
+			<div
+				class={isSelected ? '' : 'is-clickable'}
 				style={cardStyle}
 				data-testid="color-map-figure"
 			/>

--- a/packages/svelte-undp-components/src/lib/components/ColorMapPickerCard.test.ts
+++ b/packages/svelte-undp-components/src/lib/components/ColorMapPickerCard.test.ts
@@ -59,7 +59,7 @@ describe('colorMapStyle', () => {
 		const style = colorMapStyle(ColorMapTypes.SEQUENTIAL, 'viridis', true);
 
 		expect(style).toEqual(
-			'height: calc(1px * 30); width: calc(2px * 30); background: linear-gradient(90deg, #3f4a8a,#2c768f,#1f9d8a,#96d647,#fee825);'
+			'height: calc(1px * 30); width: 100%; background: linear-gradient(90deg, #3f4a8a,#2c768f,#1f9d8a,#96d647,#fee825);'
 		);
 	});
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Previously, color legend was not shown in fullwidth. Now can show it in fullwidth.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/d54947e6-a500-41a2-819a-564bc18ee09e)

Furthermore, I made title of tabs capitalized

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1330437844) by [Unito](https://www.unito.io)
