### PR TITLE
fix: when users go back to storymap header, restore all style and legend setting to be initial state.

### DIFF
--- a/.changeset/nine-lobsters-chew.md
+++ b/.changeset/nine-lobsters-chew.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-maplibre-storymap": patch
+---
+
+fix: when users go back to storymap header, restore all style and legend setting to be initial state.

--- a/packages/svelte-maplibre-storymap/src/lib/StoryMap.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/StoryMap.svelte
@@ -193,6 +193,9 @@
 	const handleOnScrollEnd = () => {
 		if (scrollY === 0) {
 			slideIndex = 0;
+			showLegend = false;
+			handleScrollToIndex(slideIndex);
+			return;
 		} else {
 			const lastChapter = $configStore.chapters[$configStore.chapters.length - 1];
 			const lastChapterElement = document.getElementById(lastChapter.id);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
