### PR TITLE
fix: check changeset file in action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,26 @@ jobs:
             iferencik
             Thuhaa
             JinIgarashi
+      - name: Check existance of changeset file
+        id: check-changeset
+        run: |
+          if find .changeset -type f -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "::set-output name=comment::Changeset files found. Merge Version Package PR before merging this."
+          else
+            echo "::set-output name=comment::No changeset files found. Ready to merge to production."
+          fi
+      - name: Post comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = '${{ steps.check-changeset.outputs.comment }}'
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+            if (comment === 'Changeset files found. Merge Version Package PR before merging this.') {
+              throw new Error(comment)
+            }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
check changeset file in action to prevent merging develop to main before versioning.

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1373285875) by [Unito](https://www.unito.io)
