### PR TITLE
fix: toggle layout.visibility instead of opacity for hillshade layer …

### DIFF
--- a/.changeset/gold-cheetahs-provide.md
+++ b/.changeset/gold-cheetahs-provide.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-maplibre-storymap": patch
+"geohub": patch
+---
+
+fix: toggle layout.visibility instead of opacity for hillshade layer since its layer type has not opacity.

--- a/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
@@ -203,20 +203,29 @@
 
 	const handleOpacityChanged = debounce((values: number, layer: Layer) => {
 		const opacity = values;
+		const visibility = opacity === 0 ? 'none' : 'visible';
 		const mapLayer = map.getLayer(layer.id);
 		const props: string[] = layerTypes[mapLayer.type];
-		props.forEach((prop) => {
-			map.setPaintProperty(layer.id, prop, opacity);
-		});
+		if (props && props.length > 0) {
+			props.forEach((prop) => {
+				map.setPaintProperty(layer.id, prop, opacity);
+			});
+		} else {
+			map.setLayoutProperty(layer.id, 'visibility', visibility);
+		}
 
 		if (layer.children && layer.children.length > 0) {
 			layer.children.forEach((child) => {
 				const childLayer = map.getLayer(child.id);
 				if (!childLayer) return;
 				const childProps: string[] = layerTypes[childLayer.type];
-				childProps.forEach((prop) => {
-					map.setPaintProperty(child.id, prop, opacity);
-				});
+				if (childProps && childProps.length > 0) {
+					childProps.forEach((prop) => {
+						map.setPaintProperty(child.id, prop, opacity);
+					});
+				} else {
+					map.setLayoutProperty(child.id, 'visibility', visibility);
+				}
 			});
 		}
 	}, 300);

--- a/packages/svelte-maplibre-storymap/src/lib/StoryMapChapter.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/StoryMapChapter.svelte
@@ -46,10 +46,17 @@
 				if (index === -1) return;
 				const l = newStyle.layers[index];
 				const props = layerTypes[l.type];
-				if (!(props && props.length > 0)) return;
-				props.forEach((prop) => {
-					newStyle.layers[index].paint[prop] = layer.opacity;
-				});
+				if (props && props.length > 0) {
+					props.forEach((prop) => {
+						newStyle.layers[index].paint[prop] = layer.opacity;
+					});
+				} else {
+					const visibility = layer.opacity === 0 ? 'none' : 'visible';
+					if (!newStyle.layers[index].layout) {
+						newStyle.layers[index].layout = {};
+					}
+					newStyle.layers[index].layout.visibility = visibility;
+				}
 			});
 			$mapStyleStore = newStyle;
 		}

--- a/packages/svelte-maplibre-storymap/src/lib/helpers.ts
+++ b/packages/svelte-maplibre-storymap/src/lib/helpers.ts
@@ -21,25 +21,38 @@ const getLayerPaintType = (map: Map, layer: string) => {
 
 export const setLayerOpacity = (map: Map, layer: StoryMapChapterLayerEvent) => {
 	const paintProps = getLayerPaintType(map, layer.layer);
-	if (!paintProps) return;
+	if (paintProps?.length > 0) {
+		paintProps.forEach(function (prop: string) {
+			let options = {};
+			if (layer.duration) {
+				const transitionProp = prop + '-transition';
+				options = { duration: layer.duration };
+				map.setPaintProperty(layer.layer, transitionProp, options);
+			}
+			map.setPaintProperty(layer.layer, prop, layer.opacity, options);
 
-	paintProps.forEach(function (prop: string) {
-		let options = {};
-		if (layer.duration) {
-			const transitionProp = prop + '-transition';
-			options = { duration: layer.duration };
-			map.setPaintProperty(layer.layer, transitionProp, options);
-		}
-		map.setPaintProperty(layer.layer, prop, layer.opacity, options);
+			const style = map.getStyle();
+			const l = style?.layers?.find((l) => l.id === layer?.layer);
+			if (l) {
+				if (!l.paint) {
+					l.paint = {};
+				}
+				l.paint[prop] = layer.opacity;
+				map.setStyle(style);
+			}
+		});
+	} else {
+		const visibility = layer.opacity === 0 ? 'none' : 'visible';
+		map.setLayoutProperty(layer.layer, 'visibility', visibility);
 
 		const style = map.getStyle();
 		const l = style?.layers?.find((l) => l.id === layer?.layer);
 		if (l) {
-			if (!l.paint) {
-				l.paint = {};
+			if (!l.layout) {
+				l.layout = {};
 			}
-			l.paint[prop] = layer.opacity;
+			l.layout.visibility = visibility;
 			map.setStyle(style);
 		}
-	});
+	}
 };

--- a/sites/geohub/src/components/pages/storymap/MapLocationSelector.svelte
+++ b/sites/geohub/src/components/pages/storymap/MapLocationSelector.svelte
@@ -144,10 +144,14 @@
 			if (index === -1) return;
 			const l = mapStyle.layers[index];
 			const props = layerTypes[l.type];
-			if (!(props && props.length > 0)) return;
-			props.forEach((prop: number) => {
-				mapStyle.layers[index].paint[prop] = layer.opacity;
-			});
+			if (props && props.length > 0) {
+				props.forEach((prop: number) => {
+					mapStyle.layers[index].paint[prop] = layer.opacity;
+				});
+			} else {
+				const visibility = layer.opacity === 0 ? 'none' : 'visible';
+				mapStyle.layers[index].layout.visibility = visibility;
+			}
 		});
 		return mapStyle;
 	};

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterMiniPreview.svelte
@@ -70,10 +70,14 @@
 			if (index === -1) return;
 			const l = newStyle.layers[index];
 			const props = layerTypes[l.type];
-			if (!(props && props.length > 0)) return;
-			props.forEach((prop) => {
-				newStyle.layers[index].paint[prop] = layer.opacity;
-			});
+			if (props && props.length > 0) {
+				props.forEach((prop) => {
+					newStyle.layers[index].paint[prop] = layer.opacity;
+				});
+			} else {
+				const visibility = layer.opacity === 0 ? 'none' : 'visible';
+				newStyle.layers[index].layout.visibility = visibility;
+			}
 		});
 		newStyle.bearing = chapter.location.bearing;
 		newStyle.pitch = chapter.location.pitch;

--- a/sites/geohub/src/components/pages/storymap/StorymapEditPreview.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapEditPreview.svelte
@@ -81,10 +81,14 @@
 				if (index === -1) return;
 				const l = newStyle.layers[index];
 				const props = layerTypes[l.type];
-				if (!(props && props.length > 0)) return;
-				props.forEach((prop) => {
-					newStyle.layers[index].paint[prop] = layer.opacity;
-				});
+				if (props && props.length > 0) {
+					props.forEach((prop) => {
+						newStyle.layers[index].paint[prop] = layer.opacity;
+					});
+				} else {
+					const visibility = layer.opacity === 0 ? 'none' : 'visible';
+					newStyle.layers[index].layout.visibility = visibility;
+				}
 			});
 
 			return newStyle;


### PR DESCRIPTION
…since its layer type has not opacity.

Thank you for submitting a pull request!

## Description

hillshade layer has no opacity, so use visibility prop instead

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
