### PR TITLE
fix: create unit tag and use colormap_name if they are available in a…

### DIFF
--- a/.changeset/four-dodos-fold.md
+++ b/.changeset/four-dodos-fold.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: create unit tag and use colormap_name if they are available in algorithm. Select asset as default if any keywords are matched.

--- a/sites/geohub/src/components/util/stac/StacCatalogDatePicker.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogDatePicker.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-	import type { Link, StacAsset, StacCatalog, StacCollection, StacItemFeature } from '$lib/types';
+	import type {
+		Link,
+		RasterAlgorithm,
+		StacAsset,
+		StacCatalog,
+		StacCollection,
+		StacItemFeature
+	} from '$lib/types';
 	import { DatePicker } from '@undp-data/svelte-undp-components';
 	import { Loader } from '@undp-data/svelte-undp-design';
 	import dayjs from 'dayjs';
@@ -10,6 +17,8 @@
 	export let collectionUrl: string;
 	export let collection: StacCollection;
 	export let selectedAsset: StacAsset;
+	export let algorithm: RasterAlgorithm;
+	export let bandIndex: number;
 
 	let intervalDatetime = collection.extent.temporal.interval[0];
 
@@ -121,6 +130,28 @@
 			asset.href = new URL(asset.href, itemUrl).href;
 		});
 		assetItems = item.assets;
+
+		// if any keywords are matched to asset name, select the asset as default
+		if (algorithm.inputs.bands) {
+			const keywords = algorithm.inputs.bands[bandIndex].keywords;
+			if (keywords?.length > 0) {
+				for (const name of Object.keys(assetItems)) {
+					let matched = false;
+					const asset = assetItems[name];
+					for (const keyword of keywords) {
+						if (asset.title.toLowerCase().indexOf(keyword.toLowerCase()) !== -1) {
+							matched = true;
+							break;
+						}
+					}
+					if (matched) {
+						selectedAsset = asset;
+						break;
+					}
+				}
+			}
+		}
+
 		dateInfo.item = item;
 	};
 

--- a/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
@@ -104,8 +104,7 @@
 			);
 			let vrtUrl = dataset.properties.links.find((l) => l.rel === 'vrt')?.href;
 			if (!vrtUrl) return;
-			vrtUrl = `${vrtUrl}?${urls.join('&')}`;
-
+			vrtUrl = `${vrtUrl.indexOf('localhost') === -1 ? vrtUrl : '/vrt'}?${urls.join('&')}`;
 			const algorithmName = selectedTool.algorithm.title ?? selectedTool.algorithmId;
 
 			let feature: DatasetFeature = JSON.parse(JSON.stringify(dataset));
@@ -142,12 +141,22 @@
 					value: selectedTool.algorithmId
 				}
 			];
+			// set unit if it is available in algorithm metadata
+			if (selectedTool.algorithm.outputs.unit) {
+				feature.properties.tags.push({
+					key: 'unit',
+					value: selectedTool.algorithm.outputs.unit
+				});
+			}
 			const rasterTile = new RasterTileData(feature);
+
+			// set colormap name if it is available in algorithm metadata
+			const colormap_name = selectedTool.algorithm.outputs.colormap_name ?? undefined;
 
 			const data: LayerCreationInfo & { geohubLayer?: Layer } = await rasterTile.add(
 				undefined,
 				undefined,
-				undefined,
+				colormap_name,
 				selectedTool.algorithmId
 			);
 			// revert tags to original
@@ -212,6 +221,8 @@
 												bind:collectionUrl
 												bind:collection
 												bind:selectedAsset={selectedAssets[index]}
+												bind:algorithm={selectedTool.algorithm}
+												bandIndex={index}
 											/>
 										</div>
 										<p class="help is-success">{band.description}</p>
@@ -227,6 +238,8 @@
 												bind:collectionUrl
 												bind:collection
 												bind:selectedAsset={selectedAssets[bandNo]}
+												bind:algorithm={selectedTool.algorithm}
+												bandIndex={bandNo - 1}
 											/>
 										</div>
 									</div>

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -105,19 +105,17 @@ export class RasterTileData {
 			if (algorithmId) {
 				params['algorithm'] = algorithmId;
 			}
-			const res = await fetch(
-				`/api/datasets/style/${bandIndex + 1}/raster${
-					Object.keys(params).length > 0
-						? `?${Object.keys(params)
-								.map((key) => `${key}=${params[key]}`)
-								.join('&')}`
-						: ''
-				}`,
-				{
-					method: 'POST',
-					body: data
-				}
-			);
+			const apiUrl = `/api/datasets/style/${bandIndex + 1}/raster${
+				Object.keys(params).length > 0
+					? `?${Object.keys(params)
+							.map((key) => `${key}=${params[key]}`)
+							.join('&')}`
+					: ''
+			}`;
+			const res = await fetch(apiUrl, {
+				method: 'POST',
+				body: data
+			});
 			savedLayerStyle = await res.json();
 		}
 		if (!savedLayerStyle?.style) {

--- a/sites/geohub/src/lib/types/RasterAlgorithm.ts
+++ b/sites/geohub/src/lib/types/RasterAlgorithm.ts
@@ -14,13 +14,17 @@ export interface RasterAlgorithm {
 	description?: string;
 	inputs: {
 		nbands: number;
-		bands?: [{ title: string; description: string; required: boolean }];
+		description?: string;
+		bands?: [{ title: string; description: string; required: boolean; keywords?: string[] }];
 	};
 	outputs: {
 		nbands: number;
 		dtype: string;
 		min?: number[];
 		max?: number[];
+		description?: string;
+		unit?: string;
+		colormap_name?: string;
 	};
 	parameters?: {
 		[key: string]: RasterAlgorithmParameter;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
It is not confirmed with cogserver yet since it has a bug now

* create `unit` tag if `outputs.unit` is available
* set `colormap_name` if `outputs.colormap_name` is available
* select asset automatically if `inputs.bands[n].keywords` are matched

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1336755042) by [Unito](https://www.unito.io)
