### PR TITLE
fix: restore raster categories correctly when users set a class color transparent or customized.

### DIFF
--- a/.changeset/little-pillows-teach.md
+++ b/.changeset/little-pillows-teach.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: restore raster categories correctly when users set a class color transparent or customized.

--- a/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
@@ -249,9 +249,11 @@
 		classifyImage();
 	};
 
-	$: $rescaleStore, handleRescaleChanged();
 	const handleRescaleChanged = debounce(() => {
 		if (!$rescaleStore) return;
+		let currentMin = colorMapRows[0].start ?? layerMin;
+		let currentMax = (colorMapRows[colorMapRows.length - 1].end as number) - 0.01 ?? layerMax;
+		if ($rescaleStore[0] === currentMin && $rescaleStore[1] === currentMax) return;
 		colorMapRows = [];
 		setInitialColorMapRows();
 		classifyImage();
@@ -276,9 +278,11 @@
 		} else {
 			setColorMapRowsFromURL();
 		}
-		classificationMethodStore.subscribe(() => {
-			handleClassificationMethodChange();
-		});
+		if (!layerHasUniqueValues) {
+			rescaleStore.subscribe(() => {
+				handleRescaleChanged();
+			});
+		}
 	});
 </script>
 
@@ -302,7 +306,10 @@
 						setting is only used when you select a property to classify the layer appearance.
 					</div>
 					<div slot="control">
-						<ClassificationMethodSelect contextKey={CLASSIFICATION_METHOD_CONTEXT_KEY} />
+						<ClassificationMethodSelect
+							contextKey={CLASSIFICATION_METHOD_CONTEXT_KEY}
+							on:change={handleClassificationMethodChange}
+						/>
 					</div>
 				</FieldControl>
 			</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3325

There were unnecessary event triggered by classification method and rescale store subscription. Fixed the bug for both raster categories legend and unique value legend.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1342970624) by [Unito](https://www.unito.io)
