### PR TITLE
Fix/show loader only layers

### DIFF
--- a/.changeset/nice-rice-tease.md
+++ b/.changeset/nice-rice-tease.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: show loader only under layers tab in map page.

--- a/.changeset/weak-cycles-drum.md
+++ b/.changeset/weak-cycles-drum.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: fixed padding for close button of FloatingPanel.

--- a/packages/svelte-undp-components/src/lib/components/FloatingPanel.svelte
+++ b/packages/svelte-undp-components/src/lib/components/FloatingPanel.svelte
@@ -42,7 +42,7 @@
 			<div class="header-buttons is-flex is-align-items-center ml-auto">
 				{#if showExpand}
 					<button
-						class="button chevron-button {isExpanded ? 'is-expanded' : ''} p-0 pl-2"
+						class="button chevron-button {isExpanded ? 'is-expanded' : ''} px-2"
 						on:click={() => {
 							isExpanded = !isExpanded;
 						}}
@@ -55,7 +55,7 @@
 				{/if}
 				{#if showClose}
 					<button
-						class="button p-0 pl-2"
+						class="button pr-2"
 						on:click={handleClose}
 						use:tippyTooltip={{ content: 'Close' }}
 					>

--- a/sites/geohub/src/components/maplibre/hillshade/Hillshade.svelte
+++ b/sites/geohub/src/components/maplibre/hillshade/Hillshade.svelte
@@ -4,12 +4,7 @@
 	import HillshadeHighlightColor from '$components/maplibre/hillshade/HillshadeHighlightColor.svelte';
 	import HillshadeIlluminationDirection from '$components/maplibre/hillshade/HillshadeIlluminationDirection.svelte';
 	import HillshadeShadowColorsvelte from '$components/maplibre/hillshade/HillshadeShadowColor.svelte';
-	import { loadMap } from '$lib/helper';
-	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '$stores';
 	import { Accordion, Help } from '@undp-data/svelte-undp-components';
-	import { Loader } from '@undp-data/svelte-undp-design';
-	import { getContext } from 'svelte';
-	const map: MapStore = getContext(MAPSTORE_CONTEXT_KEY);
 
 	export let layerId: string;
 
@@ -30,68 +25,56 @@
 			expanded[expandedDatasets[0]] = true;
 		}
 	}
-
-	const initMap = async () => {
-		return loadMap($map);
-	};
 </script>
 
-{#await initMap()}
-	<div class="is-flex is-justify-content-center p-2">
-		<Loader size="small" />
+<Accordion title="Hillshade accent color" bind:isExpanded={expanded['hillshade-accent-color']}>
+	<div class="pb-2" slot="content">
+		<HillshadeAccentColor {layerId} />
 	</div>
-{:then isInit}
-	{#if isInit}
-		<Accordion title="Hillshade accent color" bind:isExpanded={expanded['hillshade-accent-color']}>
-			<div class="pb-2" slot="content">
-				<HillshadeAccentColor {layerId} />
-			</div>
-			<div slot="buttons">
-				<Help>
-					Change the shading color used to accentuate rugged terrain like sharp cliffs and gorges.
-				</Help>
-			</div>
-		</Accordion>
-		<Accordion title="Hillshade exaggeration" bind:isExpanded={expanded['hillshade-exaggeration']}>
-			<div class="pb-2" slot="content">
-				<HillshadeExaggeration {layerId} />
-			</div>
-			<div slot="buttons">
-				<Help>Change the Intensity of the hillshade.</Help>
-			</div>
-		</Accordion>
-		<Accordion
-			title="Hillshade highlight color"
-			bind:isExpanded={expanded['hillshade-highlight-color']}
-		>
-			<div class="pb-2" slot="content">
-				<HillshadeHighlightColor {layerId} />
-			</div>
-			<div slot="buttons">
-				<Help>Change the shading color of areas that faces towards the light source.</Help>
-			</div>
-		</Accordion>
-		<Accordion
-			title="Hillshade illumination direction"
-			bind:isExpanded={expanded['hillshade-illumination-direction']}
-		>
-			<div class="pb-2" slot="content">
-				<HillshadeIlluminationDirection {layerId} />
-			</div>
-			<div slot="buttons">
-				<Help>
-					The direction of the light source used to generate the hillshading with 0 as the top of
-					the viewport
-				</Help>
-			</div>
-		</Accordion>
-		<Accordion title="Hillshade shadow color" bind:isExpanded={expanded['hillshade-shadow-color']}>
-			<div class="pb-2" slot="content">
-				<HillshadeShadowColorsvelte {layerId} />
-			</div>
-			<div slot="buttons">
-				<Help>Change the shading color of areas that face away from the light source.</Help>
-			</div>
-		</Accordion>
-	{/if}
-{/await}
+	<div slot="buttons">
+		<Help>
+			Change the shading color used to accentuate rugged terrain like sharp cliffs and gorges.
+		</Help>
+	</div>
+</Accordion>
+<Accordion title="Hillshade exaggeration" bind:isExpanded={expanded['hillshade-exaggeration']}>
+	<div class="pb-2" slot="content">
+		<HillshadeExaggeration {layerId} />
+	</div>
+	<div slot="buttons">
+		<Help>Change the Intensity of the hillshade.</Help>
+	</div>
+</Accordion>
+<Accordion
+	title="Hillshade highlight color"
+	bind:isExpanded={expanded['hillshade-highlight-color']}
+>
+	<div class="pb-2" slot="content">
+		<HillshadeHighlightColor {layerId} />
+	</div>
+	<div slot="buttons">
+		<Help>Change the shading color of areas that faces towards the light source.</Help>
+	</div>
+</Accordion>
+<Accordion
+	title="Hillshade illumination direction"
+	bind:isExpanded={expanded['hillshade-illumination-direction']}
+>
+	<div class="pb-2" slot="content">
+		<HillshadeIlluminationDirection {layerId} />
+	</div>
+	<div slot="buttons">
+		<Help>
+			The direction of the light source used to generate the hillshading with 0 as the top of the
+			viewport
+		</Help>
+	</div>
+</Accordion>
+<Accordion title="Hillshade shadow color" bind:isExpanded={expanded['hillshade-shadow-color']}>
+	<div class="pb-2" slot="content">
+		<HillshadeShadowColorsvelte {layerId} />
+	</div>
+	<div slot="buttons">
+		<Help>Change the shading color of areas that face away from the light source.</Help>
+	</div>
+</Accordion>

--- a/sites/geohub/src/components/pages/map/Content.svelte
+++ b/sites/geohub/src/components/pages/map/Content.svelte
@@ -71,15 +71,15 @@
 	/>
 </div>
 
-{#if $pageDataLoadingStore === true}
-	<div class="is-flex is-justify-content-center is-align-items-center" style="margin-top: 40%;">
-		<Loader size="medium" />
-	</div>
-{:else}
-	<div hidden={activeTab !== TabNames.DATA} class="mx-4">
-		<DataView bind:contentHeight />
-	</div>
-	<div hidden={activeTab !== TabNames.LAYERS}>
+<div hidden={activeTab !== TabNames.DATA} class="mx-4">
+	<DataView bind:contentHeight />
+</div>
+<div hidden={activeTab !== TabNames.LAYERS}>
+	{#if $pageDataLoadingStore === true}
+		<div class="is-flex is-justify-content-center is-align-items-center" style="margin-top: 40%;">
+			<Loader size="medium" />
+		</div>
+	{:else}
 		<LayerList bind:contentHeight bind:activeTab />
-	</div>
-{/if}
+	{/if}
+</div>

--- a/sites/geohub/src/components/pages/map/layers/LayerEdit.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerEdit.svelte
@@ -22,7 +22,7 @@
 {#if $editingLayerStore}
 	<div class="layer-editor">
 		<FloatingPanel title={$editingLayerStore.name} on:close={handleClose}>
-			{#if $editingLayerStore.dataset.properties.is_raster === true}
+			{#if $editingLayerStore.dataset?.properties.is_raster === true}
 				<RasterLayer bind:layer={$editingLayerStore} />
 			{:else}
 				<VectorLayer bind:layer={$editingLayerStore} />

--- a/sites/geohub/src/components/pages/map/layers/LayerInfo.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerInfo.svelte
@@ -14,16 +14,16 @@
 	const tippyTooltip = initTooltipTippy();
 
 	let isFullDescription = false;
-	let properties = layer.dataset.properties;
+	let properties = layer.dataset?.properties;
 
-	const tags: [{ key: string; value: string }] = properties.tags as unknown as [
+	const tags: [{ key: string; value: string }] = properties?.tags as unknown as [
 		{ key: string; value: string }
 	];
 	const stacType = tags?.find((t) => t.key === 'stacType')?.value;
-	const datasetUrl = properties.links?.find((l) => l.rel === 'dataset')?.href;
-	const downloadUrl = properties.links?.find((l) => l.rel === 'download')?.href;
+	const datasetUrl = properties?.links?.find((l) => l.rel === 'dataset')?.href;
+	const downloadUrl = properties?.links?.find((l) => l.rel === 'download')?.href;
 
-	const rasterInfo: RasterTileMetadata = layer.info;
+	const rasterInfo: RasterTileMetadata = layer.info as RasterTileMetadata;
 
 	const getFileSize = async (url: string) => {
 		let bytes = 'N/A';
@@ -61,7 +61,7 @@
 <Accordion title="Metadata" bind:isExpanded={expanded['metadata']}>
 	<div slot="content">
 		<div class="pb-2 is-flex is-align-items-center">
-			<span class="dataset-title is-size-5 has-text-weight-semibold">{properties.name}</span>
+			<span class="dataset-title is-size-5 has-text-weight-semibold">{properties?.name}</span>
 			{#if datasetUrl}
 				<a
 					href={datasetUrl}
@@ -78,7 +78,7 @@
 
 		{#if !(stacType && ['cog', 'mosaicjson'].includes(stacType)) || downloadUrl}
 			<div class="is-flex is-align-items-center pb-2">
-				{#if !(stacType && ['cog', 'mosaicjson'].includes(stacType))}
+				{#if !(stacType && ['cog', 'mosaicjson'].includes(stacType)) && properties}
 					<div class="pr-1">
 						<Star
 							bind:id={properties.id}
@@ -105,8 +105,10 @@
 		{/if}
 
 		<div class="is-size-6 pb-2 has-text-justified {isFullDescription ? '' : 'short-description'}">
-			<!-- eslint-disable svelte/no-at-html-tags -->
-			{@html marked(properties.description)}
+			{#if properties?.description}
+				<!-- eslint-disable svelte/no-at-html-tags -->
+				{@html marked(properties.description)}
+			{/if}
 		</div>
 
 		{#if !isFullDescription}
@@ -119,7 +121,7 @@
 		{:else}
 			<FieldControl title="license" showHelp={false}>
 				<div class="is-size-6" slot="control">
-					{properties.license ?? 'License not specified'}
+					{properties?.license ?? 'License not specified'}
 				</div>
 			</FieldControl>
 			<FieldControl title="source" showHelp={false}>
@@ -131,10 +133,10 @@
 
 			<FieldControl title="created at" showHelp={false}>
 				<div slot="control">
-					<Time timestamp={properties.createdat} format="h:mm A, MMMM D, YYYY" />
+					<Time timestamp={properties?.createdat} format="h:mm A, MMMM D, YYYY" />
 				</div>
 			</FieldControl>
-			{#if properties.created_user}
+			{#if properties?.created_user}
 				<FieldControl title="created by" showHelp={false}>
 					<div class="is-size-6" slot="control">
 						{properties.created_user}
@@ -142,14 +144,14 @@
 				</FieldControl>
 			{/if}
 
-			{#if properties.updatedat}
+			{#if properties?.updatedat}
 				<FieldControl title="updated at" showHelp={false}>
 					<div slot="control">
 						<Time timestamp={properties.updatedat} format="h:mm A, MMMM D, YYYY" />
 					</div>
 				</FieldControl>
 			{/if}
-			{#if properties.updated_user}
+			{#if properties?.updated_user}
 				<FieldControl title="updated by" showHelp={false}>
 					<div class="is-size-6" slot="control">
 						{properties.updated_user}
@@ -160,8 +162,8 @@
 	</div>
 </Accordion>
 
-{#if properties.is_raster}
-	{@const isRgbTile = isRgbRaster(rasterInfo.colorinterp)}
+{#if properties?.is_raster}
+	{@const isRgbTile = rasterInfo.colorinterp ? isRgbRaster(rasterInfo.colorinterp) : false}
 	{#if !isRgbTile}
 		<Accordion title="Dataset statistics" bind:isExpanded={expanded['statistics']}>
 			<div slot="content">

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -43,7 +43,7 @@
 	export let isExpanded = layer.isExpanded;
 	let isDeleteDialogVisible = false;
 
-	const accessLevel = layer.dataset.properties.access_level ?? AccessLevel.PUBLIC;
+	const accessLevel = layer.dataset?.properties.access_level ?? AccessLevel.PUBLIC;
 	const existLayerInMap = $map.getStyle().layers.find((l) => l.id === layer.id) ? true : false;
 
 	const tippyTooltip = initTooltipTippy();
@@ -54,10 +54,12 @@
 		const layerStyle = getLayerStyle($map, layer.id);
 		if (['raster', 'hillshade'].includes(layerStyle.type)) {
 			const metadata: RasterTileMetadata = layer.info as RasterTileMetadata;
-			bounds = [
-				[Number(metadata.bounds[0]), Number(metadata.bounds[1])],
-				[Number(metadata.bounds[2]), Number(metadata.bounds[3])]
-			];
+			if (metadata.bounds) {
+				bounds = [
+					[Number(metadata.bounds[0]), Number(metadata.bounds[1])],
+					[Number(metadata.bounds[2]), Number(metadata.bounds[3])]
+				];
+			}
 		} else {
 			const metadata: VectorTileMetadata = layer.info as VectorTileMetadata;
 			const boundsArray = metadata.bounds.split(',');

--- a/sites/geohub/src/routes/(map)/maps/+layout.svelte
+++ b/sites/geohub/src/routes/(map)/maps/+layout.svelte
@@ -76,7 +76,7 @@
 	const initiaMapStyleId: string | null = fromLocalStorage(mapStyleIdStorageKey, null);
 
 	let dialogOpen = false;
-	let toUrl: URL = undefined;
+	let toUrl: URL | undefined = undefined;
 
 	let isNewMapPage = $page.url.pathname === '/maps/edit';
 
@@ -119,7 +119,7 @@
 		} else {
 			// /map/{id} saved map page
 			let databaseStyle: DashboardMapStyle = $page.data.style;
-			if (databaseStyle && isStyleChanged(databaseStyle.style, storageMapStyle)) {
+			if (databaseStyle?.style && isStyleChanged(databaseStyle.style, storageMapStyle)) {
 				// if there is any difference between database style and current state
 				cancel();
 				dialogOpen = true;
@@ -135,7 +135,7 @@
 		toLocalStorage(mapStyleStorageKey, null);
 		toLocalStorage(mapStyleIdStorageKey, null);
 		dialogOpen = false;
-		if (browser) {
+		if (browser && toUrl) {
 			window.location.href = toUrl.toString();
 		}
 	};

--- a/sites/geohub/src/stores/editingLayer.ts
+++ b/sites/geohub/src/stores/editingLayer.ts
@@ -6,7 +6,7 @@ export const EDITING_LAYER_STORE_CONTEXT_KEY = 'maplibre-editing-layer-store';
 export type EditingLayerStore = ReturnType<typeof createEditingLayerStore>;
 
 export function createEditingLayerStore() {
-	const { set, update, subscribe } = writable<Layer>(undefined);
+	const { set, update, subscribe } = writable<Layer | undefined>(undefined);
 
 	return {
 		subscribe,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I realized loader on sidebar of map page is only needed for layers tab. Moved loader under layers tab now. so users will not be blocked to see data tab.

also fixed some lint errors.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
