### PR TITLE
fix: changed top-left controls order. show timeslider control first

### DIFF
--- a/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
@@ -71,6 +71,8 @@
 	let colormapName = 'pubu';
 	let scaleColorList: string[] = [];
 
+	let isTimeSliderActive = false;
+
 	onMount(() => {
 		const promises = loadDatasets();
 		promises.hrea.then((datasets) => {
@@ -234,12 +236,17 @@
 		dashboardSelections.forEach((dbs) => (dbs.show = false));
 		dashboardSelections[index].show = !dashboardSelections[index].show;
 		activeDashboard = dashboardSelections.find((d) => d.show === true);
+		isTimeSliderActive = setTimeSliderActive();
 		if (dashboardSelections[index].name === 'compare') {
 			electricitySelected = electricityChoices[0].name;
 			unloadAdmin();
 		} else {
 			electricitySelected = NONE_ID;
 		}
+	};
+
+	const setTimeSliderActive = () => {
+		return activeDashboard?.name !== 'analyse';
 	};
 
 	const dropdownHandler = (index: number) => {
@@ -273,6 +280,7 @@
 				on:click={() => {
 					showIntro = false;
 					activeDashboard = dashboardSelections.find((d) => d.show === true);
+					isTimeSliderActive = setTimeSliderActive();
 				}}
 			/>
 		{:else}
@@ -321,15 +329,14 @@
 	<div slot="main">
 		<div class="map" id="map" bind:this={mapContainer}>
 			{#if map}
-				{#if activeDashboard && activeDashboard.name !== 'analyse'}
-					<TimeSliderControl
-						bind:map
-						bind:electricitySelected
-						bind:loadRasterLayer
-						bind:scaleColorList
-						bind:rasterColorMapName={colormapName}
-					/>
-				{/if}
+				<TimeSliderControl
+					bind:map
+					bind:electricitySelected
+					bind:loadRasterLayer
+					bind:scaleColorList
+					bind:rasterColorMapName={colormapName}
+					bind:isActive={isTimeSliderActive}
+				/>
 			{/if}
 		</div>
 	</div>

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
@@ -10,6 +10,7 @@
 	export let scaleColorList = [];
 	export let rasterColorMapName = '';
 	export let electricitySelected: string;
+	export let isActive = false;
 
 	import { getBase64EncodedUrl } from '$lib/helper';
 	import { Slider } from '@undp-data/svelte-undp-components';
@@ -27,6 +28,7 @@
 	$: rasterColorMapName, loadLayer();
 
 	const setSlider = () => {
+		if (!isActive) return;
 		switch (electricitySelected) {
 			case 'HREA':
 				minValue = 2012;
@@ -63,6 +65,7 @@
 
 	export function loadLayer() {
 		if (!$map) return;
+		if (!isActive) return;
 		const yearValue = rangeSliderValues[0];
 		setTargetTear(yearValue);
 		let url = electricitySelected === 'HREA' ? getHreaUrl(yearValue) : getMlUrl(yearValue);
@@ -80,6 +83,7 @@
 
 	const loadRasterLayer = async (url: string) => {
 		if (!$map) return;
+		if (!url) return;
 		const res = await fetch(`${titilerUrl}/info?url=${url}`);
 		const layerInfo = await res.json();
 		if (!(layerInfo && layerInfo['band_metadata'])) {

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSliderControl.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSliderControl.svelte
@@ -49,6 +49,7 @@
 	export let loadRasterLayer;
 	export let rasterColorMapName = '';
 	export let electricitySelected: string;
+	export let isActive = false;
 
 	let controlElement: HTMLDivElement;
 
@@ -67,11 +68,21 @@
 	});
 </script>
 
-<div class="time-slider-control" bind:this={controlElement}>
+<div class="time-slider-control {isActive ? 'is-active' : ''}" bind:this={controlElement}>
 	<TimeSlider
 		bind:electricitySelected
 		bind:loadLayer={loadRasterLayer}
 		bind:scaleColorList
 		bind:rasterColorMapName
+		bind:isActive
 	/>
 </div>
+
+<style lang="scss">
+	.time-slider-control {
+		display: none;
+		&.is-active {
+			display: block;
+		}
+	}
+</style>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Controlling the order of Maplibre Control in svelte component is not straightforward. I added isActive prop in the time slider control to switch visibility of the slider.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
