### PR TITLE
fix: register STAC Catalog as a collection level with selected access level on management page.

### DIFF
--- a/.changeset/twenty-carpets-happen.md
+++ b/.changeset/twenty-carpets-happen.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: register STAC Catalog as a collection level with selected access level on management page.

--- a/sites/geohub/src/components/pages/map/data/StacExplorerButton.svelte
+++ b/sites/geohub/src/components/pages/map/data/StacExplorerButton.svelte
@@ -88,7 +88,7 @@
 		{#if showDialog}
 			<div class="explorer">
 				{#if isCatalog}
-					<StacCatalogExplorer {stacId} on:dataAdded={handleDataAdded} />
+					<StacCatalogExplorer {stacId} bind:dataset={feature} on:dataAdded={handleDataAdded} />
 				{:else}
 					<StacApiExplorer
 						{stacId}

--- a/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
@@ -260,7 +260,7 @@
 				feature.properties.tags.find((t) => t.key === 'stacApiType')?.value === 'catalog'}
 
 			{#if isCatalog}
-				<StacCatalogExplorer {stacId} on:dataAdded={dataAddedToMap} />
+				<StacCatalogExplorer {stacId} bind:dataset={feature} on:dataAdded={dataAddedToMap} />
 			{:else}
 				<StacApiExplorer {stacId} {collection} on:dataAdded={dataAddedToMap} />
 			{/if}

--- a/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.server.ts
@@ -13,10 +13,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 	const datasetId = generateHashKey(stac.url);
 	const res = await fetch(`/api/datasets/${datasetId}`);
 	const isRegistered = res.status !== 404;
+	let dataset: DatasetFeature = undefined;
+	if (res.ok) {
+		dataset = await res.json();
+	}
 	return {
 		stac,
 		datasetId,
-		isRegistered
+		isRegistered,
+		dataset
 	};
 };
 

--- a/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.ts
+++ b/sites/geohub/src/routes/(app)/management/stac/catalog/[id]/+page.ts
@@ -1,7 +1,7 @@
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ data }) => {
-	const { stac, datasetId, isRegistered } = data;
+	const { stac, datasetId, isRegistered, dataset } = data;
 	const title = `${stac.name} | STAC Catalog management | GeoHub`;
 	const content = stac.name;
 
@@ -10,6 +10,7 @@ export const load: PageLoad = async ({ data }) => {
 		content,
 		stac,
 		datasetId,
-		isRegistered
+		isRegistered,
+		dataset
 	};
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3054

Now can register collection level from STAC catalog. Also added access level selector in dialog.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/66da7940-35d9-403a-a312-97f3b12c856f)

![image](https://github.com/UNDP-Data/geohub/assets/2639701/d547b4ed-3eed-4604-88f1-37d9b7aa573e)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1334084732) by [Unito](https://www.unito.io)
