### PR TITLE
fix: exclude dist folder under documentation for make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 	rm -rf `find . -type d -name build`
 	rm -rf `find . -type d -name coverage`
 	rm -rf `find . -type d -name .turbo`
-	rm -rf `find . -type d -name dist`
+	find . -type d -name dist ! -path "./documentation/*/dist" -exec rm -rf {} +
 	rm -rf `find . -type d -name package`
 
 install:


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3517

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1369105961) by [Unito](https://www.unito.io)
