### PR TITLE
fix: preserve rescale value. add algorithm param in default style api

### DIFF
--- a/.changeset/nice-feet-float.md
+++ b/.changeset/nice-feet-float.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: accidentally removed rescale from URL when colormap is changed. Now it preserve original rescale in URL.

--- a/.changeset/plenty-suits-clean.md
+++ b/.changeset/plenty-suits-clean.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add algorithm param in default style api to create correct layer definition and metadata according to setting

--- a/sites/geohub/src/components/maplibre/raster/RasterLegendEdit.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterLegendEdit.svelte
@@ -80,13 +80,15 @@
 		// set color map and force map rerender
 		layerURL.searchParams.delete('colormap_name');
 
-		//for rescale the rangeSliderValue sis reactive and also intialized from three locations so this is used to poulate
-		// the rescale at all times
-		layerURL.searchParams.delete('rescale');
-
 		let updatedParams = { colormap_name: $colorMapNameStore };
+		// preserve current rescale value
+		let rescale = layerURL.searchParams.get('rescale');
 		if ($rescaleStore?.length === 2) {
-			updatedParams['rescale'] = $rescaleStore.join(',');
+			// use new rescale if store is available
+			rescale = $rescaleStore.join(',');
+		}
+		if (rescale) {
+			updatedParams['rescale'] = rescale;
 		}
 
 		const layerStyle = getLayerStyle($map, layerId);
@@ -104,10 +106,7 @@
 		const layerURL = new URL(layerUrl);
 		layerURL.searchParams.delete('colormap');
 
-		let updatedParams = { colormap_name: $colorMapNameStore };
-		if ($rescaleStore?.length === 2) {
-			updatedParams['rescale'] = $rescaleStore.join(',');
-		}
+		let updatedParams = { colormap_name: $colorMapNameStore, rescale: $rescaleStore.join(',') };
 
 		updateParamsInURL(layerStyle, layerURL, updatedParams, map);
 	}, 200);

--- a/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
@@ -144,7 +144,12 @@
 			];
 			const rasterTile = new RasterTileData(feature);
 
-			const data: LayerCreationInfo & { geohubLayer?: Layer } = await rasterTile.add();
+			const data: LayerCreationInfo & { geohubLayer?: Layer } = await rasterTile.add(
+				undefined,
+				undefined,
+				undefined,
+				selectedTool.algorithmId
+			);
 			// revert tags to original
 			feature.properties.tags = JSON.parse(JSON.stringify(dataset.properties.tags));
 			feature.properties.tags = [

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -5,7 +5,7 @@ import {
 	getDefaltLayerStyleForStac,
 	getFirstSymbolLayerId
 } from './helper';
-import type { RasterTileMetadata, DatasetFeature, LayerCreationInfo } from './types';
+import type { RasterTileMetadata, DatasetFeature, LayerCreationInfo, BandMetadata } from './types';
 import type { Map } from 'maplibre-gl';
 
 export class RasterTileData {
@@ -27,7 +27,7 @@ export class RasterTileData {
 				}&histogram_bins=10${algorithmId ? `&algorithm=${algorithmId}` : ''}`
 			);
 			const statistics = await resStatistics.json();
-			if (statistics) {
+			if (statistics && !algorithmId) {
 				for (let i = 0; i < metadata.band_metadata.length; i++) {
 					const bandValue = metadata.band_metadata[i][0] as string;
 					const bandDetails = statistics[bandValue];
@@ -46,15 +46,43 @@ export class RasterTileData {
 					}
 				}
 				metadata.stats = statistics;
+			} else if (statistics && algorithmId) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				metadata.band_metadata = [];
+				metadata.band_descriptions = [];
+				Object.keys(statistics).forEach((bName) => {
+					const bandDetails = statistics[bName];
+					const bandMeta: BandMetadata = {
+						STATISTICS_MAXIMUM: bandDetails.max,
+						STATISTICS_MEAN: bandDetails.mean,
+						STATISTICS_MINIMUM: bandDetails.min,
+						STATISTICS_STDDEV: bandDetails.std,
+						STATISTICS_VALID_PERCENT: bandDetails.STATISTICS_VALID_PERCENT,
+						STATISTICS_MEDIAN: bandDetails.median
+					};
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					metadata.band_metadata.push([bName, bandMeta]);
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					metadata.band_descriptions.push([bName, '']);
+				});
+				metadata.stats = statistics;
 			}
 		}
 
 		return metadata;
 	};
 
-	public add = async (map?: Map, bandIndex?: number, colormap_name?: string) => {
+	public add = async (
+		map?: Map,
+		bandIndex?: number,
+		colormap_name?: string,
+		algorithmId?: string
+	) => {
 		if (!bandIndex) {
-			const metadata: RasterTileMetadata = await this.getMetadata();
+			const metadata: RasterTileMetadata = await this.getMetadata(algorithmId);
 			bandIndex = getActiveBandIndex(metadata);
 		}
 
@@ -70,9 +98,20 @@ export class RasterTileData {
 		if (!savedLayerStyle?.style) {
 			const data = new FormData();
 			data.append('feature', JSON.stringify(this.feature));
+			const params: { [key: string]: string } = {};
+			if (colormap_name) {
+				params['colormap_name'] = colormap_name;
+			}
+			if (algorithmId) {
+				params['algorithm'] = algorithmId;
+			}
 			const res = await fetch(
 				`/api/datasets/style/${bandIndex + 1}/raster${
-					colormap_name ? `?colormap_name=${colormap_name}` : ''
+					Object.keys(params).length > 0
+						? `?${Object.keys(params)
+								.map((key) => `${key}=${params[key]}`)
+								.join('&')}`
+						: ''
 				}`,
 				{
 					method: 'POST',

--- a/sites/geohub/src/routes/api/datasets/style/[layer]/[type]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/style/[layer]/[type]/+server.ts
@@ -13,6 +13,7 @@ export const POST: RequestHandler = async ({ request, params, url, fetch }) => {
 	const layer_id = params.layer;
 	const layer_type = params.type;
 	const colormap_name = url.searchParams.get('colormap_name');
+	const algorithm = url.searchParams.get('algorithm');
 
 	if (!LAYER_TYPES.includes(layer_type)) {
 		error(404, {
@@ -32,7 +33,7 @@ export const POST: RequestHandler = async ({ request, params, url, fetch }) => {
 	if (layer_type === 'raster') {
 		const bandIndex = parseInt(layer_id) - 1;
 		const rasterDefaultStyle = new RasterDefaultStyle(dataset, config, bandIndex);
-		data = await rasterDefaultStyle.create(colormap_name);
+		data = await rasterDefaultStyle.create(colormap_name, algorithm);
 	} else {
 		const vectorDefaultStyle = new VectorDefaultStyle(dataset, config, layer_id, layer_type);
 		data = await vectorDefaultStyle.create(colormap_name);
@@ -42,7 +43,7 @@ export const POST: RequestHandler = async ({ request, params, url, fetch }) => {
 		if (layer_type === 'raster') {
 			const bandIndex = parseInt(layer_id) - 1;
 			const rasterDefaultStyle = new RasterDefaultStyle(dataset, config, bandIndex);
-			data.metadata = await rasterDefaultStyle.getMetadata();
+			data.metadata = await rasterDefaultStyle.getMetadata(algorithm);
 		} else {
 			const vectorDefaultStyle = new VectorDefaultStyle(dataset, config, layer_id, layer_type);
 			data.metadata = await vectorDefaultStyle.getMetadata();

--- a/sites/geohub/static/api/swagger/spec.yaml
+++ b/sites/geohub/static/api/swagger/spec.yaml
@@ -242,6 +242,11 @@ paths:
           in: query
           name: colormap_name
           description: 'Option. If specified, use this colormap to create layer style'
+        - schema:
+            type: string
+          in: query
+          name: algorithm
+          description: Option. Algorithm ID for raster
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3250

* fix: accidentally removed rescale from URL when colormap is changed. Now it preserve original rescale in URL.
* fix: add algorithm param in default style api to create correct layer definition and metadata according to setting

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1336541252) by [Unito](https://www.unito.io)
