### PR TITLE
fix: improved the logic of saved style update

### DIFF
--- a/.changeset/sour-dots-rescue.md
+++ b/.changeset/sour-dots-rescue.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: improved the logic of saved style update

--- a/sites/geohub/src/lib/server/helpers/getStyleById.ts
+++ b/sites/geohub/src/lib/server/helpers/getStyleById.ts
@@ -6,6 +6,7 @@ import { env } from '$env/dynamic/private';
 import MicrosoftPlanetaryStac from '$lib/stac/MicrosoftPlanetaryStac';
 import type {
 	HillshadeLayerSpecification,
+	LayerSpecification,
 	RasterLayerSpecification,
 	RasterSourceSpecification,
 	StyleSpecification,
@@ -13,7 +14,7 @@ import type {
 } from 'maplibre-gl';
 import { updateMosaicJsonBlob } from './updateMosaicJsonBlob';
 import { createDatasetLinks } from './createDatasetLinks';
-import { createAttributionFromTags, getBase64EncodedUrl } from '$lib/helper';
+import { createAttributionFromTags, getBase64EncodedUrl, getFirstSymbolLayerId } from '$lib/helper';
 import { Permission } from '$lib/config/AppConfig';
 import { getSTAC } from '.';
 
@@ -128,19 +129,41 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 				if (style.style.sources[srcName]) return;
 				const newSource = baseStyle.sources[srcName];
 				style.style.sources[srcName] = newSource;
-
-				// maybe need to copy new layers (if exists) to saved style in the future.
-				// let me not to do this since the logic is a bit complicated.
 			});
 
 			// update base layer style
-			for (const originalLayer of baseStyle.layers) {
-				const savedLayerIndex = style.style.layers.findIndex(
-					(l) => l.id === originalLayer.id && l.type === originalLayer.type
-				);
-				if (savedLayerIndex === -1) continue;
-				style.style.layers[savedLayerIndex] = JSON.parse(JSON.stringify(originalLayer));
+			const updatedLayers: LayerSpecification[] = JSON.parse(JSON.stringify(baseStyle.layers));
+			// get the total layer length exclude geohub layer for saved style
+			const totalBaseLayerLength = style.style.layers.filter(
+				(l) => style.layers.map((_l) => _l.id).includes(l.id) === false
+			).length;
+			for (const savedLayer of style.style.layers) {
+				// 	// skip if not geohub layer
+				if (baseStyle.layers.find((l) => l.id === savedLayer.id)) continue;
+				const currentIndex = style.style.layers.indexOf(savedLayer);
+
+				if (currentIndex > totalBaseLayerLength) {
+					// if it exists in the last part of layers
+					updatedLayers.push(savedLayer);
+				} else {
+					// if it exists in the middle of layers (for raster mostly)
+					const beforeOld = style.style.layers[currentIndex - 1];
+					const beforeNew = updatedLayers[currentIndex - 1];
+					if (beforeOld.id === beforeNew.id) {
+						// if layer IDs before this layer are the same, insert it at the same index
+						updatedLayers.splice(currentIndex, 0, savedLayer);
+					} else {
+						// otherwise insert layer before first symbol layer (style structure might have been changed at all)
+						const firstSymbolLayerId = getFirstSymbolLayerId(updatedLayers);
+						let idx = updatedLayers.length - 1;
+						if (firstSymbolLayerId) {
+							idx = updatedLayers.findIndex((l) => l.id === firstSymbolLayerId);
+						}
+						updatedLayers.splice(idx, 0, savedLayer);
+					}
+				}
 			}
+			style.style.layers = [...updatedLayers];
 		}
 
 		if (style.layers) {
@@ -278,6 +301,8 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 		}
 
 		return style;
+	} catch (err) {
+		console.error(err);
 	} finally {
 		dbm.end();
 	}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I improved the logic of style updating to ensure all new layers from the latest style will be added.

* firstly, copy all layers from the latest style
* then, add geohub layers from saved style.layers to new style layers in the same layer order

If the layer index is more than total layer length (exclude geohub layer), I consider it can be added in the last of layers array.
If the layer index is located at the middle of array, it compares layer id before the target layer. If before layer id is same, insert it in the same index.
Otherwise, insert it before the first symbol layer (new base style structure might have been changed).

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1342952699) by [Unito](https://www.unito.io)
