### PR TITLE
fix: adjust resource limits for ingesting and stac pipeline

### DIFF
--- a/backends/k8s/data-pipeline/yaml/ingest-environment.yaml
+++ b/backends/k8s/data-pipeline/yaml/ingest-environment.yaml
@@ -13,7 +13,7 @@ spec:
   jobTargetRef:
     parallelism: 1
     completions: 1
-    activeDeadlineSeconds: 600
+    activeDeadlineSeconds: 3600
     backoffLimit: 5
     template:
       spec:
@@ -23,6 +23,10 @@ spec:
           - name: ingest
             image: undpgeohub.azurecr.io/geohub-data-pipeline:v0.0.3
             imagePullPolicy: Always
+            resources:
+              limits:
+                memory: "10G"
+                cpu: "2000m"
             envFrom:
               - secretRef:
                   name: ingest-secrets

--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             args: ["-m", "undpstac_pipeline.cli", "queue", "--force"]
             resources:
               limits:
-                memory: "20G"
+                memory: "15G"
                 cpu: "2000m"
             envFrom:
               - secretRef:


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- changed activeDeadlineSeconds to 3600 (1 hours) for ingesting
- changed RAM limit to 10GB for ingesting (max 3 instance)
- changed RAM limit to 15GB for stac pipeline (max 1 instance)

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
