### PR TITLE
fix: set -9999 as default value for raster expression instead of zero. Also, set nodata option for -9999

### DIFF
--- a/.changeset/weak-elephants-sit.md
+++ b/.changeset/weak-elephants-sit.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: set -9999 as default value for raster expression instead of zero. Also, set nodata option for -9999

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -142,9 +142,9 @@
 		let newParams = {};
 
 		const expressionStringValue = `${Object.values(expression).join(' ')}`;
-
-		newParams['expression'] = `where(${expressionStringValue}, ${expression.band}, 0);`;
-		newParams['rescale'] = [Number(info.stats[band].min), Number(info.stats[band].max)].join(',');
+		const NO_DATA = -9999;
+		newParams['expression'] = `where(${expressionStringValue}, ${expression.band}, ${NO_DATA});`;
+		newParams['nodata'] = NO_DATA;
 
 		const url: string = getLayerSourceUrl($map, layer.id) as string;
 		const lURL = new URL(url);

--- a/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
@@ -268,6 +268,10 @@
 		if (expression) {
 			baseUrl.searchParams.set('expression', expression);
 		}
+		const nodata = getValueFromRasterTileUrl(map, layer.id, 'nodata') as string;
+		if (nodata) {
+			baseUrl.searchParams.set('nodata', nodata);
+		}
 
 		const algorithm = getValueFromRasterTileUrl(map, layer.id, 'algorithm') as string;
 		if (!algorithm) {

--- a/sites/geohub/src/lib/helper/getValueFromRasterTileUrl.ts
+++ b/sites/geohub/src/lib/helper/getValueFromRasterTileUrl.ts
@@ -22,6 +22,7 @@ export const getValueFromRasterTileUrl = (
 		| 'algorithm'
 		| 'algorithm_params'
 		| 'bidx'
+		| 'nodata'
 ): string | number[] | number[][][] | { [key: string]: number[] } => {
 	const source: RasterTileSource = map.getSource(map.getLayer(layerId).source) as RasterTileSource;
 	if (!['raster', 'raster-dem'].includes(source.type)) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I found the dataset which has 0-1 value cannot be visualized well after applying raster expression because 0 was used as default value. So, if add expression of `b1 < 0.5`, pixels with a value more than 0.5 will become 0, and makes visualization very weird.

I did the following two changes.

* set -9999 as default value for raster expression instead of using zero (0)
* set nodata option for -9999. Titiler will overwrite nodata by -9999. So, the default value will not be shown.
* removed setting `rescale` param at transform component.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/8f21a43a-8cf1-4600-9bfc-ca1259835dc3)

But I am not sure which default value is more appropriate. Not  so confident use of -9999 for nodata value.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1343004236) by [Unito](https://www.unito.io)
