### PR TITLE
fix: fixed bug when a stac catalog hax mixed both collection and item

### DIFF
--- a/.changeset/cuddly-crabs-mate.md
+++ b/.changeset/cuddly-crabs-mate.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug when a stac catalog hax mixed both collection and item

--- a/sites/geohub/src/components/util/stac/StacCatalogExplorer.svelte
+++ b/sites/geohub/src/components/util/stac/StacCatalogExplorer.svelte
@@ -98,7 +98,9 @@
 						bind:dataset
 					/>
 				{:else if page.type === 'Item'}
-					{@const collectionUrls = StacBreadcrumbs.filter((x) => x.type === 'Collection')}
+					{@const collectionUrls = StacBreadcrumbs.filter((x) =>
+						['Collection', 'Item'].includes(x.type)
+					)}
 					{@const fistColleciton = collectionUrls[0].dataUrl}
 					<StacCatalogItem
 						bind:stacId={stac.id}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
stac catalog from HREA has mixed collections and item, this PR at least fixes a bug of this catalog

https://globalnightlight.s3.amazonaws.com/HREAv1.1_COGs/AGO/AGO/catalog.json

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1376819310) by [Unito](https://www.unito.io)
