### PR TITLE
fix: add unit tag when RCA layer for stac is added

### DIFF
--- a/.changeset/long-teachers-grab.md
+++ b/.changeset/long-teachers-grab.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add unit tag when RCA layer for stac is added

--- a/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
@@ -141,13 +141,7 @@
 					value: selectedTool.algorithmId
 				}
 			];
-			// set unit if it is available in algorithm metadata
-			if (selectedTool.algorithm.outputs.unit) {
-				feature.properties.tags.push({
-					key: 'unit',
-					value: selectedTool.algorithm.outputs.unit
-				});
-			}
+
 			const rasterTile = new RasterTileData(feature);
 
 			// set colormap name if it is available in algorithm metadata
@@ -169,6 +163,14 @@
 					value: selectedTool.algorithmId
 				}
 			];
+
+			// set unit if it is available in algorithm metadata
+			if (selectedTool.algorithm.outputs.unit) {
+				feature.properties.tags.push({
+					key: 'unit',
+					value: selectedTool.algorithm.outputs.unit
+				});
+			}
 
 			data.geohubLayer = {
 				id: data.layer.id,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Previously, unit tag was overwritten and removed it.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1356455166) by [Unito](https://www.unito.io)
