### PR TITLE
fix: allow to input float value and negative value manually at NumberInput component

### DIFF
--- a/.changeset/odd-bats-rush.md
+++ b/.changeset/odd-bats-rush.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: allow to input float value and negative value manually at NumberInput component

--- a/packages/svelte-undp-components/src/lib/components/NumberInput.svelte
+++ b/packages/svelte-undp-components/src/lib/components/NumberInput.svelte
@@ -80,7 +80,6 @@
 				parts[1] = parts[1].slice(0, 2);
 				numericValue = parts.join('.');
 			}
-			console.log(numericValue);
 			// Ensure that the input is not empty
 			if (numericValue.length === 0) {
 				numericValue = '0';


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3358

Allow users to enter negative value or float value manually. also, if entered value is out of range of min/max value, it will be overwritten by force.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1344027920) by [Unito](https://www.unito.io)
