### PR TITLE
fix: change site_url from environmental variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
         run: mkdocs build
 
       - name: Build documentation for dev
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/documentation-update' }}
+        if: ${{ (github.ref != 'refs/heads/main') }}
         working-directory: ./documentation
         env:
           SITE_URL: https://docs-dev.undpgeohub.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: GeoHub UserGuide
-      url: https://docs.undpgeohub.org/
+
     steps:
       - name: checkout code repository
         uses: actions/checkout@v4
@@ -298,8 +298,18 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Build documentation
+      - name: Build documentation for production
+        if: ${{ (github.ref == 'refs/heads/main') }}
         working-directory: ./documentation
+        env:
+          SITE_URL: https://docs.undpgeohub.org/
+        run: mkdocs build
+
+      - name: Build documentation for dev
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/documentation-update' }}
+        working-directory: ./documentation
+        env:
+          SITE_URL: https://docs-dev.undpgeohub.org/
         run: mkdocs build
 
       - name: deploy userguide to Blob container Prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,14 +302,14 @@ jobs:
         if: ${{ (github.ref == 'refs/heads/main') }}
         working-directory: ./documentation
         env:
-          SITE_URL: https://docs.undpgeohub.org/
+          SITE_URL: https://docs.undpgeohub.org
         run: mkdocs build
 
       - name: Build documentation for dev
         if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/documentation-update' }}
         working-directory: ./documentation
         env:
-          SITE_URL: https://docs-dev.undpgeohub.org/
+          SITE_URL: https://docs-dev.undpgeohub.org
         run: mkdocs build
 
       - name: deploy userguide to Blob container Prod

--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -25,7 +25,7 @@ RUN git init
 
 ENV HOST=0.0.0.0
 ENV PORT=8000
-ENV SITE_URL=http://localhost:${PORT}
+ENV SITE_URL=http://${HOST}:${PORT}
 
 EXPOSE $PORT
 

--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -25,6 +25,7 @@ RUN git init
 
 ENV HOST=0.0.0.0
 ENV PORT=8000
+ENV SITE_URL=http://localhost:${PORT}
 
 EXPOSE $PORT
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -38,7 +38,7 @@ To run build mkdocs, SITE_URL environmental variable needs to be configured in a
 
 ```bash
 pipenv shell
-export SITE_URL=https://dev.undpgeohub.org
+export SITE_URL=https://docs.undpgeohub.org
 mkdocs serve
 ```
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -26,21 +26,19 @@ If you want to change the port number exposed, change it in `.env` file. As defa
 
 ### Testing your changes on your local machine
 
-To run mkdocs locally, SITE_URL environmental variable needs to be configured in advance.
-
 ```bash
 pip install pipenv
 pipenv install -r requirements.txt
-pipenv shell
-export SITE_URL=http://localhost:8000
-mkdocs serve
+pipenv run mkdocs serve
 ```
 
 ### Building documentation
 
+To run build mkdocs, SITE_URL environmental variable needs to be configured in advance. SITE_URL must be URL for production server.
+
 ```bash
 pipenv shell
-export SITE_URL=http://localhost:8000
+export SITE_URL=https://dev.undpgeohub.org
 mkdocs serve
 ```
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -10,15 +10,9 @@ all markdown files should be placed under `docs` folder. You can also put any im
 
 after putting your markdown file, open `mkdocs.yml` and edit `nav` section to link your file to navigation menu.
 
-### Testing your changes on your local machine
-
-```bash
-pip install pipenv
-pipenv install -r requirements.txt
-pipenv run mkdocs serve
-```
-
 ### Testing your changes on your local machine via Docker
+
+The best experience of documenting is to use docker-compose. The steps are as follows.
 
 1. Clone this repository: git clone https://github.com/UNDP-Data/geohub
 1. Move to documentation folder: `cd documentation`
@@ -30,10 +24,24 @@ The server will automatically live-reload with any change made to the local `./d
 
 If you want to change the port number exposed, change it in `.env` file. As default, the server will be launched at the port `8000` (There might be conflict with titiler).
 
+### Testing your changes on your local machine
+
+To run mkdocs locally, SITE_URL environmental variable needs to be configured in advance.
+
+```bash
+pip install pipenv
+pipenv install -r requirements.txt
+pipenv shell
+export SITE_URL=http://localhost:8000
+mkdocs serve
+```
+
 ### Building documentation
 
 ```bash
-pipenv run mkdocs build
+pipenv shell
+export SITE_URL=http://localhost:8000
+mkdocs serve
 ```
 
 The build output is available at `./site` inside of the container.

--- a/documentation/docker-compose.yml
+++ b/documentation/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       #Application
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-8000}
+      - SITE_URL=http://localhost:${PORT:-8000}
     ports:
       - "${PORT}:${PORT}"
     volumes:

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -8,7 +8,7 @@ site_dir: site
 repo_name: undp-data/geohub
 repo_url: https://github.com/undp-data/geohub
 edit_uri: https://github.com/undp-data/geohub/blob/develop/documentation/docs
-# site_url: https://docs.undpgeohub.org
+site_url: !!python/object/apply:os.getenv ["SITE_URL"]
 
 # Copyright
 copyright: Copyright &copy; 2024 <a href="https://undp.org">United Nations Development Programme</a>
@@ -128,10 +128,10 @@ markdown_extensions:
 
 plugins:
   - search
-  # - social:
-  #     cards_color:
-  #       fill: "#FFFFFF"
-  #       text: "#006eb5"
+  - social:
+      cards_color:
+        fill: "#FFFFFF"
+        text: "#006eb5"
   - mkdocs-video:
       css_style:
         class: "center"

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -8,7 +8,8 @@ site_dir: site
 repo_name: undp-data/geohub
 repo_url: https://github.com/undp-data/geohub
 edit_uri: https://github.com/undp-data/geohub/blob/develop/documentation/docs
-site_url: !!python/object/apply:os.getenv ["SITE_URL"]
+# configuration by env https://www.mkdocs.org/user-guide/configuration/#environment-variables
+site_url: !ENV ["SITE_URL", "http://localhost:8000"]
 
 # Copyright
 copyright: Copyright &copy; 2024 <a href="https://undp.org">United Nations Development Programme</a>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
This can allow us to use different production URLs (prod and dev, and localhsot) to build. 

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1343776808) by [Unito](https://www.unito.io)
