### PR TITLE
chore: upgraded pg_tileserv docker to 20240614

### DIFF
--- a/backends/k8s/pgtileserv/yaml/pgtileserv-deployment.yaml
+++ b/backends/k8s/pgtileserv/yaml/pgtileserv-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         type: "auto"
       containers:
         - name: pgtileserv
-          image: pramsey/pg_tileserv:20231005
+          image: pramsey/pg_tileserv:20240614
           resources:
             limits:
               memory: "2048Mi"


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I realized docker image for k8s has no longer upgraded while docker image in docker-compose.yml was upgraded by renovate

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
