### PR TITLE
fix: show geohub map id in map selector if it is selected already

### DIFF
--- a/.changeset/modern-pans-shout.md
+++ b/.changeset/modern-pans-shout.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show geohub map id in map selector if it is selected already

--- a/sites/geohub/src/components/pages/storymap/StorymapStyleSelector.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapStyleSelector.svelte
@@ -35,13 +35,12 @@
 
 	let showMapDialog = false;
 
-	let mapStyleId = '';
+	$: mapStyleId = mapConfig?.style_id ?? '';
 
 	const handleBaseStyleChanged = (e: { title: string; uri: string }) => {
 		mapConfig.base_style_id = e.title;
 		mapConfig.style = new URL(e.uri, $page.url).href;
 		mapConfig.style_id = undefined;
-
 		dispatch('change', mapConfig);
 	};
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
