### PR TITLE
 fix: update the number of selected items correctly in stac api explorer

### DIFF
--- a/.changeset/neat-jobs-brush.md
+++ b/.changeset/neat-jobs-brush.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: update the number of selected items correctly in stac api explorer

--- a/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
+++ b/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
@@ -256,6 +256,7 @@
 			if (index > -1) {
 				map.setFeatureState(feature, { click: false });
 				clickedFeatures.splice(index, 1);
+				clickedFeatures = [...clickedFeatures];
 			} else {
 				map.setFeatureState(feature, { click: true });
 				clickedFeatures = [...clickedFeatures, feature];


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #3618

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
