### PR TITLE
fix: redeploy produciton docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,26 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  deploy:
+    name: Redeploy production docker image
+    runs-on: ubuntu-latest
+    needs: build-docker
+    if: ${{ github.ref == 'refs/heads/main' }}
+    env:
+      AZURE_WEBAPP_NAME: geohub-prod
+      TAG_NAME: main
+    environment:
+      name: production
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+    steps:
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@85270a1854658d167ab239bce43949edb336fa7c
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          images: "${{ env.ACR_ENDPOINT }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}"
+
   build-and-deploy-undp-design:
     name: Build and deploy svelte UNDP design storybook
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
     env:
       AZURE_WEBAPP_NAME: geohub-prod
       TAG_NAME: main
+      IMAGE_NAME: undp-data/geohub
     environment:
       name: production
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I am not sure why only geohub-prod appservice does not redeploy docker image while other appservices will redeploy automatically when new docker image is pushed.

I added the deployment job into CI to force redeploying production image.
https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-azure/deploying-docker-to-azure-app-service

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
