### PR TITLE
fix: reset unapplied tag filter setting when the popup is closed.

### DIFF
--- a/.changeset/rude-knives-rhyme.md
+++ b/.changeset/rude-knives-rhyme.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: reset unapplied tag filter setting when the popup is closed.

--- a/sites/geohub/src/components/pages/data/datasets/TagFilter.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/TagFilter.svelte
@@ -43,6 +43,14 @@
 			if (show === true) {
 				// reload tags if tag panel is opened
 				updateTags();
+			} else {
+				TagSearchKeys.forEach((key) => {
+					currentUrl.searchParams.delete(key.key);
+				});
+				selectedTags = [];
+				query = '';
+				currentUrl = new URL(initialUrl);
+				filteredTags = getFilteredTag();
 			}
 		});
 	});


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
Please describe what you changed briefly.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1360212704) by [Unito](https://www.unito.io)
