### PR TITLE
fix: use pngjs to crop sprite image instead of using image-clipper with node-canvas

### DIFF
--- a/.changeset/healthy-lemons-rest.md
+++ b/.changeset/healthy-lemons-rest.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use pngjs to crop sprite image instead of using image-clipper with node-canvas

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       pg:
         specifier: ^8.12.0
         version: 8.12.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@auth/core':
         specifier: ^0.34.2
@@ -924,6 +927,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.6
         version: 8.11.6
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -2849,6 +2855,9 @@ packages:
 
   '@types/pg@8.11.6':
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/prop-types@15.7.12':
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
@@ -5528,6 +5537,10 @@ packages:
 
   pmtiles@3.0.7:
     resolution: {integrity: sha512-kGTFNyzmNdF8yiGxuoskNwLfUkHzC1ouJ5waL6dLID+g4hKlGnohIGX4q7qXrY0rHTK+8MwIKDTrUjY70Kk5ew==}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -8955,7 +8968,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.45
+      '@types/node': 22.4.1
 
   '@types/chroma-js@2.4.4': {}
 
@@ -8963,7 +8976,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.45
+      '@types/node': 22.4.1
 
   '@types/cookie@0.6.0': {}
 
@@ -8988,7 +9001,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
-      '@types/node': 18.19.45
+      '@types/node': 22.4.1
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -9072,6 +9085,10 @@ snapshots:
       pg-protocol: 1.6.1
       pg-types: 4.0.2
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.4.1
+
   '@types/prop-types@15.7.12': {}
 
   '@types/pug@2.0.10': {}
@@ -9092,12 +9109,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.45
+      '@types/node': 22.4.1
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.45
+      '@types/node': 22.4.1
       '@types/send': 0.17.4
 
   '@types/supercluster@7.1.3':
@@ -12123,6 +12140,8 @@ snapshots:
     dependencies:
       '@types/leaflet': 1.9.12
       fflate: 0.8.2
+
+  pngjs@7.0.0: {}
 
   polished@4.3.1:
     dependencies:

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -58,6 +58,7 @@
 		"@types/papaparse": "^5.3.14",
 		"@types/pbf": "^3.0.5",
 		"@types/pg": "^8.11.6",
+		"@types/pngjs": "^6.0.5",
 		"@types/uuid": "^10.0.0",
 		"@typescript-eslint/eslint-plugin": "8.1.0",
 		"@typescript-eslint/parser": "^8.0.0",
@@ -146,7 +147,8 @@
 		"crypto-js": "^4.2.0",
 		"jwt-decode": "^4.0.0",
 		"pbf": "^4.0.1",
-		"pg": "^8.12.0"
+		"pg": "^8.12.0",
+		"pngjs": "^7.0.0"
 	},
 	"type": "module"
 }

--- a/sites/geohub/src/lib/server/SvgLegendCreator.ts
+++ b/sites/geohub/src/lib/server/SvgLegendCreator.ts
@@ -1,3 +1,4 @@
+import { getDecimalPlaces } from '$lib/helper';
 import chroma from 'chroma-js';
 import { hexToCSSFilter } from 'hex-to-css-filter';
 
@@ -50,6 +51,18 @@ export class SvgLegendCreator {
 		colors: [number, number, number, number][],
 		options?: SvgLegendCreatorOptions
 	) {
+		let minDecimalPlaces = 0;
+		if (options?.min && typeof options.min === 'string') {
+			options.min = parseFloat(options.min);
+			minDecimalPlaces = getDecimalPlaces(options.min);
+			if (minDecimalPlaces > 2) minDecimalPlaces = 2;
+		}
+		let maxDecimalPlaces = 0;
+		if (options?.max && typeof options.max === 'string') {
+			options.max = parseFloat(options.max);
+			maxDecimalPlaces = getDecimalPlaces(options.max);
+			if (maxDecimalPlaces > 2) maxDecimalPlaces = 2;
+		}
 		const contents = `
         <defs>
             <linearGradient id='grad1' x1='0%' y1='0%' x2='100%' y2='0%'>
@@ -63,9 +76,9 @@ export class SvgLegendCreator {
             </linearGradient>
         </defs>
         ${options?.unit ? `<text x='0' y='15' font-family='${this.fontFamily}' font-size='${this.fontSize}' fill='#000000'>${options?.unit}</text>` : ''}
-        <rect y='20' width='100%' height='28' fill='url(#grad1)' />
-        ${options?.min ? `<text x='0' y='${options?.unit ? 65 : 45}' font-family='${this.fontFamily}' font-size='${this.fontSize}' fill='#000000'>${options?.min.toFixed(0)}</text>` : ''}
-        ${options?.max ? `<text x='100%' y='${options?.unit ? 65 : 45}' font-family='${this.fontFamily}' font-size='${this.fontSize}' fill='#000000' text-anchor='end'>${options?.max.toFixed(0)}</text>` : ''}
+        <rect y='${options?.unit ? 20 : 0}' width='100%' height='28' fill='url(#grad1)' />
+        ${options?.min ? `<text x='0' y='${options?.unit ? 65 : 45}' font-family='${this.fontFamily}' font-size='${this.fontSize}' fill='#000000'>${options?.min.toFixed(minDecimalPlaces)}</text>` : ''}
+        ${options?.max ? `<text x='100%' y='${options?.unit ? 65 : 45}' font-family='${this.fontFamily}' font-size='${this.fontSize}' fill='#000000' text-anchor='end'>${options?.max.toFixed(maxDecimalPlaces)}</text>` : ''}
 `;
 
 		const height = options?.unit ? 70 : 50;

--- a/sites/geohub/src/lib/server/helpers/clipSpriteServer.ts
+++ b/sites/geohub/src/lib/server/helpers/clipSpriteServer.ts
@@ -1,28 +1,40 @@
-import Clipper from 'image-clipper';
-import type { SpriteIcon, SpriteImage } from '../../types';
-import canvas from 'canvas';
+import { PNG } from 'pngjs';
+import type { SpriteIcon, SpriteImage } from '$lib/types';
 
-/**
- * Clip an image by id from sprite file image (server version)
- * @param url sprite image URL
- * @param id Sprite ID
- * @param icon sprite image data from json
- * @returns
- */
-export const clipSpriteServer = (
+export const clipSpriteServer = async (
 	url: string,
 	id: string,
 	icon: SpriteIcon
 ): Promise<SpriteImage> => {
-	return new Promise((resolve) => {
-		Clipper.configure({ canvas: canvas });
-		Clipper(url, function () {
-			this.crop(icon.x, icon.y, icon.width, icon.height).toDataURL(function (dataUrl: string) {
-				resolve({
-					src: dataUrl,
-					alt: id
-				});
-			});
-		});
-	});
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch image: ${res.statusText}`);
+	}
+
+	const arrayBuffer = await res.arrayBuffer();
+	const buffer = Buffer.from(arrayBuffer);
+
+	const png = PNG.sync.read(buffer);
+	const cropped = new PNG({ width: icon.width, height: icon.height });
+
+	for (let y = 0; y < icon.height; y++) {
+		for (let x = 0; x < icon.width; x++) {
+			const idx = ((icon.y + y) * png.width + (icon.x + x)) << 2;
+			const croppedIdx = (y * icon.width + x) << 2;
+
+			cropped.data[croppedIdx] = png.data[idx];
+			cropped.data[croppedIdx + 1] = png.data[idx + 1];
+			cropped.data[croppedIdx + 2] = png.data[idx + 2];
+			cropped.data[croppedIdx + 3] = png.data[idx + 3];
+		}
+	}
+
+	const bufferOutput = PNG.sync.write(cropped);
+	const base64 = bufferOutput.toString('base64');
+	const dataUrl = `data:image/png;base64,${base64}`;
+
+	return {
+		src: dataUrl,
+		alt: id
+	};
 };

--- a/sites/geohub/src/lib/server/helpers/generateLegendFromStyle.ts
+++ b/sites/geohub/src/lib/server/helpers/generateLegendFromStyle.ts
@@ -1,6 +1,6 @@
 import {
 	convertFunctionToExpression,
-	// fetchUrl,
+	fetchUrl,
 	getActiveBandIndex,
 	getDecimalPlaces,
 	isRgbRaster
@@ -13,7 +13,7 @@ import type {
 	DashboardMapStyle,
 	Layer,
 	RasterTileMetadata,
-	// SpriteIcon,
+	SpriteIcon,
 	VectorLayerSpecification,
 	VectorTileMetadata
 } from '$lib/types';
@@ -22,8 +22,8 @@ import type {
 	RasterSourceSpecification,
 	SpriteSpecification
 } from 'maplibre-gl';
-// import { clipSpriteServer } from './clipSpriteServer';
 import { layerTypes } from '@undp-data/svelte-maplibre-storymap';
+import { clipSpriteServer } from './clipSpriteServer';
 
 /**
  * LegendLayer interface to contain layer legend information
@@ -262,25 +262,23 @@ const getVectorPropertyNames = async (
 		colorProp = 'heatmap-color';
 	} else if (layer.type === 'symbol') {
 		colorProp = 'icon-color';
-		console.log(sprite);
-		// const iconName = layer.layout ? (layer.layout['icon-image'] as string) : undefined;
-		// if (iconName) {
-		// 	if (typeof sprite === 'string') {
-		// 		const spriteBase = sprite.replace('/sprite/sprite', '/sprite-non-sdf/sprite');
-		// 		// const spriteBase = sprite;
-		// 		const data = `${spriteBase}@2x.png`;
-		// 		const spriteJson: { [key: string]: SpriteIcon } = (await fetchUrl(
-		// 			`${spriteBase}@2x.json`
-		// 		)) as unknown as { [key: string]: SpriteIcon };
-		// 		const spriteImage = spriteJson[iconName];
-		// 		if (spriteImage) {
-		// 			const image = await clipSpriteServer(data, iconName, spriteImage);
-		// 			shape = `
-		// 			 <image x='0' y='0' width='{size}' height='{size}' xlink:href='${image.src}' style='{style}' />
-		// 			`;
-		// 		}
-		// 	}
-		// }
+		const iconName = layer.layout ? (layer.layout['icon-image'] as string) : undefined;
+		if (iconName) {
+			if (typeof sprite === 'string') {
+				const spriteBase = sprite.replace('/sprite/sprite', '/sprite-non-sdf/sprite');
+				const data = `${spriteBase}@2x.png`;
+				const spriteJson: { [key: string]: SpriteIcon } = (await fetchUrl(
+					`${spriteBase}@2x.json`
+				)) as unknown as { [key: string]: SpriteIcon };
+				const spriteImage = spriteJson[iconName];
+				if (spriteImage) {
+					const image = await clipSpriteServer(data, iconName, spriteImage);
+					shape = `
+					 <image x='0' y='0' width='{size}' height='{size}' xlink:href='${image.src}' style='{style}' />
+					`;
+				}
+			}
+		}
 	}
 
 	return {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #3979

I found a way to use pngjs instead of image-clipper with node-canvas (asked chatgpt to write code). pngjs has no dependencies, it should work

also fixed some bugs on legend api

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
