### PR TITLE
fix: update rescale store when a raster transform is applied

### DIFF
--- a/.changeset/weak-feet-rule.md
+++ b/.changeset/weak-feet-rule.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: update rescale store when a raster transform is applied

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -100,7 +100,6 @@
 			layerMin = Number(stats.min);
 			layerMax = Number(stats.max);
 		}
-		rescaleStore.set([layerMin, layerMax]);
 	};
 
 	const removeExpression = async () => {
@@ -112,6 +111,7 @@
 		await setLayerStats({});
 		updateParamsInURL(getLayerStyle($map, layer.id), urlObj, {}, map);
 		resetExpression();
+		rescaleStore.set([layerMin, layerMax]);
 	};
 
 	const applyExpression = async () => {
@@ -126,6 +126,7 @@
 
 		await setLayerStats(newParams);
 		updateParamsInURL(getLayerStyle($map, layer.id), lURL, newParams, map);
+		rescaleStore.set([layerMin, layerMax]);
 	};
 
 	const resetExpression = () => {

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -10,21 +10,28 @@
 <script lang="ts">
 	import Step from '$components/util/Step.svelte';
 	import Wizard from '$components/util/Wizard.svelte';
+	import { RasterTileData } from '$lib/RasterTileData';
 	import { RasterComparisonOperators } from '$lib/config/AppConfig';
 	import {
-		fetchUrl,
 		getActiveBandIndex,
 		getLayerSourceUrl,
 		getLayerStyle,
 		getValueFromRasterTileUrl,
 		updateParamsInURL
 	} from '$lib/helper';
-	import type { BandMetadata, Layer, RasterLayerStats, RasterTileMetadata } from '$lib/types';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
+	import type { BandMetadata, Layer, RasterTileMetadata } from '$lib/types';
+	import {
+		MAPSTORE_CONTEXT_KEY,
+		RASTERRESCALE_CONTEXT_KEY,
+		type MapStore,
+		type RasterRescaleStore
+	} from '$stores';
 	import { Notification, Slider, initTooltipTippy, isInt } from '@undp-data/svelte-undp-components';
 	import { getContext, onMount } from 'svelte';
 
 	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
+	const rescaleStore: RasterRescaleStore = getContext(RASTERRESCALE_CONTEXT_KEY);
+
 	const tippyTooltip = initTooltipTippy();
 
 	export let layer: Layer;
@@ -65,43 +72,49 @@
 		}
 	};
 
-	const setLayerStats = async () => {
-		const bandIndex = getActiveBandIndex(info); //normally info should be called as well
-
-		//necessary to create Slider
-		const band = info.active_band_no;
-		if (info.stats) {
-			layerMin = info.stats[band].min;
-			layerMax = info.stats[band].max;
+	const setLayerStats = async (params: Record<string, string> = undefined) => {
+		if (params || !info.stats) {
+			await updateStats(params);
 		} else {
-			// if stats does not exist, try to fetch it
-			const statsURL = layer.dataset.properties.links.find((l) => l.rel === 'statistics').href;
-			const statistics = (await fetchUrl(statsURL)) as unknown as RasterLayerStats;
-			info.stats = statistics;
-
-			if (info.stats) {
-				layerMin = Number(info.stats[band].min);
-				layerMax = Number(info.stats[band].max);
-			} else {
-				// still no stats, use it from info
-				const bandMetaStats = info['band_metadata'][bandIndex][1] as BandMetadata;
-				layerMin = Number(bandMetaStats['STATISTICS_MINIMUM']);
-				layerMax = Number(bandMetaStats['STATISTICS_MAXIMUM']);
-			}
+			//necessary to create Slider
+			layerMin = info.stats[info.active_band_no].min;
+			layerMax = info.stats[info.active_band_no].max;
 		}
 	};
 
-	const removeExpression = () => {
+	const updateStats = async (params: Record<string, string> = undefined) => {
+		// if stats does not exist, try to fetch it
+		const expression = params ? params['expression'] : undefined;
+		const nodata = params ? params['nodata'] : undefined;
+		if (!expression && !nodata) {
+			// still no stats, use it from info
+			const bandIndex = getActiveBandIndex(info); //normally info should be called as well
+			const bandMetaStats = info['band_metadata'][bandIndex][1] as BandMetadata;
+			layerMin = Number(bandMetaStats['STATISTICS_MINIMUM']);
+			layerMax = Number(bandMetaStats['STATISTICS_MAXIMUM']);
+		} else {
+			const rasterData = new RasterTileData(layer.dataset);
+			const rasterInfo = await rasterData.getMetadata(undefined, expression, nodata);
+			const bandName = Object.keys(rasterInfo.stats)[0];
+			const stats = rasterInfo.stats[bandName];
+			layerMin = Number(stats.min);
+			layerMax = Number(stats.max);
+		}
+		rescaleStore.set([layerMin, layerMax]);
+	};
+
+	const removeExpression = async () => {
 		const url: string = getLayerSourceUrl($map, layer.id) as string;
 		const urlObj = new URL(url);
 		urlObj.searchParams.delete('expression');
 		urlObj.searchParams.delete('nodata');
 
+		await setLayerStats({});
 		updateParamsInURL(getLayerStyle($map, layer.id), urlObj, {}, map);
 		resetExpression();
 	};
 
-	const applyExpression = () => {
+	const applyExpression = async () => {
 		let newParams = {};
 		const expressionStringValue = `${[expression.band, expression.operator, expression.value[0]].join(' ')}`;
 		const NO_DATA = -9999;
@@ -111,6 +124,7 @@
 		const url: string = getLayerSourceUrl($map, layer.id) as string;
 		const lURL = new URL(url);
 
+		await setLayerStats(newParams);
 		updateParamsInURL(getLayerStyle($map, layer.id), lURL, newParams, map);
 	};
 
@@ -277,6 +291,15 @@
 					showEditor={true}
 				/>
 			</div>
+
+			{#if $rescaleStore?.length === 2 && ($rescaleStore[0] !== layerMin || $rescaleStore[1] !== layerMax)}
+				<div class="mt-2">
+					<Notification type="warning" showCloseButton={false}>
+						Rescale values ({$rescaleStore.join(', ')}) will be removed when this transform will be
+						applied.
+					</Notification>
+				</div>
+			{/if}
 
 			<button
 				on:click={() => {

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -296,8 +296,7 @@
 			{#if $rescaleStore?.length === 2 && ($rescaleStore[0] !== layerMin || $rescaleStore[1] !== layerMax)}
 				<div class="mt-2">
 					<Notification type="warning" showCloseButton={false}>
-						Rescale values ({$rescaleStore.join(', ')}) will be removed when this transform will be
-						applied.
+						Rescale values ({$rescaleStore.join(', ')}) are removed when this transform is applied.
 					</Notification>
 				</div>
 			{/if}

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -15,19 +15,28 @@ export class RasterTileData {
 		this.feature = feature;
 	}
 
-	public getMetadata = async (algorithmId?: string) => {
+	public getMetadata = async (algorithmId?: string, expression?: string, nodata?: string) => {
 		const metadataUrl = this.feature.properties?.links?.find((l) => l.rel === 'info')?.href;
 		if (!metadataUrl) return;
 		const res = await fetch(metadataUrl);
 		const metadata: RasterTileMetadata = await res.json();
 		if (metadata && metadata.band_metadata && metadata.band_metadata.length > 0) {
-			const resStatistics = await fetch(
-				`${
-					this.feature.properties.links.find((l) => l.rel === 'statistics').href
-				}&histogram_bins=10${algorithmId ? `&algorithm=${algorithmId}` : ''}`
+			const apiUrl = new URL(
+				this.feature.properties.links.find((l) => l.rel === 'statistics').href
 			);
+			apiUrl.searchParams.set('histogram_bins', '10');
+			if (algorithmId) {
+				apiUrl.searchParams.set('algorithm', algorithmId);
+			}
+			if (expression) {
+				apiUrl.searchParams.set('expression', expression);
+			}
+			if (nodata) {
+				apiUrl.searchParams.set('nodata', nodata);
+			}
+			const resStatistics = await fetch(apiUrl);
 			const statistics = await resStatistics.json();
-			if (statistics && !algorithmId) {
+			if (statistics && !algorithmId && !expression && !nodata) {
 				for (let i = 0; i < metadata.band_metadata.length; i++) {
 					const bandValue = metadata.band_metadata[i][0] as string;
 					const bandDetails = statistics[bandValue];
@@ -46,7 +55,7 @@ export class RasterTileData {
 					}
 				}
 				metadata.stats = statistics;
-			} else if (statistics && algorithmId) {
+			} else if (statistics && (algorithmId || (expression && nodata))) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				metadata.band_metadata = [];


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3345

* update $rescaleStore when new transform is applied
![image](https://github.com/UNDP-Data/geohub/assets/2639701/ce2c304a-a2ff-4e40-a038-6c8077a9abb4)
* show warning message in transform tab if user changed rescale from default.
![image](https://github.com/UNDP-Data/geohub/assets/2639701/43896342-5a51-46dd-a7a2-237091ec07cc)

Note.
This PR does not update `layer.info.band_metadata` and `layer.info.stats` properties because band name in a layer will be changed after applying expression, this causes a tricky behaviour. But the PR will fetch the new min and max value from statistics endpoint, and update rescale values.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1353120333) by [Unito](https://www.unito.io)
