### PR TITLE
fix: force to transform user_email to lowercase in hooks.server.ts and UserPermission component

### DIFF
--- a/.changeset/shaggy-news-beam.md
+++ b/.changeset/shaggy-news-beam.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: force to transform user_email to lowercase in hooks.server.ts and UserPermission component

--- a/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/UserPermission.svelte
@@ -313,7 +313,7 @@ ${username}`;
 		try {
 			isUpadating = true;
 
-			const res = await api.add(user_email, user_permission);
+			const res = await api.add(user_email.toLowerCase(), user_permission);
 			if (res.ok) {
 				await getUserPermissions();
 				showAddDialog = false;
@@ -360,13 +360,14 @@ ${username}`;
 	};
 
 	const validateEmail = debounce((email: string) => {
+		email = email.toLowerCase();
 		if (!email) {
 			existUser = false;
 			isValidEmail = false;
 			return isValidEmail;
 		}
 		const validRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
-		existUser = permissions.find((p) => p.user_email === email) ? true : false;
+		existUser = permissions.find((p) => p.user_email.toLowerCase() === email) ? true : false;
 		isValidEmail = email.match(validRegex) ? (existUser ? false : true) : false;
 		return isValidEmail;
 	}, 300);
@@ -384,7 +385,11 @@ ${username}`;
 		const users: { id: string; user_email: string }[] = await res.json();
 		result = users
 			.filter((u) => {
-				return permissions.findIndex((p) => p.user_email === u.user_email) === -1;
+				return (
+					permissions.findIndex(
+						(p) => p.user_email.toLowerCase() === u.user_email.toLowerCase()
+					) === -1
+				);
 			})
 			.map((u) => u.user_email);
 		return result;
@@ -406,7 +411,7 @@ ${username}`;
 	};
 
 	const handleClickUseremail = (email: string) => {
-		user_email = email;
+		user_email = email.toLowerCase();
 		isValidEmail = validateEmail(user_email);
 		userList = [];
 		showUserList = false;

--- a/sites/geohub/src/hooks.server.ts
+++ b/sites/geohub/src/hooks.server.ts
@@ -81,7 +81,7 @@ const handleAccessToken = async ({ event, resolve }) => {
 							user: {
 								id: payload.id,
 								name: payload.name,
-								email: payload.email.toLowerCase()
+								email: payload.email
 							}
 						};
 					}

--- a/sites/geohub/src/hooks.server.ts
+++ b/sites/geohub/src/hooks.server.ts
@@ -81,7 +81,7 @@ const handleAccessToken = async ({ event, resolve }) => {
 							user: {
 								id: payload.id,
 								name: payload.name,
-								email: payload.email
+								email: payload.email.toLowerCase()
 							}
 						};
 					}

--- a/sites/geohub/src/lib/server/auth.ts
+++ b/sites/geohub/src/lib/server/auth.ts
@@ -78,6 +78,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 			}
 
 			if (session?.user?.email) {
+				session.user.email = session.user.email.toLowerCase();
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				session.user.id = generateHashKey(session.user.email);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

If signed user email address consists of mixed capitalized and lower case characters, and only lowercase email is added to permission table, they were considered as different email address.

To solve this issue, I made the following two changes:

- In hooks.server.ts, it will force to transform signed user email to lower case for all the time.
- In UserPermission component, validate user email after transforming to lower case, and register lower case email address even users input capitalized email. So, no capitalized email will be registered.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
