### PR TITLE
fix: run git init for mkdocs author plugin to be executed correctly

### DIFF
--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -19,6 +19,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# this is needed to run mkdocs author plugin. But it will not be syncronized to our git repository at outside of container.
+# so authors will not be shown when we use Docker to write documentation.
+RUN git init
+
 ENV HOST=0.0.0.0
 ENV PORT=8000
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Please describe what you changed briefly.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [ ] Code is up-to-date with the `develop` branch
* [ ] No build errors after `pnpm build`
* [ ] No lint errors after `pnpm lint`
* [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1339735117) by [Unito](https://www.unito.io)
