### PR TITLE
fix: the height of map in default style edit page will be changed between 300px and 700px depending on the height of browser. In addition, moved save & delete buttons to the outside of map to make them always visible.

### DIFF
--- a/.changeset/slow-shoes-decide.md
+++ b/.changeset/slow-shoes-decide.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: the height of map in default style edit page will be changed between 300px and 700px depending on the height of browser.

--- a/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/DefaultStyleEditor.svelte
@@ -69,7 +69,7 @@
 
 	let isLoading = false;
 	let innerHeight: number;
-	$: mapHeight = innerHeight * 0.8;
+	$: mapHeight = innerHeight * 0.5 < 300 ? 300 : innerHeight * 0.5 > 700 ? 700 : innerHeight * 0.5;
 
 	let showDetails = false;
 	let deleteDialogOpen = false;
@@ -494,35 +494,33 @@
 								bind:tags={feature.properties.tags}
 							/>
 						{/if}
-
-						<div class="mt-3 buttons">
-							<button
-								class="button is-primary is-uppercase has-text-weight-bold {isLoading
-									? 'is-loading'
-									: ''}"
-								on:click={handleSaved}
-								disabled={isLoading}
-							>
-								Save
-							</button>
-							{#if defaultLayerStyle?.created_user}
-								<button
-									class="button is-link is-uppercase has-text-weight-bold {isLoading
-										? 'is-loading'
-										: ''}"
-									on:click={() => (deleteDialogOpen = true)}
-									disabled={isLoading}
-								>
-									Delete
-								</button>
-							{/if}
-						</div>
 					{/if}
 				</div>
 			</div>
 		</div>
 	</div>
 </div>
+
+{#if layerSpec}
+	<div class="mt-3 buttons">
+		<button
+			class="button is-primary is-uppercase has-text-weight-bold {isLoading ? 'is-loading' : ''}"
+			on:click={handleSaved}
+			disabled={isLoading}
+		>
+			Save
+		</button>
+		{#if defaultLayerStyle?.created_user}
+			<button
+				class="button is-link is-uppercase has-text-weight-bold {isLoading ? 'is-loading' : ''}"
+				on:click={() => (deleteDialogOpen = true)}
+				disabled={isLoading}
+			>
+				Delete
+			</button>
+		{/if}
+	</div>
+{/if}
 
 <ModalTemplate title="Delete default layer style" bind:show={deleteDialogOpen}>
 	<div slot="content">
@@ -557,7 +555,6 @@
 	.map {
 		position: relative;
 		width: 100%;
-		height: 100%;
 
 		.editor {
 			background-color: white;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3305 

![image](https://github.com/UNDP-Data/geohub/assets/2639701/122f3481-8504-488e-aa07-49ca8125c010)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1341420540) by [Unito](https://www.unito.io)
