### PR TITLE
fix: replaced zonal stats for Electricity Dashboards to add 2021-2030…

### DIFF
--- a/.changeset/fuzzy-socks-dance.md
+++ b/.changeset/fuzzy-socks-dance.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: replaced zonal stats for Electricity Dashboards to add 2021-2030 data.

--- a/sites/geohub/src/routes/(map)/dashboards/+layout.server.ts
+++ b/sites/geohub/src/routes/(map)/dashboards/+layout.server.ts
@@ -5,8 +5,10 @@ import { attribution } from '$lib/config/AppConfig';
 export const load: LayoutServerLoad = async () => {
 	const attrs = [attribution, `<a target="_top" rel="noopener" href="https://www.ibm.com">IBM</a>`];
 
+	const azureUrl = `https://${env.AZURE_STORAGE_ACCOUNT_UPLOAD}.blob.core.windows.net`;
+
 	return {
-		azureUrl: `https://${env.AZURE_STORAGE_ACCOUNT_UPLOAD}.blob.core.windows.net`,
+		azureUrl,
 		titilerUrl: env.TITILER_ENDPOINT,
 		maptilerKey: env.MAPTILER_API_KEY,
 		attribution: attrs.join(', '),

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/+page.svelte
@@ -57,7 +57,7 @@
 		createElectricityDataTypeStore,
 		ELECTRICITY_DATATYPE_CONTEXT_KEY
 	} from './stores/electricityDataType';
-	import { loadAdmin, setAzureUrl, unloadAdmin } from './utils/adminLayer';
+	import { loadAdmin, setAdminUrl, unloadAdmin } from './utils/adminLayer';
 
 	export let data: PageData;
 
@@ -68,8 +68,8 @@
 	const electricityDataType = createElectricityDataTypeStore();
 	setContext(ELECTRICITY_DATATYPE_CONTEXT_KEY, electricityDataType);
 
-	const azureUrl = data.azureUrl;
-	setAzureUrl(azureUrl);
+	const adminUrl = data.adminUrl;
+	setAdminUrl(adminUrl);
 
 	let styleUrl = MapStyles[0].uri;
 	let exportOptions: ControlOptions = {
@@ -277,7 +277,7 @@
 				downloadFile(url);
 			}
 		} else {
-			let url = `${data.azureUrl}/hrea/admin/${layer.toLowerCase()}_polygons.${format.toLowerCase()}`;
+			let url = `${data.adminUrl}/${layer.toLowerCase()}_polygons.${format.toLowerCase()}`;
 
 			if (!['fgb', 'pmtiles'].includes(format.toLowerCase())) {
 				url = `${url}.zip`;

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/+page.ts
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/+page.ts
@@ -1,11 +1,15 @@
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, parent }) => {
+	const { azureUrl } = await parent();
 	const title = 'Electricity Dashboard | GeoHub';
 	const content = 'Electricity dashboard';
 	const site_description = `The 'Affordable and clean energy' dashboard helps identify vulnerable areas in the world that have limited or no access to energy.`;
 
+	const adminUrl = `${azureUrl}/hrea/admin/v3`;
+
 	return {
+		adminUrl,
 		title,
 		content,
 		site_description,

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
@@ -2,10 +2,10 @@
 	import { page } from '$app/stores';
 	import type { RasterLayerSpecification, SourceSpecification } from 'maplibre-gl';
 	import { hrea, map } from '../stores';
-	import { reloadAdmin, setAzureUrl, setTargetTear } from '../utils/adminLayer';
+	import { reloadAdmin, setAdminUrl, setTargetTear } from '../utils/adminLayer';
 
-	const azureUrl = $page.data.azureUrl;
-	setAzureUrl(azureUrl);
+	const adminUrl = $page.data.adminUrl;
+	setAdminUrl(adminUrl);
 
 	export let scaleColorList = [];
 	export let rasterColorMapName = '';

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/utils/adminLayer.ts
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/utils/adminLayer.ts
@@ -16,14 +16,14 @@ let adminLevel = 0;
 let hoveredStateId: string;
 let choropleth = true;
 let opacity = 0.8;
-let azureUrl = '';
+let adminUrl = '';
 let year = '2020';
 let scaleColorList: string[] = [];
 let adminLabelsLoaded: boolean = true;
 let colorExpression;
 
-export const setAzureUrl = (url: string) => {
-	azureUrl = url;
+export const setAdminUrl = (url: string) => {
+	adminUrl = url;
 };
 
 export const setTargetTear = (value: number) => {
@@ -131,7 +131,7 @@ const loadAdmin0 = () => {
 	const layerSource: SourceSpecification = {
 		type: 'vector',
 		promoteId: promoteId,
-		url: `pmtiles://${azureUrl}/hrea/admin/adm0_polygons.pmtiles`
+		url: `pmtiles://${adminUrl}/adm0_polygons.pmtiles`
 	};
 	const layerLine: LineLayerSpecification = {
 		id: ADM0_ID,
@@ -252,7 +252,7 @@ const loadAdminChoropleth = () => {
 	const layerSource: SourceSpecification = {
 		type: 'vector',
 		promoteId: `adm${lvl}_id`,
-		url: `pmtiles://${azureUrl}/hrea/admin/adm${lvl}_polygons.pmtiles`
+		url: `pmtiles://${adminUrl}/adm${lvl}_polygons.pmtiles`
 	};
 	const layerFill: FillLayerSpecification = {
 		id: ADM_ID,
@@ -284,7 +284,7 @@ const loadAdminHover = () => {
 	const layerSource: SourceSpecification = {
 		type: 'vector',
 		promoteId: `adm${lvl}_id`,
-		url: `pmtiles://${azureUrl}/hrea/admin/adm${lvl}_polygons.pmtiles`
+		url: `pmtiles://${adminUrl}/adm${lvl}_polygons.pmtiles`
 	};
 	const layerFill: FillLayerSpecification = {
 		id: ADM_ID,


### PR DESCRIPTION
… data.

Thank you for submitting a pull request!

## Description

closes #3785

changed folder structure of blob storage for admin data

- https://undpgeohub.blob.core.windows.net/hrea/admin
  - /v2 - zonal stats with 2021-2023 (kontur)
  - /v3 - new version with 2021-2030
    - /adm0_polygons.pmtiles
    - /adm1_polygons.pmtiles
    - /adm2_polygons.pmtiles

uploaded other formats (fgb, csv, gpkg, excel, shp) as well.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
