### PR TITLE
Max Replica to two pods for speeding up archiving

### DIFF
--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -39,7 +39,7 @@ spec:
   failedJobsHistoryLimit: 0 # Optional. Default: 100. How many failed jobs should be kept.
   envSourceContainerName: stac # Optional. Default: .spec.JobTargetRef.template.spec.containers[0]
   minReplicaCount: 0 # Optional. Default: 0
-  maxReplicaCount: 1 # Optional. Default: 100
+  maxReplicaCount: 2 # Optional. Default: 100
   rollout:
     strategy: gradual # Optional. Default: default. Which Rollout Strategy KEDA will use.
     propagationPolicy: foreground # Optional. Default: background. Kubernetes propagation policy for cleaning up existing jobs during rollout.


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

after archving historical data, can revert to one pod

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1368189859) by [Unito](https://www.unito.io)
