### PR TITLE
ci: add validated message in PR description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,14 @@ jobs:
         run: |
           git fetch origin develop:develop
           git reset --hard develop
+      - name: Check existance of changeset file
+        id: check-changeset
+        run: |
+          if find .changeset -type f -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "::set-output name=comment::Changeset files found. This PR cannot be merged. Please merge Version Package PR before merging this."
+          else
+            echo "::set-output name=comment::No changeset files found. It is ready to merge to production."
+          fi
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
@@ -82,6 +90,10 @@ jobs:
 
             This is going to merge develop branch to main branch to release to production server.
             You don't have to merge this PR now. You can merge this when it will be ready to merge for production.
+
+            ## Checked result
+
+            ${{ steps.check-changeset.outputs.comment }}
 
             ### Checklist before merging
                         
@@ -99,30 +111,10 @@ jobs:
             iferencik
             Thuhaa
             JinIgarashi
-      - name: Check existance of changeset file
-        id: check-changeset
+
+      - name: Throw error if changeset file exists at the end
         run: |
-          if find .changeset -type f -name '*.md' ! -name 'README.md' | grep -q .; then
-            echo "::set-output name=comment::Changeset files found. This PR cannot be merged. Please merge Version Package PR before merging this."
-          else
-            echo "::set-output name=comment::No changeset files found. It is ready to merge to production."
+          if echo "${{ steps.check-changeset.outputs.comment }}" | grep -q "Changeset files found."; then
+            echo "${{ steps.check-changeset.outputs.comment }}"
+            exit 1
           fi
-      - name: Post comment on PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const comment = `${{ steps.check-changeset.outputs.comment }}`
-            const params = {
-              pull_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            };
-            if (comment.indexOf("Changeset files found.") !== -1) {
-              params.event = 'REQUEST_CHANGES'
-              await github.rest.pulls.createReview(params);
-            } else {
-              params.event = 'APPROVE'
-              await github.rest.pulls.createReview(params);
-            }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
I found createReview action has never worked since the PR is created in the same action job. I included validated massage in description instead. then exit 1 if changeset file exists

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [ ] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [ ] Code is up-to-date with the `develop` branch
* [ ] No build errors after `pnpm build`
* [ ] No lint errors after `pnpm lint`
* [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1373304876) by [Unito](https://www.unito.io)
