### PR TITLE
fix: import undp-bulma from jsdelivr CDN for storybook

### DIFF
--- a/packages/svelte-undp-components/.storybook/preview-head.html
+++ b/packages/svelte-undp-components/.storybook/preview-head.html
@@ -1,4 +1,7 @@
-<link rel="stylesheet" href="node_modules/@undp-data/undp-bulma/dist/style.css" />
+<link
+	rel="stylesheet"
+	href="https://cdn.jsdelivr.net/npm/@undp-data/undp-bulma@latest/dist/style.css"
+/>
 <script>
 	window.global = window;
 </script>

--- a/packages/svelte-undp-components/package.json
+++ b/packages/svelte-undp-components/package.json
@@ -61,7 +61,6 @@
 		"@types/eslint": "^8.56.0",
 		"@typescript-eslint/eslint-plugin": "^7.0.0",
 		"@typescript-eslint/parser": "^7.0.0",
-		"@undp-data/undp-bulma": "workspace:^",
 		"bulma-switch": "^2.0.4",
 		"eslint": "^8.56.0",
 		"eslint-config-prettier": "^9.1.0",

--- a/packages/svelte-undp-design/.storybook/preview-head.html
+++ b/packages/svelte-undp-design/.storybook/preview-head.html
@@ -1,4 +1,7 @@
-<link rel="stylesheet" href="node_modules/@undp-data/undp-bulma/dist/style.css" />
+<link
+	rel="stylesheet"
+	href="https://cdn.jsdelivr.net/npm/@undp-data/undp-bulma@latest/dist/style.css"
+/>
 <script>
 	window.global = window;
 </script>

--- a/packages/svelte-undp-design/package.json
+++ b/packages/svelte-undp-design/package.json
@@ -42,7 +42,6 @@
 		"@testing-library/user-event": "^14.5.1",
 		"@typescript-eslint/eslint-plugin": "7.9.0",
 		"@typescript-eslint/parser": "^7.0.0",
-		"@undp-data/undp-bulma": "workspace:^",
 		"@vitest/coverage-istanbul": "^1.1.0",
 		"eslint": "^8.56.0",
 		"eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,9 +570,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.0.0
         version: 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@undp-data/undp-bulma':
-        specifier: workspace:^
-        version: link:../undp-bulma
       bulma-switch:
         specifier: ^2.0.4
         version: 2.0.4
@@ -691,9 +688,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.0.0
         version: 7.8.0(eslint@8.57.0)(typescript@5.4.5)
-      '@undp-data/undp-bulma':
-        specifier: workspace:^
-        version: link:../undp-bulma
       '@vitest/coverage-istanbul':
         specifier: ^1.1.0
         version: 1.6.0(vitest@1.6.0(@types/node@20.12.11)(jsdom@24.0.0)(sass@1.77.1))


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
importing undp-bulma css from node_modules seems not working. I changed to import from jsdelivr.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1368268501) by [Unito](https://www.unito.io)
