### PR TITLE
 fix: add unit tag if algorithm's outputs.unit prop is available for showing unit in legend.

### DIFF
--- a/.changeset/curly-beers-move.md
+++ b/.changeset/curly-beers-move.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add unit tag if algorithm's outputs.unit prop is available for showing unit in legend.

--- a/sites/geohub/src/components/maplibre/raster/RasterAlgorithmExplorer.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterAlgorithmExplorer.svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
 	export interface AlgorithmLayerSpec {
 		algorithmId: string;
+		algorithm: RasterAlgorithm;
 		sourceId: string;
 		source: RasterSourceSpecification | RasterDEMSourceSpecification;
 		layerId: string;
@@ -188,6 +189,7 @@
 
 		return {
 			algorithmId: id,
+			algorithm: algorithms[id],
 			sourceId,
 			source,
 			layerId,
@@ -235,6 +237,7 @@
 
 		return {
 			algorithmId: id,
+			algorithm: algorithms[id],
 			sourceId,
 			source,
 			layerId,

--- a/sites/geohub/src/components/maplibre/raster/RasterAlgorithms.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterAlgorithms.svelte
@@ -125,6 +125,7 @@
 							description={args.description}
 							bind:value={parameters[key]}
 							defaultValue={args.default}
+							unit={args.unit}
 							minimum={args.minimum}
 							exclusiveMinimum={args.exclusiveMinimum}
 							maximum={args.maximum}

--- a/sites/geohub/src/components/pages/map/data/DataCard.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataCard.svelte
@@ -210,6 +210,13 @@
 			const rasterTile = new RasterTileData(feature);
 			const rasterInfo = await rasterTile.getMetadata(layerSpec.algorithmId);
 
+			if (layerSpec.algorithm.outputs.unit) {
+				feature.properties.tags.push({
+					key: 'unit',
+					value: layerSpec.algorithm.outputs.unit
+				});
+			}
+
 			rasterInfo.active_band_no = Object.keys(rasterInfo.stats)[0];
 
 			$layerListStore = [

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -33,6 +33,7 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 
 	public create = async (colormap_name?: string, algorithmId?: string) => {
 		this.metadata = await this.getMetadata(algorithmId);
+		console.log(this.metadata);
 		if (!this.bandIndex) {
 			this.bandIndex = getActiveBandIndex(this.metadata);
 		}

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -33,7 +33,6 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 
 	public create = async (colormap_name?: string, algorithmId?: string) => {
 		this.metadata = await this.getMetadata(algorithmId);
-		console.log(this.metadata);
 		if (!this.bandIndex) {
 			this.bandIndex = getActiveBandIndex(this.metadata);
 		}

--- a/sites/geohub/src/lib/types/RasterAlgorithm.ts
+++ b/sites/geohub/src/lib/types/RasterAlgorithm.ts
@@ -7,6 +7,7 @@ export interface RasterAlgorithmParameter {
 	maximum?: number;
 	exclusiveMinimum?: number;
 	minimum?: number;
+	unit?: string;
 	options_descriptions?: string[];
 }
 

--- a/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/data/[id]/+page.svelte
@@ -203,6 +203,13 @@
 		const rasterInfo = await rasterTile.getMetadata(layerSpec.algorithmId);
 		const metadata = rasterInfo;
 
+		if (layerSpec.algorithm.outputs.unit) {
+			feature.properties.tags.push({
+				key: 'unit',
+				value: layerSpec.algorithm.outputs.unit
+			});
+		}
+
 		metadata.active_band_no = Object.keys(metadata.stats)[0];
 
 		// add layer to local storage


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
also, set unit in PropertyEditor for algorithm if available

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1356432250) by [Unito](https://www.unito.io)
