### PR TITLE
fix: use colormap defined in titiler algorithm by default

### DIFF
--- a/.changeset/five-tips-float.md
+++ b/.changeset/five-tips-float.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use the colormap defined in the titiler algorithm by default

--- a/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
+++ b/sites/geohub/src/components/util/stac/StacApiExplorer.svelte
@@ -548,7 +548,7 @@
 					const data: LayerCreationInfo & { geohubLayer?: Layer } = await rasterTile.add(
 						undefined,
 						undefined,
-						undefined,
+						selectedTool?.outputs?.colormap_name,
 						selectedAlgorithmName
 					);
 					data.geohubLayer = {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Use defined colormap in titiler algorithm by default for tools
Fixes #4023 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
