### PR TITLE
fix: removed icon-overlap property at static image api

### DIFF
--- a/sites/static-image-api/src/lib/server/renderMap.ts
+++ b/sites/static-image-api/src/lib/server/renderMap.ts
@@ -1,7 +1,7 @@
 import mbgl from '@maplibre/maplibre-gl-native';
 import sharp from 'sharp';
 import path from 'path';
-import { LayerSpecification, type StyleSpecification } from 'maplibre-gl';
+import { type StyleSpecification } from 'maplibre-gl';
 import { getSource } from './sources';
 
 export type extensionFormat = 'jpeg' | 'png' | 'webp';
@@ -81,7 +81,18 @@ export const renderMap = async (
 		},
 		ratio: ratio
 	});
+
+	// icon-overlap property is likely not supported by native, thus remove it from style
+	style.layers
+		.filter((l) => l.type === 'symbol')
+		.forEach((l) => {
+			if (l.layout && 'icon-overlap' in l.layout) {
+				delete l.layout['icon-overlap'];
+			}
+		});
+
 	map.load(style);
+
 	console.info(`renderMap: loaded style`);
 
 	const sharpOptions: sharp.CreateRaw = {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
This fix remove `icon-overlap` property from symbol layer since it is not supported by maplibre native. Partially fixes #3534

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1372558169) by [Unito](https://www.unito.io)
