### PR TITLE
fix: show labels on slider if algorithm's options_descriptions property is available

### DIFF
--- a/.changeset/eight-forks-design.md
+++ b/.changeset/eight-forks-design.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+feat: add formatter option to Slider and PropertyEditor components

--- a/.changeset/perfect-ligers-explain.md
+++ b/.changeset/perfect-ligers-explain.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show labels on slider if algorithm's options_descriptions property is available

--- a/packages/svelte-undp-components/src/lib/components/PropertyEditor.stories.ts
+++ b/packages/svelte-undp-components/src/lib/components/PropertyEditor.stories.ts
@@ -62,6 +62,22 @@ const meta = {
 		showEditor: {
 			type: 'boolean',
 			defaultValue: false
+		},
+		showRestPip: {
+			control: 'select',
+			options: ['label', 'pip', true, false],
+			description:
+				'Whether to show a pip or label for all values except first & last. See https://simeydotme.github.io/svelte-range-slider-pips/en/options/#rest',
+			defaultValue: true
+		},
+		showAll: {
+			control: 'select',
+			options: ['label', 'pip', false],
+			defaultValue: false
+		},
+		formatter: {
+			description:
+				'So although we used prefix and suffix to add some formatting before and after the values, we can also use the formatter function to format the values in any way we like. See https://simeydotme.github.io/svelte-range-slider-pips/en/examples/formatter/'
 		}
 	}
 } satisfies Meta<PropertyEditor>;
@@ -248,5 +264,34 @@ export const StringValue: Story = {
 		value: 'string value....',
 		defaultValue: '',
 		isExpanded: true
+	}
+};
+
+const options = [
+	'No clouds',
+	'Almost no clouds',
+	'Very few clouds',
+	'Partially cloudy',
+	'Cloudy',
+	'Very cloudy'
+];
+
+export const IntegerSliderWithFormatter: Story = {
+	args: {
+		id: 'property',
+		type: 'integer',
+		title: 'Property name',
+		description: 'Property description',
+		value: 1,
+		defaultValue: 1,
+		minimum: 0,
+		maximum: 5,
+		isExpanded: true,
+		showAll: 'label',
+		showRestPip: true,
+		formatter: (value) => {
+			const label = options[value];
+			return label;
+		}
 	}
 };

--- a/packages/svelte-undp-components/src/lib/components/PropertyEditor.svelte
+++ b/packages/svelte-undp-components/src/lib/components/PropertyEditor.svelte
@@ -216,6 +216,9 @@
 						-
 					{/if}
 					{value >= 0 ? value : value * -1}
+				{:else if typeof value === 'number'}
+					{@const formattedValue = formatter(value, 0, 0)}
+					{formattedValue}
 				{:else}
 					{value}
 				{/if}

--- a/packages/svelte-undp-components/src/lib/components/PropertyEditor.svelte
+++ b/packages/svelte-undp-components/src/lib/components/PropertyEditor.svelte
@@ -96,6 +96,24 @@
 	 */
 	export let showEditor = false;
 
+	export let showRestPip: boolean | 'pip' | 'label' = false;
+
+	/**
+	 * Whether to show a pip or label for every value. Possible values are:
+	 * - false all values in the Slider will not have a pip or label
+	 * - pip a pip (only) will be shown for all values
+	 * - label label (and pip) is shown on all values
+	 *
+	 * It is only available when slider is shown
+	 */
+	export let showAll: boolean | 'pip' | 'label' = false;
+
+	export let formatter: (value: number, index: number, percent: number) => number | string = (
+		value
+	) => {
+		return value;
+	};
+
 	const DEFAULT_MINIMUM = -9999;
 	const DEFAULT_MAXIMUM = 9999;
 
@@ -228,7 +246,7 @@
 
 	{#if isExpanded}
 		{@const step = type === 'integer' ? 1 : 0.1}
-		<div class="expanded-container px-3 pb-4">
+		<div class="expanded-container px-5 pb-4">
 			{#if description}
 				<p class="help">{description}</p>
 			{/if}
@@ -251,13 +269,15 @@
 						{min}
 						{max}
 						{step}
-						rest={false}
+						bind:rest={showRestPip}
 						flost={true}
 						first="label"
 						last="label"
 						values={[value]}
+						bind:all={showAll}
 						bind:showEditor
 						on:change={setSliderValue}
+						{formatter}
 					/>
 				{:else if typeof value === 'number'}
 					<NumberInput

--- a/packages/svelte-undp-components/src/lib/components/Slider.stories.ts
+++ b/packages/svelte-undp-components/src/lib/components/Slider.stories.ts
@@ -98,6 +98,10 @@ const meta = {
 			description:
 				'If enabled, show the manual text editor. Currently only available for first two values.',
 			defaultValue: false
+		},
+		formatter: {
+			description:
+				'So although we used prefix and suffix to add some formatting before and after the values, we can also use the formatter function to format the values in any way we like. See https://simeydotme.github.io/svelte-range-slider-pips/en/examples/formatter/'
 		}
 	}
 } satisfies Meta<Slider>;
@@ -233,5 +237,28 @@ export const Disabled: Story = {
 		step: 1,
 		values: [50],
 		disabled: true
+	}
+};
+
+const options = [
+	'No clouds',
+	'Almost no clouds',
+	'Very few clouds',
+	'Partially cloudy',
+	'Cloudy',
+	'Very cloudy'
+];
+
+export const Formatter: Story = {
+	args: {
+		min: 0,
+		max: 5,
+		step: 1,
+		values: [1],
+		all: 'label',
+		formatter: (value) => {
+			const label = options[value];
+			return label;
+		}
 	}
 };

--- a/packages/svelte-undp-components/src/lib/components/Slider.svelte
+++ b/packages/svelte-undp-components/src/lib/components/Slider.svelte
@@ -23,6 +23,12 @@
 	export let range: boolean | 'min' | 'max' = values.length > 1 ? true : false;
 	export let showEditor = false;
 
+	export let formatter: (value: number, index: number, percent: number) => number | string = (
+		value
+	) => {
+		return value;
+	};
+
 	const setSliderValue = debounce((e: { detail: { values: number[] } }) => {
 		values = e.detail.values;
 		dispatch('change', {
@@ -55,6 +61,7 @@
 		bind:disabled
 		bind:prefix
 		bind:suffix
+		{formatter}
 	/>
 
 	{#if showEditor}

--- a/sites/geohub/src/components/maplibre/raster/RasterAlgorithms.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterAlgorithms.svelte
@@ -131,6 +131,16 @@
 							exclusiveMaximum={args.exclusiveMaximum}
 							on:change={handleParameterValueChanged}
 							bind:isExpanded={expanded[key]}
+							showRestPip={args.options_descriptions ? true : false}
+							showAll={args.options_descriptions ? 'pip' : false}
+							formatter={(value) => {
+								const options = args.options_descriptions;
+								if (options && options.length > 0) {
+									return options[value];
+								} else {
+									return value;
+								}
+							}}
 						/>
 					{/each}
 				</div>

--- a/sites/geohub/src/lib/types/RasterAlgorithm.ts
+++ b/sites/geohub/src/lib/types/RasterAlgorithm.ts
@@ -7,6 +7,7 @@ export interface RasterAlgorithmParameter {
 	maximum?: number;
 	exclusiveMinimum?: number;
 	minimum?: number;
+	options_descriptions?: string[];
 }
 
 export interface RasterAlgorithm {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description


* fix: show labels on slider if algorithm's options_descriptions property is available
* feat: add formatter option to Slider and PropertyEditor components

![image](https://github.com/UNDP-Data/geohub/assets/2639701/f051bd09-677d-4253-87f6-f21b5bcac570)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [x] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1356344543) by [Unito](https://www.unito.io)
