### PR TITLE
fix: fixed size of preview map in sidebar of storymap editor.

### DIFF
--- a/.changeset/fresh-wombats-attack.md
+++ b/.changeset/fresh-wombats-attack.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed size of preview map in sidebar of storymap editor.

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
@@ -77,7 +77,7 @@
 	.preview {
 		position: relative;
 		width: 100%;
-		height: 100px;
+		height: 128px;
 
 		&.is-active {
 			border: 2px solid #4f95dd;

--- a/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
@@ -187,7 +187,7 @@
 	</div>
 
 	<div class="chapters-editor is-flex" style="height: {editorContentHeight}px;">
-		<div class="sidebar pr-2" bind:clientWidth={sidebarWidth}>
+		<div class="sidebar" bind:clientWidth={sidebarWidth}>
 			<div
 				class="chapters is-flex is-flex-direction-column"
 				style="height: {slidePreviewHeight}px;"
@@ -276,9 +276,8 @@
 			border-top: 1px solid #d4d6d8;
 
 			.sidebar {
-				min-width: 200px;
-
 				.chapters {
+					width: 264px;
 					overflow-y: auto;
 					overflow-x: hidden;
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixed size of preview map to 216x128px

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
