### PR TITLE
fix: switch maplibre map object to use static api for preview.

### DIFF
--- a/.changeset/twelve-tips-obey.md
+++ b/.changeset/twelve-tips-obey.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: switch maplibre map object to use static api for preview.

--- a/sites/geohub/src/components/pages/storymap/StorymapStyleSelector.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapStyleSelector.svelte
@@ -77,15 +77,6 @@
 	</div>
 </FieldControl>
 
-<!-- <Tabs
-	bind:tabs
-	bind:activeTab
-	isBoxed={false}
-	isCentered={false}
-	isUppercase={true}
-	fontWeight="semibold"
-/> -->
-
 <FieldControl
 	title={activeTab === 'base_style_id' ? 'Choose map style' : 'Choose a map from GeoHub'}
 	showHelp={false}

--- a/sites/geohub/src/lib/helper/getMapImageFromStyle.ts
+++ b/sites/geohub/src/lib/helper/getMapImageFromStyle.ts
@@ -1,0 +1,29 @@
+import type { StyleSpecification } from 'maplibre-gl';
+
+export const getMapImageFromStyle = async (
+	style: StyleSpecification,
+	width: number,
+	height: number,
+	staticApiUrl: string
+) => {
+	const staticApi = `${staticApiUrl}/style/static/auto/${width}x${height}.webp`;
+	const res = await fetch(staticApi, { method: 'POST', body: JSON.stringify(style) });
+	if (!res.ok) {
+		return '';
+	}
+	const blob = await res.blob();
+	const arrayBuffer = await blob.arrayBuffer();
+	const base64String = arrayBufferToBase64(arrayBuffer);
+	const dataUrl = `data:${blob.type};base64,${base64String}`;
+	return dataUrl;
+};
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+	let binary = '';
+	const bytes = new Uint8Array(buffer);
+	const len = bytes.byteLength;
+	for (let i = 0; i < len; i++) {
+		binary += String.fromCharCode(bytes[i]);
+	}
+	return btoa(binary);
+};

--- a/sites/geohub/src/lib/helper/index.ts
+++ b/sites/geohub/src/lib/helper/index.ts
@@ -15,6 +15,7 @@ export * from './getLayerProperties';
 export * from './getLayerStyle';
 export * from './getLayerSourceUrl';
 export * from './getLineWidth';
+export * from './getMapImageFromStyle';
 export * from './getPropertyValueFromExpression';
 export * from './getSampleFromInterval';
 export * from './getSpriteImageIist';


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

because there are so many maplibre objects in side bar, performance had a problem. I switched to use static image api to get preview image by using post method.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
