### PR TITLE
fix: only update preview in sidebar if chapter has any changes.

### DIFF
--- a/.changeset/short-apples-exercise.md
+++ b/.changeset/short-apples-exercise.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: only update preview in sidebar if chapter has any changes.

--- a/sites/geohub/src/components/pages/storymap/MapLocationSelector.svelte
+++ b/sites/geohub/src/components/pages/storymap/MapLocationSelector.svelte
@@ -106,9 +106,8 @@
 	};
 
 	onMount(async () => {
-		if (!locationMapContainer) return;
 		const style = await applyLayerEvent();
-
+		if (!locationMapContainer) return;
 		locationMap = new Map({
 			container: locationMapContainer,
 			style: style,

--- a/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(storymap)/storymaps/[[id]]/edit/+page.svelte
@@ -251,13 +251,13 @@
 	const handleSlideEdit = (e: { detail: { chapter: StoryMapChapter } }) => {
 		const chapter: StoryMapChapter = e.detail.chapter;
 
-		if (!$activeStorymapChapterStore) {
+		if ($activeStorymapChapterStore?.id === chapter.id) {
+			showSlideSetting = !showSlideSetting;
+		} else {
 			showSlideSetting = true;
 			isHeaderSlideActive = false;
 			$activeStorymapChapterStore = chapter;
 			requirePreviewUpdated = !requirePreviewUpdated;
-		} else {
-			showSlideSetting = !showSlideSetting;
 		}
 	};
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

in the mini preview of sidebar, check whether actual chapter object has been changed. if not changed, never trigger flag to update map image.

previously, when user click a chapter, it updated map image even it is not changed. now improved (I believe!)

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
