### PR TITLE
fix: In raster transform, use layer max + 1 for <, <= operator. and Use min - 1 for >, >= operator.

### DIFF
--- a/.changeset/nine-mangos-melt.md
+++ b/.changeset/nine-mangos-melt.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: In raster transform, use layer max + 1 for <, <= operator. and Use min - 1 for >, >= operator.

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -117,7 +117,12 @@
 	const applyExpression = async () => {
 		let newParams = {};
 		const expressionStringValue = `${[expression.band, expression.operator, expression.value[0]].join(' ')}`;
-		const NO_DATA = -9999;
+		let NO_DATA = -9999;
+		if (['<', '<='].includes(expression.operator)) {
+			NO_DATA = layerMax + 1;
+		} else if (['>', '>='].includes(expression.operator)) {
+			NO_DATA = layerMin - 1;
+		}
 		newParams['expression'] = `where(${expressionStringValue}, ${expression.band}, ${NO_DATA});`;
 		newParams['nodata'] = NO_DATA;
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Improved default value setting for raster transform. When `<`, `<=`, `>`, `>=` operator is selected, visualization is improved. But still has an issue of nodata value masking when `\=`, `!=` is selected (still -9999 is used)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1353205842) by [Unito](https://www.unito.io)
