### PR TITLE
fix: moved some dependencies to devDependencies and switched prod docker image to distroless image

### DIFF
--- a/.changeset/real-snakes-hammer.md
+++ b/.changeset/real-snakes-hammer.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: moved some dependencies to devDependencies

--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -61,7 +61,7 @@ WORKDIR /app/sites/geohub
 RUN ./build-nodemodules.sh
 
 # production image
-FROM node:20-slim
+FROM gcr.io/distroless/nodejs20-debian12
 
 WORKDIR /geohub
 # copy build folder from build image
@@ -69,4 +69,4 @@ COPY --from=build /app/sites/geohub/build /geohub
 
 EXPOSE 3000
 
-CMD ["node", "index.js"]
+CMD [ "index.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,12 +801,6 @@ importers:
 
   sites/geohub:
     dependencies:
-      '@auth/core':
-        specifier: 0.28.0
-        version: 0.28.0
-      '@auth/sveltekit':
-        specifier: 0.14.0
-        version: 0.14.0(@sveltejs/kit@2.5.4)(svelte@4.2.12)
       '@azure/service-bus':
         specifier: ^7.9.3
         version: 7.9.4
@@ -822,21 +816,12 @@ importers:
       '@mapbox/vector-tile':
         specifier: ^1.3.1
         version: 1.3.1
-      arraystat:
-        specifier: ^1.7.77
-        version: 1.7.78
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
-      file-saver:
-        specifier: ^2.0.5
-        version: 2.0.5
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
-      mathjs:
-        specifier: ^12.2.1
-        version: 12.4.1
       pbf:
         specifier: ^3.2.1
         version: 3.2.1
@@ -844,6 +829,12 @@ importers:
         specifier: ^8.11.3
         version: 8.11.3
     devDependencies:
+      '@auth/core':
+        specifier: 0.28.0
+        version: 0.28.0
+      '@auth/sveltekit':
+        specifier: 0.14.0
+        version: 0.14.0(@sveltejs/kit@2.5.4)(svelte@4.2.12)
       '@azure/web-pubsub-client':
         specifier: 1.0.0
         version: 1.0.0
@@ -946,6 +937,9 @@ importers:
       '@zerodevx/svelte-toast':
         specifier: ^0.9.5
         version: 0.9.5(svelte@4.2.12)
+      arraystat:
+        specifier: ^1.7.78
+        version: 1.7.78
       bulma:
         specifier: ^0.9.4
         version: 0.9.4
@@ -1024,6 +1018,9 @@ importers:
       marked:
         specifier: ^12.0.0
         version: 12.0.1
+      mathjs:
+        specifier: ^12.4.1
+        version: 12.4.1
       millify:
         specifier: ^6.1.0
         version: 6.1.0
@@ -1157,7 +1154,7 @@ packages:
       oauth4webapi: 2.10.3
       preact: 10.11.3
       preact-render-to-string: 5.2.3(preact@10.11.3)
-    dev: false
+    dev: true
 
   /@auth/sveltekit@0.14.0(@sveltejs/kit@2.5.4)(svelte@4.2.12):
     resolution: {integrity: sha512-I4ec4hcL4BTHgebJ1KvjX/8VclLuJAkcJdPwH0BOGt20qlu+wipI7EQjJy6EG2s4p0cAEWaIGGKFhMZIUfb+1Q==}
@@ -1173,7 +1170,7 @@ packages:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'
       - nodemailer
-    dev: false
+    dev: true
 
   /@aw-web-design/x-default-browser@1.4.126:
     resolution: {integrity: sha512-Xk1sIhyNC/esHGGVjL/niHLowM0csl/kFO5uawBy4IrWwy0o1G8LGt3jP6nmWGz+USxeeqbihAmp/oVZju6wug==}
@@ -2629,6 +2626,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+    dev: true
 
   /@babel/template@7.24.0:
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
@@ -3369,7 +3367,7 @@ packages:
 
   /@panva/hkdf@1.1.1:
     resolution: {integrity: sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==}
-    dev: false
+    dev: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5391,7 +5389,7 @@ packages:
   /arraystat@1.7.78:
     resolution: {integrity: sha512-IuSi9+gdoSg/nCUz5jaNtEhf6zADmQj1GW+XXD8sBiTjLU2VkwYA8ivYHMiI/TFxpLjZFWZPWccEWhmexQl67w==}
     engines: {node: '>=17.0.0'}
-    dev: false
+    dev: true
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -5967,7 +5965,7 @@ packages:
 
   /complex.js@2.1.1:
     resolution: {integrity: sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==}
-    dev: false
+    dev: true
 
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -6491,6 +6489,7 @@ packages:
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+    dev: true
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -7012,7 +7011,7 @@ packages:
 
   /escape-latex@1.2.0:
     resolution: {integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==}
-    dev: false
+    dev: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -7450,10 +7449,6 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /file-saver@2.0.5:
-    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
-    dev: false
-
   /file-selector@0.6.0:
     resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
     engines: {node: '>= 12'}
@@ -7607,7 +7602,7 @@ packages:
 
   /fraction.js@4.3.4:
     resolution: {integrity: sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==}
-    dev: false
+    dev: true
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -8567,10 +8562,11 @@ packages:
 
   /javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
-    dev: false
+    dev: true
 
   /jose@5.2.3:
     resolution: {integrity: sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==}
+    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -9228,7 +9224,7 @@ packages:
       seedrandom: 3.0.5
       tiny-emitter: 2.1.0
       typed-function: 4.1.1
-    dev: false
+    dev: true
 
   /mdast-util-find-and-replace@3.0.1:
     resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
@@ -9938,7 +9934,7 @@ packages:
 
   /oauth4webapi@2.10.3:
     resolution: {integrity: sha512-9FkXEXfzVKzH63GUOZz1zMr3wBaICSzk6DLXx+CGdrQ10ItNk2ePWzYYc1fdmKq1ayGFb2aX97sRCoZ2s0mkDw==}
-    dev: false
+    dev: true
 
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
@@ -10507,11 +10503,11 @@ packages:
     dependencies:
       preact: 10.11.3
       pretty-format: 3.8.0
-    dev: false
+    dev: true
 
   /preact@10.11.3:
     resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
-    dev: false
+    dev: true
 
   /preferred-pm@3.1.3:
     resolution: {integrity: sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==}
@@ -10570,7 +10566,7 @@ packages:
 
   /pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
-    dev: false
+    dev: true
 
   /pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
@@ -10841,6 +10837,7 @@ packages:
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+    dev: true
 
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
@@ -11164,7 +11161,7 @@ packages:
 
   /seedrandom@3.0.5:
     resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
-    dev: false
+    dev: true
 
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -12026,7 +12023,7 @@ packages:
 
   /tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
-    dev: false
+    dev: true
 
   /tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
@@ -12305,7 +12302,7 @@ packages:
   /typed-function@4.1.1:
     resolution: {integrity: sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==}
     engines: {node: '>= 14'}
-    dev: false
+    dev: true
 
   /typescript@5.4.3:
     resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -33,6 +33,8 @@
 	},
 	"homepage": "https://github.com/UNDP-Data/geohub#readme",
 	"devDependencies": {
+		"@auth/core": "0.28.0",
+		"@auth/sveltekit": "0.14.0",
 		"@azure/web-pubsub-client": "1.0.0",
 		"@neodrag/svelte": "^2.0.3",
 		"@sjmc11/tourguidejs": "^0.0.16",
@@ -67,6 +69,7 @@
 		"@watergis/legend-symbol": "^0.2.3",
 		"@watergis/maplibre-gl-tour": "^1.0.3",
 		"@zerodevx/svelte-toast": "^0.9.5",
+		"arraystat": "^1.7.78",
 		"bulma": "^0.9.4",
 		"bulma-divider": "^0.2.0",
 		"bulma-o-steps": "^1.1.0",
@@ -93,6 +96,7 @@
 		"lodash-es": "^4.17.21",
 		"maplibre-gl": "^4.0.0",
 		"marked": "^12.0.0",
+		"mathjs": "^12.4.1",
 		"millify": "^6.1.0",
 		"papaparse": "^5.4.1",
 		"pmtiles": "^3.0.3",
@@ -126,18 +130,13 @@
 		"vitest": "^1.1.1"
 	},
 	"dependencies": {
-		"@auth/core": "0.28.0",
-		"@auth/sveltekit": "0.14.0",
 		"@azure/service-bus": "^7.9.3",
 		"@azure/storage-blob": "^12.17.0",
 		"@azure/web-pubsub": "^1.1.1",
 		"@mapbox/geo-viewport": "^0.5.0",
 		"@mapbox/vector-tile": "^1.3.1",
-		"arraystat": "^1.7.77",
 		"crypto-js": "^4.2.0",
-		"file-saver": "^2.0.5",
 		"jwt-decode": "^4.0.0",
-		"mathjs": "^12.2.1",
 		"pbf": "^3.2.1",
 		"pg": "^8.11.3"
 	},


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
reduced 299MB to 267MB for production docker image

I moved some dependencies to devDependencies. like auth.js modules can be in dev, I think. this can reduce size of node_modules folder

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1331291679) by [Unito](https://www.unito.io)
