### PR TITLE
refactor: Use map context api instead of global store variable

### DIFF
--- a/sites/geohub/src/routes/(map)/dashboards/ceei/+page.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/ceei/+page.svelte
@@ -2,7 +2,12 @@
 	import DropdownSearch from './components/DropdownSearch.svelte';
 
 	import { MapStyles } from '$lib/config/AppConfig';
-	import { HEADER_HEIGHT_CONTEXT_KEY, type HeaderHeightStore } from '$stores';
+	import {
+		createMapStore,
+		HEADER_HEIGHT_CONTEXT_KEY,
+		MAPSTORE_CONTEXT_KEY,
+		type HeaderHeightStore
+	} from '$stores';
 	import { bbox } from '@turf/turf';
 	import '@undp-data/cgaz-admin-tool/dist/maplibre-cgaz-admin-control.css';
 	import MaplibreStyleSwitcherControl from '@undp-data/style-switcher';
@@ -13,29 +18,24 @@
 	import type { FeatureCollection } from 'geojson';
 	import { uniq } from 'lodash-es';
 	import {
+		addProtocol,
 		AttributionControl,
 		GeolocateControl,
 		Map,
 		NavigationControl,
 		Popup,
 		ScaleControl,
-		addProtocol,
 		type LngLatBoundsLike
 	} from 'maplibre-gl';
 	import 'maplibre-gl/dist/maplibre-gl.css';
 	import pako from 'pako';
 	import * as pmtiles from 'pmtiles';
-	import { getContext, onMount } from 'svelte';
+	import { getContext, onMount, setContext } from 'svelte';
 	import * as topojson from 'topojson-client';
 	import { read, utils } from 'xlsx';
 	import type { PageData } from './$types';
 	import LayerControl from './components/LayerControl.svelte';
-	import {
-		layers as layerStore,
-		map as mapStore,
-		mapPopup as popupStore,
-		type Layer
-	} from './stores';
+	import { layers as layerStore, mapPopup as popupStore, type Layer } from './stores';
 	import { computeCEEI, headerMapping, loadInitial } from './utils/layerHelper';
 
 	export let data: PageData;
@@ -52,6 +52,8 @@
 	let selectedCountryFilter = null;
 
 	const headerHeightStore: HeaderHeightStore = getContext(HEADER_HEIGHT_CONTEXT_KEY);
+	const mapStore = createMapStore();
+	setContext(MAPSTORE_CONTEXT_KEY, mapStore);
 
 	const loadDatasets = async (): Promise<Layer> => {
 		const ceeiTopojsonGzipUrl = `${data.azureUrl}/ceei/ceei.topojson.gz`;
@@ -229,7 +231,7 @@
 					};
 					waiting();
 				});
-				loadInitial(initialLayer);
+				loadInitial(map, initialLayer);
 			});
 		});
 

--- a/sites/geohub/src/routes/(map)/dashboards/ceei/components/LayerControl.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/ceei/components/LayerControl.svelte
@@ -2,13 +2,16 @@
 	import {
 		ColorMapPicker,
 		ModalTemplate,
+		handleEnterKey,
 		initTippy,
 		initTooltipTippy
 	} from '@undp-data/svelte-undp-components';
 	import { Button, Loader, TextInput } from '@undp-data/svelte-undp-design';
 
+	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import { Slider } from '@undp-data/svelte-undp-components';
 	import chroma from 'chroma-js';
+	import { getContext } from 'svelte';
 	import type { Layer } from '../stores';
 	import {
 		applyDataSimulation,
@@ -20,6 +23,8 @@
 		updatePaintOfLayer,
 		uploadData
 	} from '../utils/layerHelper';
+
+	const mapStore: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	export let layerDetails: Layer;
 	export let index: number;
@@ -195,7 +200,7 @@
 			return slider;
 		});
 
-		applyDataSimulation(index, null, null);
+		applyDataSimulation($mapStore, index, null, null);
 		calculatePillarTotal();
 
 		pillarSliders = pillarSliders.map((slider) => {
@@ -297,7 +302,7 @@
 			multiplierMap[slider.label] = multiplier;
 		});
 
-		applyDataSimulation(index, sliders, multiplierMap);
+		applyDataSimulation($mapStore, index, sliders, multiplierMap);
 	};
 
 	const handleClicked = (callback: (index?: number) => unknown, index?: number) => () => {
@@ -331,7 +336,9 @@
 			<button
 				class="button menu-button px-0 py-0 is-flex is-align-items-center is-justify-content-center"
 				class:disabled={!layerDetails.isDataLoaded}
-				on:click={handleClicked(toggleLayerVisibility, index)}
+				on:click={() => {
+					toggleLayerVisibility($mapStore, index);
+				}}
 				use:tippy={{ content: tooltipContent }}
 				use:tippyTooltip={{ content: 'Change the layer visibility' }}
 			>
@@ -355,8 +362,8 @@
 						<a
 							role="button"
 							tabindex="0"
-							on:click={handleClicked(openEditLayerNameModal)}
-							on:keydown={handleKeydown(openEditLayerNameModal)}
+							on:click={openEditLayerNameModal}
+							on:keydown={handleEnterKey}
 							class="dropdown-item is-flex is-gap-2 is-align-items-center"
 							class:disabled={!layerDetails.isDataLoaded}
 						>
@@ -370,8 +377,10 @@
 						<a
 							role="button"
 							tabindex="0"
-							on:click={handleClicked(duplicateLayer, index)}
-							on:keydown={handleKeydown(duplicateLayer, index)}
+							on:click={() => {
+								duplicateLayer($mapStore, index);
+							}}
+							on:keydown={handleEnterKey}
 							class="dropdown-item is-flex is-gap-2 is-align-items-center"
 							class:disabled={!layerDetails.isDataLoaded}
 						>
@@ -402,8 +411,10 @@
 								role="button"
 								tabindex="0"
 								class="dropdown-item is-flex is-gap-2 is-align-items-center"
-								on:click={handleClicked(deleteLayer, index)}
-								on:keydown={handleKeydown(deleteLayer, index)}
+								on:click={() => {
+									deleteLayer($mapStore, index);
+								}}
+								on:keydown={handleEnterKey}
 								class:disabled={!layerDetails.isDataLoaded}
 							>
 								<i class="fa-solid fa-trash"></i>
@@ -713,7 +724,7 @@
 				title={layerDetails.isDataLoaded ? 'Download' : 'NOT READY FOR DOWNLOAD'}
 				isPrimary={false}
 				isDisabled={!layerDetails.isDataLoaded}
-				on:clicked={() => downloadData(index)}
+				on:clicked={() => downloadData($mapStore, index)}
 			></Button>
 		</div>
 		<div class="is-background-light p-4 is-flex is-flex-direction-column is-gap-1">
@@ -722,7 +733,7 @@
 				title="Upload"
 				isPrimary={false}
 				isDisabled={!layerDetails.isDataLoaded}
-				on:clicked={() => uploadData(index)}
+				on:clicked={() => uploadData($mapStore, index)}
 			></Button>
 			{#if !layerDetails.isDataLoaded}
 				<div class="is-flex is-justify-content-center is-align-items-center">
@@ -762,7 +773,7 @@
 			title="Save"
 			isPrimary={false}
 			on:clicked={() => {
-				updatePaintOfLayer(index, colorMapName);
+				updatePaintOfLayer($mapStore, index, colorMapName);
 				closeEditColorScaleModel();
 			}}
 		></Button>

--- a/sites/geohub/src/routes/(map)/dashboards/ceei/stores/index.ts
+++ b/sites/geohub/src/routes/(map)/dashboards/ceei/stores/index.ts
@@ -7,8 +7,6 @@ import type {
 } from 'maplibre-gl';
 import { writable } from 'svelte/store';
 
-// map store for maplibre-gl object
-export const map = writable<Map>(undefined);
 export const mapPopup = writable<Popup>(undefined);
 
 export interface Layer {
@@ -20,7 +18,7 @@ export interface Layer {
 	bounds: LngLatBoundsLike;
 	data: object[];
 	sliders?;
-	muliplierMap?;
+	muliplierMap?: Map;
 	isVisible: boolean;
 	isMapLoaded: boolean;
 	isDataLoaded: boolean;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

global store variable is not safe, switched to use context api for map object.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
