### PR TITLE
fix: use default text-font if a symbol layer does not have default te…

### DIFF
--- a/.changeset/shy-plums-sparkle.md
+++ b/.changeset/shy-plums-sparkle.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use default text-font if a symbol layer does not have default text-font property

--- a/sites/geohub/src/lib/server/helpers/getStyleById.ts
+++ b/sites/geohub/src/lib/server/helpers/getStyleById.ts
@@ -23,6 +23,7 @@ import voyagerStyle from '@undp-data/style/dist/style.json';
 import darkStyle from '@undp-data/style/dist/dark.json';
 import positronStyle from '@undp-data/style/dist/positron.json';
 import aerialStyle from '@undp-data/style/dist/aerialstyle.json';
+import { DefaultUserConfig } from '$lib/config/DefaultUserConfig';
 
 export const getStyleById = async (id: number, url: URL, email?: string, is_superuser = false) => {
 	const dbm = new DatabaseManager();
@@ -192,6 +193,15 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 			}
 			style.style.layers = [...updatedLayers];
 		}
+
+		// if text-font is not set, use default font.
+		style.style.layers.forEach((l) => {
+			if (l.type === 'symbol') {
+				if (!l.layout['text-font']) {
+					l.layout['text-font'] = [DefaultUserConfig.LabelTextFont];
+				}
+			}
+		});
 
 		if (style.layers) {
 			const currentTime = new Date();


### PR DESCRIPTION
…xt-font property

Thank you for submitting a pull request!

## Description
fixes #3595

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1377695452) by [Unito](https://www.unito.io)
