### PR TITLE
fix: use h5 of undp-bulma for ModalTemplate title

### DIFF
--- a/.changeset/cyan-carrots-smoke.md
+++ b/.changeset/cyan-carrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: use h5 of undp-bulma for ModalTemplate title

--- a/packages/svelte-undp-components/src/lib/components/ModalTemplate.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ModalTemplate.svelte
@@ -37,7 +37,7 @@
 			{#if showClose}
 				<button class="delete is-large" aria-label="close" title="Close" on:click={close} />
 			{/if}
-			<p class="title is-5">{title}</p>
+			<h5 class="title is-5">{title}</h5>
 
 			<slot name="content" />
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #3842

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
