### PR TITLE
fix: setSky will add sky spec to style json itself. this affects checking whether style is changed. remove sky prop before saving and exclude it from checking.

### DIFF
--- a/.changeset/proud-beans-applaud.md
+++ b/.changeset/proud-beans-applaud.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: setSky will add sky spec to style json itself. this affects checking whether style is changed. remove sky prop before saving and exclude it from checking.

--- a/sites/geohub/src/lib/helper/isStyleChanged.ts
+++ b/sites/geohub/src/lib/helper/isStyleChanged.ts
@@ -22,6 +22,12 @@ const deleteAdminSources = (style: StyleSpecification) => {
 			delete style.sources[src];
 		}
 	});
+
+	// delete sky
+	if ('sky' in style) {
+		delete style.sky;
+	}
+
 	return style;
 };
 

--- a/sites/geohub/src/routes/api/style/+server.ts
+++ b/sites/geohub/src/routes/api/style/+server.ts
@@ -314,6 +314,12 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 	}
 
 	const styleJson: StyleSpecification = body.style;
+
+	// delete sky
+	if ('sky' in styleJson) {
+		delete styleJson.sky;
+	}
+
 	Object.keys(styleJson.sources).forEach((key) => {
 		const source = styleJson.sources[key];
 		if ('url' in source && source.url.startsWith(url.origin)) {
@@ -425,6 +431,12 @@ export const PUT: RequestHandler = async ({ request, url, locals }) => {
 	const client = await dbm.start();
 	try {
 		const styleJson: StyleSpecification = body.style;
+
+		// delete sky
+		if ('sky' in styleJson) {
+			delete styleJson.sky;
+		}
+
 		Object.keys(styleJson.sources).forEach((key) => {
 			const source = styleJson.sources[key];
 			if ('url' in source && source.url.startsWith(url.origin)) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
