### PR TITLE
fix: add data from 2021 to 2030 to line charts on dashboard

### DIFF
--- a/.changeset/calm-snails-dream.md
+++ b/.changeset/calm-snails-dream.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add data from 2021 to 2030 to line charts on dashboard

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/Charts.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/Charts.svelte
@@ -5,6 +5,7 @@
 	import '@carbon/charts-svelte/styles.css';
 	import { type SegmentButton } from '@undp-data/svelte-undp-components';
 	import { format } from 'd3-format';
+	import { HREA_MAX_YEAR, HREA_MIN_YEAR } from '../constansts';
 	import { admin, hrea, map } from '../stores';
 
 	const titilerUrl = $page.data.titilerUrl;
@@ -13,7 +14,7 @@
 	const HOVER = 'hover';
 	const CLICK = 'click';
 
-	const HREA_NODATA = -3.3999999521443642e38;
+	const HREA_NODATA = 254;
 
 	const carbonChartOptions = {
 		title: '',
@@ -28,7 +29,13 @@
 				title: 'Electrification',
 				scaleType: 'linear',
 				ticks: {
-					formatter: (e) => `${e * 100}%`
+					formatter: (e) => {
+						let value = e;
+						if (value <= 1) {
+							value = e * 100;
+						}
+						return `${value}%`;
+					}
 				}
 			}
 		},
@@ -95,7 +102,7 @@
 		controller.abort();
 		controller = new AbortController();
 		for (const [name, getDataURL, noData, ignoreValue, total] of options) {
-			for (let x = 2012; x <= 2020; x++) {
+			for (let x = HREA_MIN_YEAR; x <= HREA_MAX_YEAR; x++) {
 				if (!ignoreValue.includes(x)) {
 					const url = `${titilerUrl}/point/${lng},${lat}?url=${getDataURL(x)}&unscale=true`;
 					fetch(url, { signal: controller.signal })
@@ -148,7 +155,7 @@
 			.join(', ');
 		adminBarValues = [];
 		carbonChartData = [];
-		for (let i = 2020; i >= 2012; i--) {
+		for (let i = HREA_MAX_YEAR; i >= HREA_MIN_YEAR; i--) {
 			adminBarValues = [
 				...adminBarValues,
 				{ year: i, value: $admin[`hrea_${i}`], category: HREA_ID }

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
@@ -16,13 +16,14 @@
 
 	import { getBase64EncodedUrl } from '$lib/helper';
 	import { Slider } from '@undp-data/svelte-undp-components';
+	import { HREA_MAX_YEAR, HREA_MIN_YEAR } from '../constansts';
 	const UNDP_DASHBOARD_RASTER_LAYER_ID = 'dashboard-electricity-raster-layer';
 	const UNDP_DASHBOARD_RASTER_SOURCE_ID = 'dashboard-electricity-raster-source';
 
 	const titilerUrl = $page.data.titilerUrl;
 
-	let minValue = 2012;
-	let maxValue = 2030;
+	let minValue = HREA_MIN_YEAR;
+	let maxValue = HREA_MAX_YEAR;
 	let rangeSliderValues = [2020];
 
 	$: electricitySelected, loadLayer();

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/constansts.ts
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/constansts.ts
@@ -83,3 +83,6 @@ export const ELECTRICITY_DATASETS: { [key: string]: DashBoardDataset[] } = {
 		}
 	]
 };
+
+export const HREA_MAX_YEAR = 2030;
+export const HREA_MIN_YEAR = 2012;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

realized line chart does not include forecast data

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
