### PR TITLE
fix: set black color of border for bulma select to align with UNDP design.

### DIFF
--- a/.changeset/strong-kangaroos-trade.md
+++ b/.changeset/strong-kangaroos-trade.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/undp-bulma": patch
+---
+
+fix: set black color of border for bulma select to align with UNDP design.

--- a/packages/undp-bulma/bulma.scss
+++ b/packages/undp-bulma/bulma.scss
@@ -138,6 +138,10 @@ $black: #000;
   }
 }
 
+.select select {
+  border-color: $black !important;
+}
+
 // load SohneBreit font
 @font-face {
   font-display: swap;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

realized select box needs color to be black in UNDP design.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
