### PR TITLE
fix: Use nodata_value from info if available, otherwise use -9999 or threshold value inputted

### DIFF
--- a/.changeset/tall-suits-applaud.md
+++ b/.changeset/tall-suits-applaud.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: Use nodata_value from info if available, otherwise use -9999 or threshold value inputted

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterTransformSimple.svelte
@@ -110,18 +110,27 @@
 
 		await setLayerStats({});
 		updateParamsInURL(getLayerStyle($map, layer.id), urlObj, {}, map);
+
+		if (['<', '<='].includes(expression.operator)) {
+			rescaleStore.set([$rescaleStore[0], layerMax]);
+		} else if (['>', '>='].includes(expression.operator)) {
+			rescaleStore.set([layerMin, $rescaleStore[1]]);
+		} else {
+			rescaleStore.set([layerMin, layerMax]);
+		}
 		resetExpression();
-		rescaleStore.set([layerMin, layerMax]);
 	};
 
 	const applyExpression = async () => {
 		let newParams = {};
 		const expressionStringValue = `${[expression.band, expression.operator, expression.value[0]].join(' ')}`;
-		let NO_DATA = -9999;
-		if (['<', '<='].includes(expression.operator)) {
-			NO_DATA = layerMax + 1;
-		} else if (['>', '>='].includes(expression.operator)) {
-			NO_DATA = layerMin - 1;
+		let NO_DATA = info.nodata_value ?? -9999;
+		if (!('nodata_value' in info)) {
+			if (['<', '<='].includes(expression.operator)) {
+				NO_DATA = expression.value[0] + 1;
+			} else if (['>', '>='].includes(expression.operator)) {
+				NO_DATA = expression.value[0] - 1;
+			}
 		}
 		newParams['expression'] = `where(${expressionStringValue}, ${expression.band}, ${NO_DATA});`;
 		newParams['nodata'] = NO_DATA;
@@ -131,7 +140,12 @@
 
 		await setLayerStats(newParams);
 		updateParamsInURL(getLayerStyle($map, layer.id), lURL, newParams, map);
-		rescaleStore.set([layerMin, layerMax]);
+
+		if (['<', '<='].includes(expression.operator)) {
+			rescaleStore.set([$rescaleStore[0], expression.value[0]]);
+		} else if (['>', '>='].includes(expression.operator)) {
+			rescaleStore.set([expression.value[0], $rescaleStore[1]]);
+		}
 	};
 
 	const resetExpression = () => {

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -55,7 +55,7 @@ export class RasterTileData {
 					}
 				}
 				metadata.stats = statistics;
-			} else if (statistics && (algorithmId || (expression && nodata))) {
+			} else if (statistics && (algorithmId || expression || nodata)) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				metadata.band_metadata = [];


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Use nodata_value in info api if available, otherwise use -9999 for = and != operator, use threshold + 1 if < and <=, Use threshold - 1 if > and >=.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1353267788) by [Unito](https://www.unito.io)
