### PR TITLE
chore: add scaledjob triggered by cron

### DIFF
--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -27,8 +27,8 @@ spec:
             args: ["-m", "undpstac_pipeline.cli", "queue", "--force"]
             resources:
               limits:
-                memory: "12G"
-                cpu: "1000m"
+                memory: "10G"
+                cpu: "2000m"
             envFrom:
               - secretRef:
                   name: stac-secrets

--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -27,8 +27,8 @@ spec:
             args: ["-m", "undpstac_pipeline.cli", "queue", "--force"]
             resources:
               limits:
-                memory: "15G"
-                cpu: "2000m"
+                memory: "12G"
+                cpu: "1000m"
             envFrom:
               - secretRef:
                   name: stac-secrets
@@ -53,3 +53,48 @@ spec:
         messageCount: "1" # default 5, scale/spin a pod for every message
         activationMessageCount: "0" # default 0, ensure no pods exist if no messages exist in the queue
         connectionFromEnv: AZURE_SERVICE_BUS_CONNECTION_STRING
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: stac-scaled-cron-job
+  namespace: stac
+spec:
+  jobTargetRef:
+    parallelism: 1
+    completions: 1
+    activeDeadlineSeconds: 300
+    backoffLimit: 5
+    template:
+      spec:
+        nodeSelector:
+          type: "pipeline"
+        containers:
+          - name: stac
+            image: undpgeohub.azurecr.io/undp-data/geo-undpstac-pipeline:v0.0.4
+            imagePullPolicy: Always
+            command: ["python3"]
+            # register a message for yesterday into service bus queue
+            args:
+              ["-m", "queue_register.cli", "yesterday", "--type", "nighttime"]
+            resources:
+              limits:
+                memory: "1G"
+                cpu: "100m"
+            envFrom:
+              - secretRef:
+                  name: stac-secrets
+                  optional: false
+        restartPolicy: Never
+  pollingInterval: 600 # Optional. set 10 min for interval to ensure only a process is created
+  envSourceContainerName: stac # Optional. Default: .spec.JobTargetRef.template.spec.containers[0]
+  scalingStrategy:
+    strategy: default
+  triggers:
+    - type: cron
+      metadata:
+        # Required
+        timezone: UTC # The acceptable values would be a value from the IANA Time Zone Database.
+        start: 30 23 * * * # At 23:30 PM
+        end: 40 23 * * * # At 23:40 PM
+        desiredReplicas: "1"

--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -39,7 +39,7 @@ spec:
   failedJobsHistoryLimit: 0 # Optional. Default: 100. How many failed jobs should be kept.
   envSourceContainerName: stac # Optional. Default: .spec.JobTargetRef.template.spec.containers[0]
   minReplicaCount: 0 # Optional. Default: 0
-  maxReplicaCount: 1 # Optional. Default: 100
+  maxReplicaCount: 2 # Optional. Default: 100
   rollout:
     strategy: gradual # Optional. Default: default. Which Rollout Strategy KEDA will use.
     propagationPolicy: foreground # Optional. Default: background. Kubernetes propagation policy for cleaning up existing jobs during rollout.


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description


* added another scaled job to be triggered by cron
* trigger at 23:30pm to 23:40pm
* add new message for yesterday

adding yesterday's message may not work since most of data was created 2 to 3 days later. maybe adding 3 to 5 days days before is better??

https://eogdata.mines.edu/nighttime_light/nightly/rade9d_sunfiltered/?C=N;O=D

![image](https://github.com/UNDP-Data/geohub/assets/2639701/050e0c5a-05b1-4f09-8c25-7397eb357096)

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1364781110) by [Unito](https://www.unito.io)
