### PR TITLE
fix: changed Card tab design of storymap editor

### DIFF
--- a/.changeset/olive-ways-try.md
+++ b/.changeset/olive-ways-try.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: changed Card tab design of storymap editor

--- a/sites/geohub/src/components/pages/storymap/ImageUploader.svelte
+++ b/sites/geohub/src/components/pages/storymap/ImageUploader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Dropzone from '@undp-data/svelte-file-dropzone';
-	import { initTooltipTippy } from '@undp-data/svelte-undp-components';
+	import { FieldControl, initTooltipTippy } from '@undp-data/svelte-undp-components';
 	import { createEventDispatcher } from 'svelte';
 
 	const dispatch = createEventDispatcher();
@@ -47,17 +47,23 @@
 			/>
 		</div>
 	{:else}
-		<Dropzone
-			accept={acceptedExts.join(',')}
-			noClick={false}
-			multiple={false}
-			inputElement={undefined}
-			on:drop={async (e) => await handleFileSelect(e)}
-		>
-			<div style="display: flex; justify-content: center; align-items: center; height: 100%">
-				<p>Drag & drop or select a file here</p>
-			</div>
-		</Dropzone>
+		<div class="dropzone">
+			<FieldControl title="Upload an image" showHelp={false}>
+				<div slot="control">
+					<Dropzone
+						accept={acceptedExts.join(',')}
+						noClick={false}
+						multiple={false}
+						inputElement={undefined}
+						on:drop={async (e) => await handleFileSelect(e)}
+					>
+						<div style="display: flex; justify-content: center; align-items: center; height: 100%">
+							<p>Drag & drop or select a file here</p>
+						</div>
+					</Dropzone>
+				</div>
+			</FieldControl>
+		</div>
 	{/if}
 </div>
 
@@ -75,5 +81,9 @@
 			top: 3px;
 			right: 3px;
 		}
+	}
+
+	.dropzone {
+		width: 100%;
 	}
 </style>

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
@@ -164,40 +164,43 @@
 						<div slot="content">
 							<ImageUploader bind:dataUrl={chapter.image} on:change={handleChange} />
 						</div>
-						<div slot="buttons">
-							<Help>Upload an image for the slide</Help>
-						</div>
 					</Accordion>
 					<Accordion title="Card Alignment" bind:isExpanded={expanded['alignment']}>
 						<div slot="content">
-							<SegmentButtons
-								size="small"
-								capitalized={true}
-								fontWeight="semibold"
-								buttons={[
-									{ title: 'left', value: 'left', icon: 'fa-solid fa-align-left' },
-									{ title: 'center', value: 'center', icon: 'fa-solid fa-align-center' },
-									{ title: 'right', value: 'right', icon: 'fa-solid fa-align-right' },
-									{ title: 'full', value: 'full', icon: 'fa-solid fa-arrows-left-right-to-line' }
-								]}
-								bind:selected={chapter.alignment}
-								on:change={handleChange}
-							/>
+							<FieldControl title="Choose card alignment" showHelp={false}>
+								<div slot="control">
+									<SegmentButtons
+										size="normal"
+										capitalized={true}
+										fontWeight="semibold"
+										buttons={[
+											{ title: 'left', value: 'left', icon: 'fa-solid fa-align-left' },
+											{ title: 'center', value: 'center', icon: 'fa-solid fa-align-center' },
+											{ title: 'right', value: 'right', icon: 'fa-solid fa-align-right' }
+											// { title: 'full', value: 'full', icon: 'fa-solid fa-arrows-left-right-to-line' }
+										]}
+										bind:selected={chapter.alignment}
+										on:change={handleChange}
+									/>
+								</div>
+							</FieldControl>
 						</div>
 						<div slot="buttons">
 							<Help>Defines where the story text should appear over the map.</Help>
 						</div>
 					</Accordion>
 
-					<Accordion title="Card hidden" bind:isExpanded={expanded['cardHidden']}>
+					<Accordion title="Card visibility" bind:isExpanded={expanded['cardHidden']}>
 						<div slot="content">
-							<Switch
-								bind:toggled={chapter.cardHidden}
-								on:change={handleChange}
-								showValue={true}
-								toggledText="Hide card content"
-								untoggledText="Show card content"
-							/>
+							<FieldControl title="Hide card content" showHelp={false}>
+								<div slot="control">
+									<Switch
+										bind:toggled={chapter.cardHidden}
+										on:change={handleChange}
+										showValue={false}
+									/>
+								</div>
+							</FieldControl>
 						</div>
 						<div slot="buttons">
 							<Help>

--- a/sites/geohub/src/components/pages/storymap/StorymapHeaderEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapHeaderEdit.svelte
@@ -127,7 +127,7 @@
 									{/if}
 								</div>
 							</FieldControl>
-							<FieldControl title="Subtitle" showHelp={true} showHelpPopup={false}>
+							<FieldControl title="Subtitle" showHelp={false} showHelpPopup={false}>
 								<div slot="control">
 									<textarea
 										class="textarea"
@@ -136,12 +136,8 @@
 										placeholder="Input subtitle..."
 									></textarea>
 								</div>
-								<div slot="help">
-									Please provide subtitle to support the title of your storymap. This is also shown
-									as description at your storymap page. This is an optional setting.
-								</div>
 							</FieldControl>
-							<FieldControl title="Supporting information" showHelp={true} showHelpPopup={false}>
+							<FieldControl title="Note" showHelp={true} showHelpPopup={false}>
 								<div slot="control">
 									<input
 										class="input"
@@ -151,8 +147,7 @@
 									/>
 								</div>
 								<div slot="help">
-									Any additional supporting information, which is author name, published date or any
-									other, can be inputted here. This is an optional setting.
+									Any additional supporting information such as author name, published date, etc.
 								</div>
 							</FieldControl>
 						</div>
@@ -160,7 +155,7 @@
 							<Help>Type the slide title and subtitle of the story</Help>
 						</div>
 					</Accordion>
-					<Accordion title="Logo image" bind:isExpanded={expanded['image']}>
+					<Accordion title="Logo" bind:isExpanded={expanded['image']}>
 						<div slot="content">
 							<ImageUploader bind:dataUrl={$configStore.logo} />
 						</div>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixed Card tab design (except layer selection) according to the below wireframe

https://www.figma.com/design/xPemdxTmvPi2homUZ2dyw0/UNDP-GeoHub-UI?node-id=3474-5209&focus-id=3474-5492&m=dev

https://www.figma.com/design/xPemdxTmvPi2homUZ2dyw0/UNDP-GeoHub-UI?node-id=3474-5209&focus-id=3474-5388&m=dev

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
