### PR TITLE
fix: set default text-font if text-field property is used without tex…

### DIFF
--- a/.changeset/famous-adults-remain.md
+++ b/.changeset/famous-adults-remain.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: set default text-font if text-field property is used without text-font property

--- a/sites/geohub/src/lib/server/helpers/getStyleById.ts
+++ b/sites/geohub/src/lib/server/helpers/getStyleById.ts
@@ -197,7 +197,7 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 		// if text-font is not set, use default font.
 		style.style.layers.forEach((l) => {
 			if (l.type === 'symbol') {
-				if (!l.layout['text-font']) {
+				if (l.layout['text-field'] && !l.layout['text-font']) {
 					l.layout['text-font'] = [DefaultUserConfig.LabelTextFont];
 				}
 			}


### PR DESCRIPTION
…t-font property

Thank you for submitting a pull request!

## Description
check whether text-filed exists before adding default text-font property

### Type of Pull Request
<!-- ignore-task-list-start -->

* [ ] Adding a feature
* [x] Fixing a bug
* [ ] Maintaining documents
* [ ] Adding tests
* [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings
<!-- ignore-task-list-start -->

* [x] Code is up-to-date with the `develop` branch
* [x] No build errors after `pnpm build`
* [x] No lint errors after `pnpm lint`
* [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
* [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets


* [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1377724570) by [Unito](https://www.unito.io)
