### PR TITLE
fix: changed docker-compose to docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,28 +40,28 @@ docker-build:
 	@echo "------------------------------------------------------------------"
 	@echo "Building dev Docker image"
 	@echo "------------------------------------------------------------------"
-	docker-compose -f docker/docker-compose.yml build
+	docker compose -f docker/docker-compose.yml build
 
 docker-up:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Running in dev mode"
 	@echo "------------------------------------------------------------------"
-	docker-compose -f docker/docker-compose.yml up
+	docker compose -f docker/docker-compose.yml up
 
 docker-down:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Destroy docker containers"
 	@echo "------------------------------------------------------------------"
-	docker-compose -f docker/docker-compose.yml down
+	docker compose -f docker/docker-compose.yml down
 
 shell:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Shelling in dev mode"
 	@echo "------------------------------------------------------------------"
-	docker-compose -f docker/docker-compose.yml exec geohub /bin/bash
+	docker compose -f docker/docker-compose.yml exec geohub /bin/bash
 
 docker-prod: docker-prod-build docke-prod-run
 	


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

after my docker was updated in Mac, `docker-compose` is never found in my local. changed to `docker compose`

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
