### PR TITLE
refactor: use await locals.auth() instead of deprecated getSession().

### DIFF
--- a/.changeset/smooth-houses-try.md
+++ b/.changeset/smooth-houses-try.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+refactor: use `await locals.auth()` instead of deprecated `getSession()`.

--- a/sites/geohub/src/hooks.server.ts
+++ b/sites/geohub/src/hooks.server.ts
@@ -49,9 +49,9 @@ const handleAccessToken = async ({ event, resolve }) => {
 		if (token) {
 			const payload: TokenPayload = await verifyJWT(token);
 			if (payload) {
-				// update locals.getSession function to return payload from token
+				// update locals.auth function to return payload from token
 				event.locals = {
-					getSession: async () => {
+					auth: async () => {
 						return {
 							user: {
 								id: payload.id,

--- a/sites/geohub/src/routes/(app)/data/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/+page.server.ts
@@ -7,8 +7,8 @@ import { env } from '$env/dynamic/private';
 import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async (event) => {
-	const { locals, url, parent, depends } = event;
-	const session = await locals.getSession();
+	const { url, parent, depends } = event;
+	const { session } = await parent();
 
 	const wss = {
 		url: '',

--- a/sites/geohub/src/routes/(app)/data/[[id]]/edit/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/[[id]]/edit/+page.server.ts
@@ -273,7 +273,7 @@ export const actions = {
 	publish: async (event) => {
 		const { request, locals, fetch } = event;
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) {
 				return fail(403, { message: 'No permission' });
 			}

--- a/sites/geohub/src/routes/(app)/data/[id]/style/edit/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/[id]/style/edit/+page.server.ts
@@ -4,8 +4,8 @@ import { error } from '@sveltejs/kit';
 import { getDomainFromEmail } from '$lib/helper';
 import { AccessLevel, Permission } from '$lib/config/AppConfig';
 
-export const load: PageServerLoad = async ({ fetch, params, locals }) => {
-	const session = await locals.getSession();
+export const load: PageServerLoad = async ({ fetch, params, parent }) => {
+	const { session } = await parent();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/(app)/data/upload/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/data/upload/+page.server.ts
@@ -17,7 +17,7 @@ export const actions = {
 	 */
 	getSasUrl: async ({ request, locals }) => {
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) return {};
 			const userHash = session?.user.id;
 			const selectedFilesString = (await request.formData()).get('SelectedFiles') as string;
@@ -41,7 +41,7 @@ export const actions = {
 	},
 	completingUpload: async ({ request, locals }) => {
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) return {};
 			const token = session.accessToken;
 			const data = await request.formData();

--- a/sites/geohub/src/routes/(app)/management/stac/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/management/stac/+page.server.ts
@@ -6,7 +6,7 @@ export const actions = {
 	register: async (event) => {
 		const { request, locals } = event;
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) {
 				return fail(403, { message: 'No permission' });
 			}

--- a/sites/geohub/src/routes/(app)/management/stac/api/[id]/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/management/stac/api/[id]/+page.server.ts
@@ -6,7 +6,7 @@ export const actions = {
 	register: async (event) => {
 		const { request, locals } = event;
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) {
 				return fail(403, { message: 'No permission' });
 			}

--- a/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.server.ts
@@ -24,7 +24,7 @@ export const actions = {
 	register: async (event) => {
 		const { request, locals } = event;
 		try {
-			const session = await locals.getSession();
+			const session = await locals.auth();
 			if (!session) {
 				return fail(403, { message: 'No permission' });
 			}

--- a/sites/geohub/src/routes/(app)/maps/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/maps/+page.server.ts
@@ -3,10 +3,9 @@ import type { MapsData, TableViewType } from '$lib/types';
 import { AccessLevel } from '$lib/config/AppConfig';
 import type { UserConfig } from '$lib/config/DefaultUserConfig';
 
-export const load: PageServerLoad = async ({ locals, url, parent, depends, fetch }) => {
-	const session = await locals.getSession();
-
+export const load: PageServerLoad = async ({ url, parent, depends, fetch }) => {
 	const parentData = await parent();
+	const { session } = parentData;
 	const config: UserConfig = parentData.config;
 
 	const apiUrl = new URL(url);

--- a/sites/geohub/src/routes/(app)/settings/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/settings/+page.server.ts
@@ -3,8 +3,8 @@ import { DefaultUserConfig } from '$lib/config/DefaultUserConfig';
 import { error, fail } from '@sveltejs/kit';
 import { FontJsonUrl } from '$lib/config/AppConfig';
 
-export const load: PageServerLoad = async ({ locals }) => {
-	const session = await locals.getSession();
+export const load: PageServerLoad = async ({ parent }) => {
+	const { session } = await parent();
 	if (!session) {
 		error(403, {
 			message: `No permission to access.`
@@ -25,7 +25,7 @@ const getFonts = async () => {
 export const actions = {
 	save: async (event) => {
 		const { request, locals } = event;
-		const session = await locals.getSession();
+		const session = await locals.auth();
 		if (!session) {
 			return fail(403, { message: 'No permission' });
 		}

--- a/sites/geohub/src/routes/+layout.server.ts
+++ b/sites/geohub/src/routes/+layout.server.ts
@@ -7,7 +7,7 @@ import { HeaderItems } from '$lib/server/config/HeaderItems';
 import { getFooterItems, type FooterItemType } from '$lib/server/config/FooterItems';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	let geohubApi = url.origin;
 	if (geohubApi.indexOf('localhost') > -1) {

--- a/sites/geohub/src/routes/api/datasets/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/+server.ts
@@ -35,7 +35,7 @@ import { removeSasTokenFromDatasetUrl } from '$lib/helper';
  * @returns GeojSON FeatureCollection
  */
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 
 	const dbm = new DatabaseManager();
@@ -269,7 +269,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ fetch, locals, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;

--- a/sites/geohub/src/routes/api/datasets/[id]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/+server.ts
@@ -13,7 +13,7 @@ import { getDomainFromEmail } from '$lib/helper';
 import { DatasetPermissionManager } from '$lib/server/DatasetPermissionManager';
 
 export const GET: RequestHandler = async ({ params, locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 	let is_superuser = false;
 	if (user_email) {
@@ -68,7 +68,7 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify({ message: 'Permission error' }), {
 			status: 403

--- a/sites/geohub/src/routes/api/datasets/[id]/permission/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/permission/+server.ts
@@ -8,7 +8,7 @@ import {
 } from '$lib/server/DatasetPermissionManager';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ params, locals, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -87,7 +87,7 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 };
 
 export const PUT: RequestHandler = async ({ params, locals, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -141,7 +141,7 @@ export const PUT: RequestHandler = async ({ params, locals, request }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;

--- a/sites/geohub/src/routes/api/datasets/[id]/preview/style.json/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/preview/style.json/+server.ts
@@ -10,7 +10,7 @@ import geoViewport from '@mapbox/geo-viewport';
 import { error } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async ({ params, locals, url, fetch }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 	const id = params.id;
 

--- a/sites/geohub/src/routes/api/datasets/[id]/star/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/star/+server.ts
@@ -3,7 +3,7 @@ import { getDatasetStarCount } from '$lib/server/helpers';
 import DatabaseManager from '$lib/server/DatabaseManager';
 
 export const POST: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify({ message: 'Permission error' }), {
 			status: 403
@@ -57,7 +57,7 @@ export const POST: RequestHandler = async ({ locals, params }) => {
 };
 
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify({ message: 'Permission error' }), {
 			status: 403

--- a/sites/geohub/src/routes/api/datasets/[id]/style/[layer]/[type]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/style/[layer]/[type]/+server.ts
@@ -23,7 +23,7 @@ import VectorDefaultStyle from '$lib/server/defaultStyle/VectorDefaultStyle';
 import { DatasetPermissionManager } from '$lib/server/DatasetPermissionManager';
 
 export const GET: RequestHandler = async ({ params, locals, url, fetch }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 	const id = params.id;
 	const layer_id = params.layer;
@@ -116,7 +116,7 @@ export const GET: RequestHandler = async ({ params, locals, url, fetch }) => {
 };
 
 export const POST: RequestHandler = async ({ params, locals, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}
@@ -248,7 +248,7 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/ingesting/+server.ts
@@ -19,7 +19,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 			status: 403
 		});
 	}
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify({ message: 'Permission error' }), {
 			status: 403

--- a/sites/geohub/src/routes/api/menu/+server.ts
+++ b/sites/geohub/src/routes/api/menu/+server.ts
@@ -4,7 +4,7 @@ import { DataCategories } from '$lib/config/AppConfig';
 import type { Continent, Country } from '$lib/types';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const breadcrumbs = url.searchParams.get('breadcrumbs') ?? 'Home';
 
 	const selectedMenus = breadcrumbs.split(',');

--- a/sites/geohub/src/routes/api/settings/+server.ts
+++ b/sites/geohub/src/routes/api/settings/+server.ts
@@ -3,7 +3,7 @@ import DatabaseManager from '$lib/server/DatabaseManager';
 import { DefaultUserConfig, type UserConfig } from '$lib/config/DefaultUserConfig';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify({ message: 'Permission error' }), {
 			status: 403
@@ -31,7 +31,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 };
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		return new Response(JSON.stringify(DefaultUserConfig), {});
 	}

--- a/sites/geohub/src/routes/api/stac/+server.ts
+++ b/sites/geohub/src/routes/api/stac/+server.ts
@@ -4,7 +4,7 @@ import { getSTAC, getSTACs, isSuperuser, upsertSTAC } from '$lib/server/helpers'
 import type { Stac } from '$lib/types';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	const user_email = session?.user.email;
 
@@ -23,7 +23,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 };
 
 export const POST: RequestHandler = async ({ locals, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/stac/[id]/+server.ts
+++ b/sites/geohub/src/routes/api/stac/[id]/+server.ts
@@ -15,7 +15,7 @@ export const GET: RequestHandler = async ({ params }) => {
 };
 
 export const PUT: RequestHandler = async ({ locals, params, request }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}
@@ -44,7 +44,7 @@ export const PUT: RequestHandler = async ({ locals, params, request }) => {
 };
 
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/style/+server.ts
+++ b/sites/geohub/src/routes/api/style/+server.ts
@@ -28,7 +28,7 @@ import { StylePermissionManager } from '$lib/server/StylePermissionManager.ts';
  * ]
  */
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 
 	let is_superuser = false;
@@ -292,7 +292,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
  * }
  */
 export const POST: RequestHandler = async ({ request, url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}
@@ -382,7 +382,7 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
  * }
  */
 export const PUT: RequestHandler = async ({ request, url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/style/[id].json/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id].json/+server.ts
@@ -9,7 +9,7 @@ import { error } from '@sveltejs/kit';
  * GET: ./api/style/{id}.json
  */
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	const styleId = Number(params.id);
 	if (!styleId) {

--- a/sites/geohub/src/routes/api/style/[id]/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/+server.ts
@@ -7,7 +7,7 @@ import { AccessLevel, Permission } from '$lib/config/AppConfig';
 import { error } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async ({ params, locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const email = session?.user?.email;
 
 	const styleId = Number(params.id);
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
  * DELETE: ./api/style/{id}
  */
 export const DELETE: RequestHandler = async ({ params, url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/style/[id]/permission/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/permission/+server.ts
@@ -8,7 +8,7 @@ import {
 } from '$lib/server/StylePermissionManager.ts';
 
 export const GET: RequestHandler = async ({ params, locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -37,7 +37,7 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 };
 
 export const POST: RequestHandler = async ({ params, locals, request, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -87,7 +87,7 @@ export const POST: RequestHandler = async ({ params, locals, request, url }) => 
 };
 
 export const PUT: RequestHandler = async ({ params, locals, request, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;
@@ -141,7 +141,7 @@ export const PUT: RequestHandler = async ({ params, locals, request, url }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user_email = session?.user.email;

--- a/sites/geohub/src/routes/api/style/[id]/star/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/star/+server.ts
@@ -4,7 +4,7 @@ import DatabaseManager from '$lib/server/DatabaseManager';
 import { error } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}
@@ -54,7 +54,7 @@ export const POST: RequestHandler = async ({ locals, params }) => {
 };
 
 export const DELETE: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) {
 		error(403, { message: 'Permission error' });
 	}

--- a/sites/geohub/src/routes/api/style/[id]/static/[bbox]/[width]x[height].[format]/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/static/[bbox]/[width]x[height].[format]/+server.ts
@@ -7,7 +7,7 @@ import { AccessLevel } from '$lib/config/AppConfig';
 import { env } from '$env/dynamic/private';
 
 export const GET: RequestHandler = async ({ locals, params, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	const bbox = params.bbox;
 	const width = Number(params.width);

--- a/sites/geohub/src/routes/api/style/[id]/static/[lon],[lat],[zoom],[bearing],[pitch]/[width]x[height].[format]/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/static/[lon],[lat],[zoom],[bearing],[pitch]/[width]x[height].[format]/+server.ts
@@ -7,7 +7,7 @@ import { AccessLevel } from '$lib/config/AppConfig';
 import { env } from '$env/dynamic/private';
 
 export const GET: RequestHandler = async ({ locals, params, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	const lon = Number(params.lon);
 	const lat = Number(params.lat);

--- a/sites/geohub/src/routes/api/style/[id]/static/auto/[width]x[height].[format]/+server.ts
+++ b/sites/geohub/src/routes/api/style/[id]/static/auto/[width]x[height].[format]/+server.ts
@@ -7,7 +7,7 @@ import { getDomainFromEmail } from '$lib/helper';
 import { AccessLevel } from '$lib/config/AppConfig';
 
 export const GET: RequestHandler = async ({ locals, params, url, fetch }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 
 	const width = Number(params.width);
 	const height = Number(params.height);

--- a/sites/geohub/src/routes/api/tags/+server.ts
+++ b/sites/geohub/src/routes/api/tags/+server.ts
@@ -13,7 +13,7 @@ import DatabaseManager from '$lib/server/DatabaseManager';
  * @returns the list of key and value in tag table
  */
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	const user_email = session?.user.email;
 
 	const dbm = new DatabaseManager();

--- a/sites/geohub/src/routes/api/token/+server.ts
+++ b/sites/geohub/src/routes/api/token/+server.ts
@@ -4,7 +4,7 @@ import { isSuperuser } from '$lib/server/helpers';
 import { signJWT, verifyJWT, type TokenPayload } from '$lib/server/token';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const user = session.user;

--- a/sites/geohub/src/routes/api/users/+server.ts
+++ b/sites/geohub/src/routes/api/users/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { searchUsersByEmail } from '$lib/server/helpers';
 
 export const GET: RequestHandler = async ({ locals, url }) => {
-	const session = await locals.getSession();
+	const session = await locals.auth();
 	if (!session) error(403, { message: 'Permission error' });
 
 	const query = url.searchParams.get('query');


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
found `locals.getSession` is deprecated. switched to use `locals.auth()` or use `parent()` if it is child pages.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1330480948) by [Unito](https://www.unito.io)
