### PR TITLE
fix: disable featurestate of admin tool for geohub main map page

### DIFF
--- a/.changeset/two-birds-guess.md
+++ b/.changeset/two-birds-guess.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: disable featurestate of admin tool for geohub main map page

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -303,7 +303,7 @@
 
 		const adminOptions = AdminControlOptions;
 		adminOptions.isHover = false;
-		$map.addControl(new MaplibreCgazAdminControl(AdminControlOptions), 'top-left');
+		$map.addControl(new MaplibreCgazAdminControl(adminOptions), 'top-left');
 
 		styleSwitcher = new MaplibreStyleSwitcherControl(MapStyles, {
 			defaultStyle: defaultStyle

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -301,6 +301,8 @@
 			$map.addControl(gc, 'top-left');
 		}
 
+		const adminOptions = AdminControlOptions;
+		adminOptions.isHover = false;
 		$map.addControl(new MaplibreCgazAdminControl(AdminControlOptions), 'top-left');
 
 		styleSwitcher = new MaplibreStyleSwitcherControl(MapStyles, {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
fixes #3584

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1376657086) by [Unito](https://www.unito.io)
