### PR TITLE
fix: fixed bug of rescale when min/max is 0-1

### DIFF
--- a/.changeset/calm-horses-fry.md
+++ b/.changeset/calm-horses-fry.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of rescale when min/max is 0-1

--- a/sites/geohub/src/components/maplibre/raster/RasterRescale.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterRescale.svelte
@@ -55,8 +55,9 @@
 		}
 	}
 
-	// let step = ($rescaleStore[1] - $rescaleStore[0]) * 1e-2;
-	let step = isInt(layerMin) && isInt(layerMax) ? 1 : 0.1;
+	// if min and max are integer, set step to 1, otherwise use 0.1 for step.
+	// but use 0.1 step if the difference of min and max is less than 1
+	let step = isInt(layerMin) && isInt(layerMax) && layerMax - layerMin > 1 ? 1 : 0.1;
 
 	const onSliderStop = (e) => {
 		$rescaleStore = [...e.detail.values];


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fix #3360

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1344587695) by [Unito](https://www.unito.io)
