### PR TITLE
fix: only update the slide mini preview in sidebar which is updated by slide setting.

### DIFF
--- a/.changeset/beige-hornets-flow.md
+++ b/.changeset/beige-hornets-flow.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: return toggled value through change event in Switch component.

--- a/.changeset/gentle-trainers-own.md
+++ b/.changeset/gentle-trainers-own.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: only update the slide mini preview in sidebar which is updated by slide setting.

--- a/packages/svelte-undp-design/src/lib/Switch/Switch.svelte
+++ b/packages/svelte-undp-design/src/lib/Switch/Switch.svelte
@@ -49,13 +49,17 @@
 			return;
 		}
 		toggled = !toggled;
-		dispatch('change');
+		dispatch('change', {
+			toggled
+		});
 	};
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (!disabled && event.key === 'Enter') {
 			toggled = !toggled;
-			dispatch('change');
+			dispatch('change', {
+				toggled
+			});
 		}
 	};
 </script>

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
@@ -80,6 +80,20 @@
 		dispatch('change');
 	};
 
+	const handleLayerEventChange = () => {
+		if (!$activeChapterStore) return;
+		for (let i = 0; i < $configStore.chapters.length; i++) {
+			if ($configStore.chapters[i].id === $activeChapterStore.id) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				$configStore.chapters[i] = $activeChapterStore;
+			}
+		}
+		activeChapterStore.set($activeChapterStore);
+		mapLocationSelector.updateMapStyle();
+		dispatch('change');
+	};
+
 	const handleClose = () => {
 		dispatch('close');
 	};
@@ -107,8 +121,20 @@
 		$activeChapterStore.base_style_id = mapConfig.base_style_id;
 		$activeChapterStore.style_id = mapConfig.style_id;
 		$activeChapterStore.style = mapConfig.style;
+		if ($activeChapterStore.onChapterEnter) {
+			$activeChapterStore.onChapterEnter = undefined;
+		}
+		for (let i = 0; i < $configStore.chapters.length; i++) {
+			if ($configStore.chapters[i].id === $activeChapterStore.id) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				$configStore.chapters[i] = $activeChapterStore;
+			}
+		}
+		activeChapterStore.set($activeChapterStore);
 		mapLocationSelector.updateMapStyle();
-		handleChange();
+
+		dispatch('change');
 	};
 
 	onMount(() => {
@@ -363,10 +389,12 @@
 					{#if $activeChapterStore.style_id}
 						<Accordion title="Layer Selection" bind:isExpanded={expanded['onChapterEnter']}>
 							<div slot="content">
-								<StorymapChapterLayerEventEditor
-									chapterLayerEvent="onChapterEnter"
-									on:change={handleChange}
-								/>
+								{#key mapLocationChanged}
+									<StorymapChapterLayerEventEditor
+										chapterLayerEvent="onChapterEnter"
+										on:change={handleLayerEventChange}
+									/>
+								{/key}
 							</div>
 							<div slot="buttons">
 								<Help>

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
@@ -14,6 +14,10 @@
 	import { debounce } from 'lodash-es';
 	import { type StyleSpecification } from 'maplibre-gl';
 	import { createEventDispatcher, getContext, onMount } from 'svelte';
+	import {
+		ACTIVE_STORYMAP_CHAPTER_CONTEXT_KEY,
+		type ActiveStorymapChapterStore
+	} from './StorymapChapterEdit.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -24,6 +28,10 @@
 	let isHovered = false;
 
 	let configStore: StoryMapConfigStore = getContext(STORYMAP_CONFIG_STORE_CONTEXT_KEY);
+	const activeChapterStore: ActiveStorymapChapterStore = getContext(
+		ACTIVE_STORYMAP_CHAPTER_CONTEXT_KEY
+	);
+
 	let template_id: StoryMapTemplate;
 
 	const tippyTooltip = initTooltipTippy();
@@ -34,8 +42,16 @@
 
 	let mapImageData: string;
 
+	let requireUpdate = false;
+
 	onMount(async () => {
 		updateMapStyle();
+
+		activeChapterStore.subscribe(() => {
+			if ($activeChapterStore?.id === chapter.id) {
+				requireUpdate = !requireUpdate;
+			}
+		});
 	});
 
 	const applyLayerEvent = async () => {
@@ -102,28 +118,31 @@
 		isHovered = false;
 	}}
 >
-	{#if mapImageData}
-		<img
-			src={mapImageData}
-			alt="map preview"
-			loading="lazy"
-			width={212}
-			height={124}
-			draggable={false}
-		/>
-		<div class="overlay">
-			<StoryMapChapter
-				bind:chapter
-				bind:activeId={chapter.id}
-				bind:template={template_id}
-				size="small"
+	{#key requireUpdate}
+		{#if mapImageData}
+			<img
+				src={mapImageData}
+				alt="map preview"
+				loading="lazy"
+				width={212}
+				height={124}
+				draggable={false}
 			/>
-		</div>
-	{:else}
-		<div class="is-flex is-justify-content-center mt-6">
-			<Loader size="small" />
-		</div>
-	{/if}
+			<div class="overlay">
+				<StoryMapChapter
+					bind:chapter
+					bind:activeId={chapter.id}
+					bind:template={template_id}
+					size="small"
+				/>
+			</div>
+		{:else}
+			<div class="is-flex is-justify-content-center mt-6">
+				<Loader size="small" />
+			</div>
+		{/if}
+	{/key}
+
 	{#if isActive || isHovered}
 		<div class="is-flex ope-buttons">
 			<button

--- a/sites/geohub/src/lib/helper/getMapImageFromStyle.ts
+++ b/sites/geohub/src/lib/helper/getMapImageFromStyle.ts
@@ -7,7 +7,11 @@ export const getMapImageFromStyle = async (
 	staticApiUrl: string
 ) => {
 	const staticApi = `${staticApiUrl}/style/static/auto/${width}x${height}.webp`;
-	const res = await fetch(staticApi, { method: 'POST', body: JSON.stringify(style) });
+	const res = await fetch(staticApi, {
+		method: 'POST',
+		body: JSON.stringify(style),
+		cache: 'no-store'
+	});
 	if (!res.ok) {
 		return '';
 	}

--- a/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
@@ -255,7 +255,7 @@
 			showSlideSetting = true;
 			isHeaderSlideActive = false;
 			$activeStorymapChapterStore = chapter;
-			requireUpdated = !requireUpdated;
+			requirePreviewUpdated = !requirePreviewUpdated;
 		} else {
 			showSlideSetting = !showSlideSetting;
 		}
@@ -275,7 +275,7 @@
 				$configStore.chapters[i] = $activeStorymapChapterStore;
 			}
 		}
-		requireUpdated = !requireUpdated;
+		requirePreviewUpdated = !requirePreviewUpdated;
 	};
 
 	const handleSlideDuplicated = (e: { detail: { chapter: StoryMapChapter } }) => {
@@ -287,12 +287,11 @@
 		duplicated.id = uuidv4();
 
 		if (cIndex === $configStore.chapters.length - 1) {
-			$configStore.chapters.push(duplicated);
+			$configStore.chapters = [...$configStore.chapters, duplicated];
 		} else {
 			$configStore.chapters.splice(cIndex + 1, 0, duplicated);
+			$configStore.chapters = [...$configStore.chapters];
 		}
-		$configStore.chapters = [...$configStore.chapters];
-
 		requireUpdated = !requireUpdated;
 	};
 
@@ -535,39 +534,39 @@
 						</button>
 					{/key}
 
-					<!-- {#key requireUpdated} -->
-					{#each $configStore.chapters as chapter, index}
-						{@const slideNo = index + 2}
-						{@const isActive = $activeStorymapChapterStore?.id === chapter.id}
-						<button
-							class="is-flex chapter-preview py-3 pr-4 {isActive ? 'is-active' : ''} {hovering ===
-							chapter.id
-								? 'is-dropping'
-								: ``} {draggingUp ? 'drag-up' : 'drag-down'}"
-							on:click={() => {
-								handleChapterClicked(chapter);
-							}}
-							draggable={true}
-							on:dragstart={(event) => dragstart(event, chapter.id)}
-							on:drop|preventDefault={(event) => drop(event, index)}
-							on:dragover={(event) => dragover(event)}
-							on:dragenter={(event) => dragenter(event, chapter.id)}
-						>
-							<p class="slide-number px-4 is-size-7">{slideNo}</p>
-							<StorymapChapterMiniPreview
-								bind:chapter
-								{isActive}
-								on:edit={handleSlideEdit}
-								on:delete={handleSlideDeleted}
-								on:duplicate={handleSlideDuplicated}
-								on:change={() => {
-									requirePreviewUpdated = !requirePreviewUpdated;
+					{#key requireUpdated}
+						{#each $configStore.chapters as chapter, index}
+							{@const slideNo = index + 2}
+							{@const isActive = $activeStorymapChapterStore?.id === chapter.id}
+							<button
+								class="is-flex chapter-preview py-3 pr-4 {isActive ? 'is-active' : ''} {hovering ===
+								chapter.id
+									? 'is-dropping'
+									: ``} {draggingUp ? 'drag-up' : 'drag-down'}"
+								on:click={() => {
+									handleChapterClicked(chapter);
 								}}
-								disabled={isProcessing}
-							/>
-						</button>
-					{/each}
-					<!-- {/key} -->
+								draggable={true}
+								on:dragstart={(event) => dragstart(event, chapter.id)}
+								on:drop|preventDefault={(event) => drop(event, index)}
+								on:dragover={(event) => dragover(event)}
+								on:dragenter={(event) => dragenter(event, chapter.id)}
+							>
+								<p class="slide-number px-4 is-size-7">{slideNo}</p>
+								<StorymapChapterMiniPreview
+									bind:chapter
+									{isActive}
+									on:edit={handleSlideEdit}
+									on:delete={handleSlideDeleted}
+									on:duplicate={handleSlideDuplicated}
+									on:change={() => {
+										requirePreviewUpdated = !requirePreviewUpdated;
+									}}
+									disabled={isProcessing}
+								/>
+							</button>
+						{/each}
+					{/key}
 				{/if}
 			</div>
 			<div class="p-2" bind:clientHeight={newslideButtonHeight}>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #3955 

- only update slide mini preview when user change setting 
- update all slides' preview in sidebar if user delete or duplicate the slide

I switched to use context api with writable store instead of prop to reduce reactivitiy

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
