### PR TITLE
fix: add dynamic vector to tools

### DIFF
--- a/.changeset/two-feet-grin.md
+++ b/.changeset/two-feet-grin.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+feat: added links of Dynamic Vector Simulation datasets into Tools page

--- a/sites/geohub/src/routes/(app)/tools/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/tools/+page.server.ts
@@ -1,5 +1,5 @@
 import { ALGORITHM_TAG_KEY } from '$components/maplibre/raster/RasterAlgorithmExplorer.svelte';
-import type { Tag } from '$lib/types';
+import type { DatasetFeatureCollection, Tag } from '$lib/types';
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
@@ -19,12 +19,20 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	const filteredAlgos: { [key: string]: RasterAlgorithm } = {};
 
 	algoTags.forEach((tag) => {
+		if (Array.isArray(tag.value)) return;
 		if (!algorithms[tag.value]) return;
 		filteredAlgos[tag.value] = algorithms[tag.value];
 	});
 
+	// get dynamic similation datasets
+	const resDynamic = await fetch(
+		`/api/datasets?type=pgtileserv&layertype=function&query=dynamic&limit=999`
+	);
+	const dynamicDatasets: DatasetFeatureCollection = await resDynamic.json();
+
 	return {
-		algorithms: filteredAlgos
+		algorithms: filteredAlgos,
+		datasets: dynamicDatasets
 	};
 };
 

--- a/sites/geohub/src/routes/(app)/tools/+page.svelte
+++ b/sites/geohub/src/routes/(app)/tools/+page.svelte
@@ -407,6 +407,30 @@
 						{/each}
 					</div>
 
+					<h3 class="title is-3 mt-6">Simulation add-ons</h3>
+
+					<div class="columns is-multiline is-mobile">
+						{#each data.datasets.features as dataset}
+							{@const datasetUrl = dataset.properties.links.find((l) => l.rel === 'dataset')?.href}
+							{@const sdgs = dataset.properties.tags
+								.filter((t) => t.key === 'sdg_goal')
+								.map((t) => Number(t.value))
+								.sort((a, b) => a - b)
+								.map((v) => `SDG${v}`)}
+							{#if datasetUrl}
+								<div class="column is-one-third-tablet is-one-quarter-desktop is-full-mobile">
+									<Card
+										linkName="Explore Dataset"
+										tag="Simulation, {sdgs?.length > 0 ? sdgs.join(', ') : ''}"
+										title={dataset.properties.name}
+										description={dataset.properties.description}
+										url={datasetUrl}
+									/>
+								</div>
+							{/if}
+						{/each}
+					</div>
+
 					<h3 class="title is-3 mt-6">Terrain add-ons</h3>
 
 					<div class="columns is-multiline is-mobile">

--- a/sites/geohub/src/routes/(app)/tools/+page.svelte
+++ b/sites/geohub/src/routes/(app)/tools/+page.svelte
@@ -421,7 +421,7 @@
 								<div class="column is-one-third-tablet is-one-quarter-desktop is-full-mobile">
 									<Card
 										linkName="Explore Dataset"
-										tag="Simulation, {sdgs?.length > 0 ? sdgs.join(', ') : ''}"
+										tag={sdgs?.length > 0 ? sdgs.join(', ') : 'Simulation'}
 										title={dataset.properties.name}
 										description={dataset.properties.description}
 										url={datasetUrl}

--- a/sites/geohub/src/routes/(app)/tools/+page.ts
+++ b/sites/geohub/src/routes/(app)/tools/+page.ts
@@ -1,13 +1,14 @@
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ data }) => {
-	const { algorithms } = data;
+	const { algorithms, datasets } = data;
 	const title = 'Tools | GeoHub';
 	const content = 'Tools';
 
 	return {
 		title,
 		content,
-		algorithms
+		algorithms,
+		datasets
 	};
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I think vector simulation datasets are also an important tool in GeoHub. Hence, I added these links to tools page as `Simulation add-ons` section.

If click a card, it will be redirected to the dataset page.

![image](https://github.com/UNDP-Data/geohub/assets/2639701/c8a5ae0e-0e3f-4abc-ad03-5ed7426512d6)


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
