### PR TITLE
fix: fixed bug of post method of /api/datasets endpoint to check if d…

### DIFF
--- a/.changeset/odd-bears-trade.md
+++ b/.changeset/odd-bears-trade.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of post method of /api/datasets endpoint to check if data is type=azure

--- a/sites/geohub/src/routes/api/datasets/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/+server.ts
@@ -314,10 +314,10 @@ export const POST: RequestHandler = async ({ fetch, locals, request }) => {
 	body.properties.url = decodeURI(body.properties.url);
 
 	await upsertDataset(body);
-
 	// if the dataset is under data-upload storage account, delete .ingesting file after registering metadata
+	const dataType = body.properties.tags?.find((t) => t.key === 'type')?.value ?? '';
 	const azaccount = env.AZURE_STORAGE_ACCOUNT_UPLOAD;
-	if (body.properties.url.indexOf(azaccount) > -1) {
+	if (dataType === 'azure' && body.properties.url.indexOf(azaccount) > -1) {
 		const ingestingFileUrl = `${body.properties.url.replace('pmtiles://', '')}.ingesting`;
 		const sasToken = await generateAzureBlobSasToken(ingestingFileUrl, 60000, 'rwd');
 		const ingestingUrlWithSasUrl = `${ingestingFileUrl}${sasToken}`;
@@ -332,7 +332,6 @@ export const POST: RequestHandler = async ({ fetch, locals, request }) => {
 			}
 		}
 	}
-
 	const dbm = new DatabaseManager();
 	let dataset: DatasetFeature;
 	try {

--- a/sites/geohub/src/routes/api/datasets/[id]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/+server.ts
@@ -105,7 +105,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 		await dsm.delete(client, dataset.properties.id);
 
 		const azaccount = env.AZURE_STORAGE_ACCOUNT_UPLOAD;
-		if (dataset.properties.url.indexOf(azaccount) > -1) {
+		const dataType = dataset.properties.tags?.find((t) => t.key === 'type')?.value ?? '';
+		if (dataType === 'azure' && dataset.properties.url.indexOf(azaccount) > -1) {
 			const blobServiceClient = getBlobServiceClient(
 				env.AZURE_STORAGE_ACCOUNT_UPLOAD,
 				env.AZURE_STORAGE_ACCESS_KEY_UPLOAD


### PR DESCRIPTION
…ata is type=azure

Thank you for submitting a pull request!

## Description
because pgtileserv url contains `undpgeohub` word, the endpoint was accessing azure blob storage and it caused an error after registration. I added to check type tag is `azure`

it is also related to #3537

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1371563713) by [Unito](https://www.unito.io)
