### PR TITLE
fix: simplified the logic of state management for RasterTransform

### DIFF
--- a/.changeset/gentle-paws-give.md
+++ b/.changeset/gentle-paws-give.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: simplified the logic of state management for RasterTransform

--- a/sites/geohub/src/lib/types/RasterExpression.ts
+++ b/sites/geohub/src/lib/types/RasterExpression.ts
@@ -1,5 +1,0 @@
-export interface RasterExpression {
-	band: string;
-	operator?: string;
-	value?: string[];
-}

--- a/sites/geohub/src/lib/types/index.ts
+++ b/sites/geohub/src/lib/types/index.ts
@@ -25,7 +25,6 @@ export * from './PgtileservIndexJson';
 export * from './RasterAlgorithm';
 export * from './RasterLayerStats';
 export * from './RasterSimpleExpression';
-export * from './RasterExpression';
 export * from './RasterTileMetadata';
 export * from './Region';
 export * from './Sprite';


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3316

I simplified the code related to state management. Each input element value is now directly binded to expression object other than having two variables to syncronize state.

Also, moved `RasterExpression` interface to the component itself since it is not used by any other component. 

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1343067861) by [Unito](https://www.unito.io)
