### PR TITLE
fix: collapse storymap legend in small screen as default

### DIFF
--- a/.changeset/tidy-jokes-compare.md
+++ b/.changeset/tidy-jokes-compare.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-maplibre-storymap": patch
+---
+
+fix: collapse storymap legend in small screen as default

--- a/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
@@ -83,6 +83,7 @@
 	export let width = '268px';
 	export let origin = '';
 	export let position: ControlPosition = 'bottom-left';
+	export let isExpanded = true;
 
 	let control: MaplibreLegendControl | undefined;
 	let contentDiv: HTMLDivElement;
@@ -232,7 +233,7 @@
 </script>
 
 <div class="contents" bind:this={contentDiv}>
-	<FloatingPanel title="Legend" showClose={false}>
+	<FloatingPanel title="Legend" showClose={false} bind:isExpanded>
 		{#if legend?.length > 1}
 			<div class="is-flex is-align-items-center layer-header px-4 pt-2">
 				<div class="layer-header-buttons buttons">

--- a/packages/svelte-maplibre-storymap/src/lib/StoryMap.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/StoryMap.svelte
@@ -61,6 +61,10 @@
 	let slideIndex = 0;
 	let scrollY = 0;
 	let scrollBeyondFooter = false;
+	let innerWidth = 0;
+
+	// collapse legend for small screen device
+	$: isLegendExpanded = innerWidth < 768 ? false : true;
 
 	let sky: SkyControl;
 
@@ -230,7 +234,7 @@
 	}, 300);
 </script>
 
-<svelte:window bind:scrollY on:scrollend={handleOnScrollEnd} />
+<svelte:window bind:innerWidth bind:scrollY on:scrollend={handleOnScrollEnd} />
 
 <div class="storymap-main" style="margin-top: {marginTop}px;">
 	{#if config.showProgress !== false}
@@ -288,6 +292,7 @@
 					bind:styleId={activeStyleId}
 					bind:origin={activeStyleOrigin}
 					bind:position={legendPosition}
+					bind:isExpanded={isLegendExpanded}
 				/>
 			{/key}
 		{/key}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

In mobile, legend can be hidden as default, so it does not interrupt users to see stories.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
