### PR TITLE
fix: disabled hovered feature state for dashboard

### DIFF
--- a/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
@@ -110,7 +110,7 @@
 			styleSwitcher.initialise();
 
 			const adminOptions = AdminControlOptions;
-			adminOptions.isHover = true;
+			adminOptions.isHover = false;
 			map.addControl(new MaplibreCgazAdminControl(AdminControlOptions), 'top-left');
 		});
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

disable hovered feature state for admin tool since the geometry is different from electricity data's admin

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
