### PR TITLE
fix: show loader for export control, improved UI of export control

### DIFF
--- a/.changeset/angry-years-hide.md
+++ b/.changeset/angry-years-hide.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-geohub-static-image-controls": patch
+---
+
+fix: added hiddenApiTypes property in Static Image API Control

--- a/.changeset/itchy-cooks-teach.md
+++ b/.changeset/itchy-cooks-teach.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-geohub-static-image-controls": patch
+---
+
+fix: use SegmentButtons and FieldControls from svelte-undp-components

--- a/.changeset/olive-pillows-protect.md
+++ b/.changeset/olive-pillows-protect.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: Updated StaticImageControl, and make api type setting hidden for GeoHub's export control

--- a/.changeset/shaggy-flowers-divide.md
+++ b/.changeset/shaggy-flowers-divide.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-geohub-static-image-controls": patch
+---
+
+fix: show loader for export control

--- a/.changeset/six-flies-bathe.md
+++ b/.changeset/six-flies-bathe.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: added more options of capitalized, uppercase and fontweight for segmentbuttons component

--- a/packages/svelte-static-image-controls/package.json
+++ b/packages/svelte-static-image-controls/package.json
@@ -66,6 +66,7 @@
 		"@neodrag/svelte": "^2.0.3",
 		"@placemarkio/geo-viewport": "^1.0.2",
 		"@undp-data/svelte-copy-to-clipboard": "workspace:^",
+		"@undp-data/svelte-undp-components": "workspace:^",
 		"@undp-data/undp-bulma": "workspace:^",
 		"debounce": "^2.0.0",
 		"maplibre-gl": "^4.0.0"

--- a/packages/svelte-static-image-controls/src/lib/MaplibreStaticImageControl.svelte
+++ b/packages/svelte-static-image-controls/src/lib/MaplibreStaticImageControl.svelte
@@ -93,6 +93,8 @@
 		bounds: map.getContainer()
 	};
 
+	let isExporting = false;
+
 	const handleButtonClicked = () => {
 		show = !show;
 	};
@@ -117,26 +119,32 @@
 	};
 
 	const handleExport = async () => {
-		const url = new URL(apiUrl);
-		url.searchParams.delete('url');
+		try {
+			isExporting = true;
 
-		const styleJson = map.getStyle();
+			const url = new URL(apiUrl);
+			url.searchParams.delete('url');
 
-		const urlParts = url.pathname.split('.');
-		const extension = urlParts[urlParts.length - 1];
+			const styleJson = map.getStyle();
 
-		const res = await fetch(url, {
-			method: 'POST',
-			body: JSON.stringify(styleJson)
-		});
-		const blob = await res.blob();
-		const blobUrl = window.URL.createObjectURL(blob);
-		let a = document.createElement('a');
-		a.href = blobUrl;
-		a.download = `${styleJson.name ?? 'map'}.${extension}`;
-		document.body.appendChild(a);
-		a.click();
-		a.remove();
+			const urlParts = url.pathname.split('.');
+			const extension = urlParts[urlParts.length - 1];
+
+			const res = await fetch(url, {
+				method: 'POST',
+				body: JSON.stringify(styleJson)
+			});
+			const blob = await res.blob();
+			const blobUrl = window.URL.createObjectURL(blob);
+			let a = document.createElement('a');
+			a.href = blobUrl;
+			a.download = `${styleJson.name ?? 'map'}.${extension}`;
+			document.body.appendChild(a);
+			a.click();
+			a.remove();
+		} finally {
+			isExporting = false;
+		}
 	};
 </script>
 
@@ -184,9 +192,14 @@
 	{#if apiUrl}
 		<div class="mt-2">
 			<button
-				class="button is-primary is-uppercase has-text-weight-bold is-fullwidth"
-				on:click={handleExport}>Export</button
+				class="button is-primary is-uppercase has-text-weight-bold is-fullwidth {isExporting
+					? 'is-loading'
+					: ''}"
+				disabled={isExporting}
+				on:click={handleExport}
 			>
+				Export
+			</button>
 		</div>
 	{/if}
 </div>

--- a/packages/svelte-static-image-controls/src/lib/MaplibreStaticImageControl.svelte
+++ b/packages/svelte-static-image-controls/src/lib/MaplibreStaticImageControl.svelte
@@ -74,6 +74,11 @@
 	 */
 	export let showAdvanced = false;
 
+	/**
+	 * If true, make API types (Center, BBOX, Auto) hiddden
+	 */
+	export let hiddenApiTypes = false;
+
 	export let title = 'Export map';
 
 	export let position: ControlPosition = 'top-right';
@@ -172,6 +177,7 @@
 		bind:apiBase
 		bind:showAdvanced
 		bind:options
+		bind:hiddenApiTypes
 		on:change={handleUrlChanged}
 	/>
 

--- a/packages/svelte-static-image-controls/src/lib/StaticImageControl.svelte
+++ b/packages/svelte-static-image-controls/src/lib/StaticImageControl.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { bounds } from '@placemarkio/geo-viewport';
+	import { FieldControl, Notification, SegmentButtons } from '@undp-data/svelte-undp-components';
 	import debounce from 'debounce';
 	import type { Map } from 'maplibre-gl';
 	import { createEventDispatcher, onMount } from 'svelte';
@@ -212,10 +213,13 @@
 </script>
 
 <div class="export-contents">
-	<div class="column p-0 field">
-		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label class="label">Page size</label>
-		<div class="control has-icons-left">
+	<FieldControl
+		title="page size"
+		showHelp={false}
+		isFirstCharCapitalized={true}
+		fontWeight="semibold"
+	>
+		<div slot="control" class="control has-icons-left">
 			<div class="select is-fullwidth">
 				<select bind:value={selectedPageName}>
 					<option value="custom">Custom</option>
@@ -229,79 +233,96 @@
 				<i class="fa-solid fa-file-lines"></i>
 			</div>
 		</div>
-	</div>
+	</FieldControl>
 
 	{#if selectedPageName !== 'custom'}
-		<div class="field">
-			<!-- svelte-ignore a11y-label-has-associated-control -->
-			<label class="label">Orientation</label>
-			<div class="control">
-				<div class="buttons has-addons is-left">
-					{#each PageOrientations as orientation}
-						<button
-							class="button is-small {selectedOrientation === orientation ? 'is-link' : ''}"
-							on:click={() => {
-								selectedOrientation = orientation;
-							}}
-						>
-							<span class="is-capitalized">{orientation}</span>
-						</button>
-					{/each}
-				</div>
+		{@const orientationButtons = PageOrientations.map((o) => {
+			return { title: o, value: o };
+		})}
+		<FieldControl
+			title="Orientation"
+			showHelp={false}
+			isFirstCharCapitalized={true}
+			fontWeight="semibold"
+		>
+			<div slot="control">
+				<SegmentButtons
+					size="small"
+					capitalized={true}
+					fontWeight="semibold"
+					buttons={orientationButtons}
+					bind:selected={selectedOrientation}
+				/>
 			</div>
-		</div>
+		</FieldControl>
 	{/if}
 
 	{#if selectedPageName === 'custom'}
 		<div class="is-flex">
-			<div class="field m-1">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Width</label>
-				<div class="control is-flex is-align-items-center">
-					<input
-						class="input is-small"
-						type="number"
-						placeholder="Type width"
-						bind:value={width}
-						on:change={handleMoveend}
-					/>
-					<span class="pl-1">px</span>
+			<FieldControl
+				title="Width"
+				showHelp={false}
+				isFirstCharCapitalized={true}
+				fontWeight="semibold"
+			>
+				<div slot="control" class="mr-2">
+					<div class="control is-flex is-align-items-center">
+						<input
+							class="input is-small"
+							type="number"
+							placeholder="Type width"
+							bind:value={width}
+							on:change={handleMoveend}
+						/>
+						<span class="pl-1">px</span>
+					</div>
 				</div>
-			</div>
-			<div class="field m-1">
-				<!-- svelte-ignore a11y-label-has-associated-control -->
-				<label class="label">Height</label>
-				<div class="control is-flex is-align-items-center">
-					<input
-						class="input is-small"
-						type="number"
-						placeholder="Type height"
-						bind:value={height}
-						on:change={handleMoveend}
-					/>
-					<span class="pl-1">px</span>
+			</FieldControl>
+
+			<FieldControl
+				title="Height"
+				showHelp={false}
+				isFirstCharCapitalized={true}
+				fontWeight="semibold"
+			>
+				<div slot="control">
+					<div class="control is-flex is-align-items-center">
+						<input
+							class="input is-small"
+							type="number"
+							placeholder="Type height"
+							bind:value={height}
+							on:change={handleMoveend}
+						/>
+						<span class="pl-1">px</span>
+					</div>
 				</div>
-			</div>
+			</FieldControl>
 		</div>
 	{/if}
 
-	<div class="field">
-		<!-- svelte-ignore a11y-label-has-associated-control -->
-		<label class="label">High resolution</label>
-		<div class="control">
-			<div class="buttons has-addons is-left">
-				{#each [1, 2, 3, 4] as r}
-					<button
-						class="button is-small {options.ratio === r ? 'is-link' : ''}"
-						on:click={() => {
-							options.ratio = r;
-							updateApiUrl();
-						}}>@{r}x</button
-					>
-				{/each}
-			</div>
+	<FieldControl
+		title="High resolution"
+		showHelp={false}
+		isFirstCharCapitalized={true}
+		fontWeight="semibold"
+	>
+		<div slot="control">
+			<SegmentButtons
+				size="small"
+				capitalized={true}
+				fontWeight="semibold"
+				buttons={[
+					{ title: '@1x', value: 1 },
+					{ title: '@2x', value: 2 },
+					{ title: '@3x', value: 3 },
+					{ title: '@4x', value: 4 }
+				]}
+				bind:selected={options.ratio}
+				on:change={updateApiUrl}
+			/>
 		</div>
-	</div>
+	</FieldControl>
 
 	<span class="is-flex">
 		<span class="is-size-6 has-text-weight-bold mr-2 my-auto">Advanced settings</span>
@@ -322,25 +343,29 @@
 	</span>
 
 	{#if showAdvanced}
-		<div class="field">
-			<!-- svelte-ignore a11y-label-has-associated-control -->
-			<label class="label">File extension</label>
-			<div class="control">
-				<div class="buttons has-addons is-left">
-					{#each supportedExtensions as ext}
-						<button
-							class="button {options.extension === ext ? 'is-link' : ''}"
-							on:click={() => {
-								options.extension = ext;
-								updateApiUrl();
-							}}>{ext}</button
-						>
-					{/each}
-				</div>
+		<FieldControl
+			title="File extension"
+			showHelp={false}
+			isFirstCharCapitalized={true}
+			fontWeight="semibold"
+		>
+			<div slot="control">
+				<SegmentButtons
+					size="small"
+					uppercase={true}
+					fontWeight="semibold"
+					buttons={supportedExtensions.map((e) => {
+						return { title: e, value: e };
+					})}
+					bind:selected={options.extension}
+					on:change={updateApiUrl}
+				/>
 			</div>
-		</div>
+		</FieldControl>
 
-		<div class="tabs is-toggle is-toggle-rounded is-fullwidth mt-1 mb-2">
+		<div
+			class="tabs is-toggle is-small is-toggle-rounded is-fullwidth mt-1 mb-2 is-capitalized has-text-weight-semibold"
+		>
 			<ul>
 				<li class={options.defaultApi === 'center' ? 'is-active' : ''}>
 					<!-- svelte-ignore a11y-missing-attribute -->
@@ -380,46 +405,59 @@
 
 		<div class="p-1" hidden={options.defaultApi !== 'center'}>
 			<div class="is-flex">
-				<div class="field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">longitude</label>
-					<div class="control">
+				<FieldControl
+					title="longitude"
+					showHelp={false}
+					isFirstCharCapitalized={true}
+					fontWeight="semibold"
+				>
+					<div slot="control">
 						<input class="input is-small" type="number" bind:value={options.longitude} readonly />
 					</div>
-				</div>
-				<div class="field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">latitude</label>
-					<div class="control">
+				</FieldControl>
+				<FieldControl
+					title="latitude"
+					showHelp={false}
+					isFirstCharCapitalized={true}
+					fontWeight="semibold"
+				>
+					<div slot="control">
 						<input class="input is-small" type="number" bind:value={options.latitude} readonly />
 					</div>
-				</div>
+				</FieldControl>
 			</div>
 
 			<div class="is-flex">
-				<div class="field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">zoom level</label>
-					<div class="control">
+				<FieldControl
+					title="zoom level"
+					showHelp={false}
+					isFirstCharCapitalized={true}
+					fontWeight="semibold"
+				>
+					<div slot="control">
 						<input class="input is-small" type="number" bind:value={options.zoom} readonly />
 					</div>
-				</div>
-
-				<div class="field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">bearing</label>
-					<div class="control">
+				</FieldControl>
+				<FieldControl
+					title="bearing"
+					showHelp={false}
+					isFirstCharCapitalized={true}
+					fontWeight="semibold"
+				>
+					<div slot="control">
 						<input class="input is-small" type="number" bind:value={options.bearing} readonly />
 					</div>
-				</div>
-
-				<div class="field">
-					<!-- svelte-ignore a11y-label-has-associated-control -->
-					<label class="label">pitch</label>
-					<div class="control">
+				</FieldControl>
+				<FieldControl
+					title="pitch"
+					showHelp={false}
+					isFirstCharCapitalized={true}
+					fontWeight="semibold"
+				>
+					<div slot="control">
 						<input class="input is-small" type="number" bind:value={options.pitch} readonly />
 					</div>
-				</div>
+				</FieldControl>
 			</div>
 		</div>
 
@@ -428,48 +466,60 @@
 				{@const bbox = options.bbox}
 
 				<div class="is-flex">
-					<div class="field">
-						<!-- svelte-ignore a11y-label-has-associated-control -->
-						<label class="label">min longitude</label>
-						<div class="control">
+					<FieldControl
+						title="min longitude"
+						showHelp={false}
+						isFirstCharCapitalized={true}
+						fontWeight="semibold"
+					>
+						<div slot="control">
 							<input class="input is-small" type="number" value={bbox[0]} readonly />
 						</div>
-					</div>
-					<div class="field">
-						<!-- svelte-ignore a11y-label-has-associated-control -->
-						<label class="label">max longitude</label>
-						<div class="control">
-							<input class="input is-small" type="number" value={bbox[1]} readonly />
+					</FieldControl>
+
+					<FieldControl
+						title="max longitude"
+						showHelp={false}
+						isFirstCharCapitalized={true}
+						fontWeight="semibold"
+					>
+						<div slot="control">
+							<input class="input is-small" type="number" value={bbox[2]} readonly />
 						</div>
-					</div>
+					</FieldControl>
 				</div>
 
 				<div class="is-flex">
-					<div class="field">
-						<!-- svelte-ignore a11y-label-has-associated-control -->
-						<label class="label">min latitude</label>
-						<div class="control">
-							<input class="input is-small" type="number" value={bbox[2]} readonly />
+					<FieldControl
+						title="min latitude"
+						showHelp={false}
+						isFirstCharCapitalized={true}
+						fontWeight="semibold"
+					>
+						<div slot="control">
+							<input class="input is-small" type="number" value={bbox[1]} readonly />
 						</div>
-					</div>
-					<div class="field">
-						<!-- svelte-ignore a11y-label-has-associated-control -->
-						<label class="label">max latitude</label>
-						<div class="control">
+					</FieldControl>
+
+					<FieldControl
+						title="max latitude"
+						showHelp={false}
+						isFirstCharCapitalized={true}
+						fontWeight="semibold"
+					>
+						<div slot="control">
 							<input class="input is-small" type="number" value={bbox[3]} readonly />
 						</div>
-					</div>
+					</FieldControl>
 				</div>
 			{/if}
 		</div>
 
 		<div class="p-1" hidden={options.defaultApi !== 'auto'}>
-			<article class="message is-info">
-				<div class="message-body">
-					Position is automatically determined based on the overlays or the map style’s default
-					center coordinates.
-				</div>
-			</article>
+			<Notification type="info" showCloseButton={false}>
+				Position is automatically determined based on the overlays or the map style’s default center
+				coordinates.
+			</Notification>
 		</div>
 	{/if}
 </div>

--- a/packages/svelte-static-image-controls/src/lib/StaticImageControl.svelte
+++ b/packages/svelte-static-image-controls/src/lib/StaticImageControl.svelte
@@ -42,6 +42,11 @@
 	 */
 	export let showAdvanced = false;
 
+	/**
+	 * If true, make API types (Center, BBOX, Auto) hiddden
+	 */
+	export let hiddenApiTypes = false;
+
 	let previewContainer: HTMLDivElement;
 
 	const defaultOptions: ControlOptions = {
@@ -362,165 +367,166 @@
 				/>
 			</div>
 		</FieldControl>
-
-		<div
-			class="tabs is-toggle is-small is-toggle-rounded is-fullwidth mt-1 mb-2 is-capitalized has-text-weight-semibold"
-		>
-			<ul>
-				<li class={options.defaultApi === 'center' ? 'is-active' : ''}>
-					<!-- svelte-ignore a11y-missing-attribute -->
-					<!-- svelte-ignore a11y-interactive-supports-focus -->
-					<a
-						role="tab"
-						on:click={() => handleActiveTabChanged('center')}
-						on:keydown={handleEnterKey}
-						data-sveltekit-preload-data="off"
-						data-sveltekit-preload-code="off">center</a
-					>
-				</li>
-				<li class={options.defaultApi === 'bbox' ? 'is-active' : ''}>
-					<!-- svelte-ignore a11y-missing-attribute -->
-					<!-- svelte-ignore a11y-interactive-supports-focus -->
-					<a
-						role="tab"
-						on:click={() => handleActiveTabChanged('bbox')}
-						on:keydown={handleEnterKey}
-						data-sveltekit-preload-data="off"
-						data-sveltekit-preload-code="off">bounding box</a
-					>
-				</li>
-				<li class={options.defaultApi === 'auto' ? 'is-active' : ''}>
-					<!-- svelte-ignore a11y-missing-attribute -->
-					<!-- svelte-ignore a11y-interactive-supports-focus -->
-					<a
-						role="tab"
-						on:click={() => handleActiveTabChanged('auto')}
-						on:keydown={handleEnterKey}
-						data-sveltekit-preload-data="off"
-						data-sveltekit-preload-code="off">auto</a
-					>
-				</li>
-			</ul>
-		</div>
-
-		<div class="p-1" hidden={options.defaultApi !== 'center'}>
-			<div class="is-flex">
-				<FieldControl
-					title="longitude"
-					showHelp={false}
-					isFirstCharCapitalized={true}
-					fontWeight="semibold"
-				>
-					<div slot="control">
-						<input class="input is-small" type="number" bind:value={options.longitude} readonly />
-					</div>
-				</FieldControl>
-				<FieldControl
-					title="latitude"
-					showHelp={false}
-					isFirstCharCapitalized={true}
-					fontWeight="semibold"
-				>
-					<div slot="control">
-						<input class="input is-small" type="number" bind:value={options.latitude} readonly />
-					</div>
-				</FieldControl>
+		{#if !hiddenApiTypes}
+			<div
+				class="tabs is-toggle is-small is-toggle-rounded is-fullwidth mt-1 mb-2 is-capitalized has-text-weight-semibold"
+			>
+				<ul>
+					<li class={options.defaultApi === 'center' ? 'is-active' : ''}>
+						<!-- svelte-ignore a11y-missing-attribute -->
+						<!-- svelte-ignore a11y-interactive-supports-focus -->
+						<a
+							role="tab"
+							on:click={() => handleActiveTabChanged('center')}
+							on:keydown={handleEnterKey}
+							data-sveltekit-preload-data="off"
+							data-sveltekit-preload-code="off">center</a
+						>
+					</li>
+					<li class={options.defaultApi === 'bbox' ? 'is-active' : ''}>
+						<!-- svelte-ignore a11y-missing-attribute -->
+						<!-- svelte-ignore a11y-interactive-supports-focus -->
+						<a
+							role="tab"
+							on:click={() => handleActiveTabChanged('bbox')}
+							on:keydown={handleEnterKey}
+							data-sveltekit-preload-data="off"
+							data-sveltekit-preload-code="off">bounding box</a
+						>
+					</li>
+					<li class={options.defaultApi === 'auto' ? 'is-active' : ''}>
+						<!-- svelte-ignore a11y-missing-attribute -->
+						<!-- svelte-ignore a11y-interactive-supports-focus -->
+						<a
+							role="tab"
+							on:click={() => handleActiveTabChanged('auto')}
+							on:keydown={handleEnterKey}
+							data-sveltekit-preload-data="off"
+							data-sveltekit-preload-code="off">auto</a
+						>
+					</li>
+				</ul>
 			</div>
 
-			<div class="is-flex">
-				<FieldControl
-					title="zoom level"
-					showHelp={false}
-					isFirstCharCapitalized={true}
-					fontWeight="semibold"
-				>
-					<div slot="control">
-						<input class="input is-small" type="number" bind:value={options.zoom} readonly />
-					</div>
-				</FieldControl>
-				<FieldControl
-					title="bearing"
-					showHelp={false}
-					isFirstCharCapitalized={true}
-					fontWeight="semibold"
-				>
-					<div slot="control">
-						<input class="input is-small" type="number" bind:value={options.bearing} readonly />
-					</div>
-				</FieldControl>
-				<FieldControl
-					title="pitch"
-					showHelp={false}
-					isFirstCharCapitalized={true}
-					fontWeight="semibold"
-				>
-					<div slot="control">
-						<input class="input is-small" type="number" bind:value={options.pitch} readonly />
-					</div>
-				</FieldControl>
-			</div>
-		</div>
-
-		<div class="p-1" hidden={options.defaultApi !== 'bbox'}>
-			{#if options.bbox}
-				{@const bbox = options.bbox}
-
+			<div class="p-1" hidden={options.defaultApi !== 'center'}>
 				<div class="is-flex">
 					<FieldControl
-						title="min longitude"
+						title="longitude"
 						showHelp={false}
 						isFirstCharCapitalized={true}
 						fontWeight="semibold"
 					>
 						<div slot="control">
-							<input class="input is-small" type="number" value={bbox[0]} readonly />
+							<input class="input is-small" type="number" bind:value={options.longitude} readonly />
 						</div>
 					</FieldControl>
-
 					<FieldControl
-						title="max longitude"
+						title="latitude"
 						showHelp={false}
 						isFirstCharCapitalized={true}
 						fontWeight="semibold"
 					>
 						<div slot="control">
-							<input class="input is-small" type="number" value={bbox[2]} readonly />
+							<input class="input is-small" type="number" bind:value={options.latitude} readonly />
 						</div>
 					</FieldControl>
 				</div>
 
 				<div class="is-flex">
 					<FieldControl
-						title="min latitude"
+						title="zoom level"
 						showHelp={false}
 						isFirstCharCapitalized={true}
 						fontWeight="semibold"
 					>
 						<div slot="control">
-							<input class="input is-small" type="number" value={bbox[1]} readonly />
+							<input class="input is-small" type="number" bind:value={options.zoom} readonly />
 						</div>
 					</FieldControl>
-
 					<FieldControl
-						title="max latitude"
+						title="bearing"
 						showHelp={false}
 						isFirstCharCapitalized={true}
 						fontWeight="semibold"
 					>
 						<div slot="control">
-							<input class="input is-small" type="number" value={bbox[3]} readonly />
+							<input class="input is-small" type="number" bind:value={options.bearing} readonly />
+						</div>
+					</FieldControl>
+					<FieldControl
+						title="pitch"
+						showHelp={false}
+						isFirstCharCapitalized={true}
+						fontWeight="semibold"
+					>
+						<div slot="control">
+							<input class="input is-small" type="number" bind:value={options.pitch} readonly />
 						</div>
 					</FieldControl>
 				</div>
-			{/if}
-		</div>
+			</div>
 
-		<div class="p-1" hidden={options.defaultApi !== 'auto'}>
-			<Notification type="info" showCloseButton={false}>
-				Position is automatically determined based on the overlays or the map style’s default center
-				coordinates.
-			</Notification>
-		</div>
+			<div class="p-1" hidden={options.defaultApi !== 'bbox'}>
+				{#if options.bbox}
+					{@const bbox = options.bbox}
+
+					<div class="is-flex">
+						<FieldControl
+							title="min longitude"
+							showHelp={false}
+							isFirstCharCapitalized={true}
+							fontWeight="semibold"
+						>
+							<div slot="control">
+								<input class="input is-small" type="number" value={bbox[0]} readonly />
+							</div>
+						</FieldControl>
+
+						<FieldControl
+							title="max longitude"
+							showHelp={false}
+							isFirstCharCapitalized={true}
+							fontWeight="semibold"
+						>
+							<div slot="control">
+								<input class="input is-small" type="number" value={bbox[2]} readonly />
+							</div>
+						</FieldControl>
+					</div>
+
+					<div class="is-flex">
+						<FieldControl
+							title="min latitude"
+							showHelp={false}
+							isFirstCharCapitalized={true}
+							fontWeight="semibold"
+						>
+							<div slot="control">
+								<input class="input is-small" type="number" value={bbox[1]} readonly />
+							</div>
+						</FieldControl>
+
+						<FieldControl
+							title="max latitude"
+							showHelp={false}
+							isFirstCharCapitalized={true}
+							fontWeight="semibold"
+						>
+							<div slot="control">
+								<input class="input is-small" type="number" value={bbox[3]} readonly />
+							</div>
+						</FieldControl>
+					</div>
+				{/if}
+			</div>
+
+			<div class="p-1" hidden={options.defaultApi !== 'auto'}>
+				<Notification type="info" showCloseButton={false}>
+					Position is automatically determined based on the overlays or the map style’s default
+					center coordinates.
+				</Notification>
+			</div>
+		{/if}
 	{/if}
 </div>
 

--- a/packages/svelte-static-image-controls/src/routes/+page.svelte
+++ b/packages/svelte-static-image-controls/src/routes/+page.svelte
@@ -106,6 +106,7 @@
 			apiBase="https://staticimage.undpgeohub.org/api"
 			bind:options
 			on:change={handleUrlChanged}
+			hiddenApiTypes={false}
 		/>
 	{/if}
 </div>

--- a/packages/svelte-undp-components/src/lib/components/SegmentButtons.stories.ts
+++ b/packages/svelte-undp-components/src/lib/components/SegmentButtons.stories.ts
@@ -32,6 +32,22 @@ const meta = {
 			control: 'select',
 			options: ['small', 'normal', 'medium', 'large'],
 			defaultValue: 'normal'
+		},
+		capitalized: {
+			type: 'boolean',
+			description: 'If true, capitalize title',
+			defaultValue: false
+		},
+		uppercase: {
+			type: 'boolean',
+			description: 'If true, transform title to uppercase',
+			defaultValue: false
+		},
+		fontWeight: {
+			control: 'select',
+			options: ['light', 'normal', 'medium', 'semibold', 'bold'],
+			description: 'Font weight of tab title',
+			defaultValue: 'normal'
 		}
 	}
 } satisfies Meta<SegmentButtons>;
@@ -140,6 +156,24 @@ export const WithoutWrap: Story = {
 	}
 };
 
+export const Capitalized: Story = {
+	args: {
+		buttons: longButtons,
+		selected: longButtons[0].value,
+		wrap: true,
+		capitalized: true
+	}
+};
+
+export const Uppercase: Story = {
+	args: {
+		buttons: longButtons,
+		selected: longButtons[0].value,
+		wrap: true,
+		uppercase: true
+	}
+};
+
 export const Small: Story = {
 	args: {
 		buttons,
@@ -169,5 +203,45 @@ export const Large: Story = {
 		buttons,
 		selected: buttons[0].value,
 		size: 'large'
+	}
+};
+
+export const LightFont: Story = {
+	args: {
+		buttons,
+		selected: buttons[0].value,
+		fontWeight: 'light'
+	}
+};
+
+export const NormalFont: Story = {
+	args: {
+		buttons,
+		selected: buttons[0].value,
+		fontWeight: 'normal'
+	}
+};
+
+export const MediumFont: Story = {
+	args: {
+		buttons,
+		selected: buttons[0].value,
+		fontWeight: 'medium'
+	}
+};
+
+export const SemiboldFont: Story = {
+	args: {
+		buttons,
+		selected: buttons[0].value,
+		fontWeight: 'semibold'
+	}
+};
+
+export const BoldFont: Story = {
+	args: {
+		buttons,
+		selected: buttons[0].value,
+		fontWeight: 'bold'
 	}
 };

--- a/packages/svelte-undp-components/src/lib/components/SegmentButtons.svelte
+++ b/packages/svelte-undp-components/src/lib/components/SegmentButtons.svelte
@@ -77,6 +77,7 @@
 			padding-left: 1rem;
 			padding-right: 1rem;
 			min-width: fit-content !important;
+			height: 34px;
 		}
 	}
 </style>

--- a/packages/svelte-undp-components/src/lib/components/SegmentButtons.svelte
+++ b/packages/svelte-undp-components/src/lib/components/SegmentButtons.svelte
@@ -15,6 +15,9 @@
 	export let selectedItems: { [key: string | number]: boolean } = {};
 	export let wrap = false;
 	export let size: 'small' | 'normal' | 'medium' | 'large' = 'normal';
+	export let capitalized = false;
+	export let uppercase = false;
+	export let fontWeight: 'light' | 'normal' | 'medium' | 'semibold' | 'bold' = 'normal';
 
 	const dispatch = createEventDispatcher();
 
@@ -52,7 +55,11 @@
 						<i class={button.icon} />
 					</span>
 				{/if}
-				<span>{button.title}</span>
+				<span
+					class="has-text-weight-{fontWeight} {capitalized ? 'is-capitalized' : ''} {uppercase
+						? 'is-uppercase'
+						: ''}">{button.title}</span
+				>
 			</button>
 		</p>
 	{/each}
@@ -65,5 +72,11 @@
 		padding-left: 1.5rem;
 		padding-right: 1.5rem;
 		border: 1px solid #000;
+
+		&.is-small {
+			padding-left: 1rem;
+			padding-right: 1rem;
+			min-width: fit-content !important;
+		}
 	}
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       '@undp-data/svelte-copy-to-clipboard':
         specifier: workspace:^
         version: link:../copy-to-clipboard
+      '@undp-data/svelte-undp-components':
+        specifier: workspace:^
+        version: link:../svelte-undp-components
       '@undp-data/undp-bulma':
         specifier: workspace:^
         version: link:../undp-bulma

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -403,6 +403,7 @@
 		style={styleUrl}
 		apiBase={$page.data.staticApiUrl}
 		bind:options={exportOptions}
+		hiddenApiTypes={true}
 		position="top-right"
 	/>
 {/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3318

* fix: added hiddenApiTypes property in Static Image API Control
* fix: use SegmentButtons and FieldControls from svelte-undp-components
* fix: show loader for export control
* fix: added more options of capitalized, uppercase and fontweight for segmentbuttons component
* fix: Updated StaticImageControl, and make api type setting hidden for GeoHub's export control

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1342095241) by [Unito](https://www.unito.io)
