### PR TITLE
fix: check whether assets are selected for all input bands when the date is changed from picker.

### DIFF
--- a/.changeset/healthy-geese-hunt.md
+++ b/.changeset/healthy-geese-hunt.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: check whether assets are selected for all input bands when the date is changed from picker.

--- a/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogTools.svelte
@@ -256,14 +256,20 @@
 					{#if Object.keys(selectedAssets).length > 0}
 						{@const isDuplicated = isAssetDuplicated()}
 						{@const isAllSelected =
-							selectedTool.algorithm.inputs.nbands === Object.keys(selectedAssets).length ||
-							selectedTool.algorithm.inputs.bands?.length === Object.keys(selectedAssets).length}
+							selectedTool.algorithm.inputs.nbands ===
+								Object.keys(selectedAssets).filter((key) => selectedAssets[key] !== undefined)
+									.length ||
+							selectedTool.algorithm.inputs.bands?.length ===
+								Object.keys(selectedAssets).filter((key) => selectedAssets[key] !== undefined)
+									.length}
 
-						{#if isDuplicated || errorMessage}
+						{#if isDuplicated || errorMessage || !isAllSelected}
 							<Notification type="danger" showCloseButton={false}>
 								{#if isDuplicated}
 									Same item was selected several times. Please assign different date and item each
 									input band.
+								{:else if !isAllSelected}
+									Please select an asset item for each input band.
 								{:else if errorMessage}
 									The server returned an error ({errorMessage}). Please try again later.
 								{/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
previously, when month is changed, the day is kept from the previous month's. and add button was not disabled.

Now it checks whether all assets for input bands are selected.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/64715ace-3b4f-46f1-a79a-c79f588ab46b)

![image](https://github.com/UNDP-Data/geohub/assets/2639701/a9f49e0b-490d-489d-8ea4-4423b7421bc5)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1361738675) by [Unito](https://www.unito.io)
