### PR TITLE
Fix/3992 fix legend position

### DIFF
--- a/.changeset/olive-cows-bow.md
+++ b/.changeset/olive-cows-bow.md
@@ -2,4 +2,5 @@
 "@undp-data/svelte-maplibre-storymap": patch
 ---
 
-fix: fix legendPosition type error.
+- fix: fix legendPosition type error.
+- fix: set default width of legend as 384px.

--- a/.changeset/olive-cows-bow.md
+++ b/.changeset/olive-cows-bow.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-maplibre-storymap": patch
+---
+
+fix: fix legendPosition type error.

--- a/.changeset/small-poems-joke.md
+++ b/.changeset/small-poems-joke.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fix legend position always to be at bottom-left

--- a/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
+++ b/packages/svelte-maplibre-storymap/src/lib/MaplibreLegendControl.svelte
@@ -80,7 +80,7 @@
 
 	export let map: Map;
 	export let styleId: string;
-	export let width = '268px';
+	export let width = 384;
 	export let origin = '';
 	export let position: ControlPosition = 'bottom-left';
 	export let isExpanded = true;
@@ -128,7 +128,7 @@
 		try {
 			isLoading = true;
 
-			const res = await fetch(`${origin}/api/style/${styleId}/legend?width=${width}`);
+			const res = await fetch(`${origin}/api/style/${styleId}/legend?width=${width - 32}px`);
 			legend = await res.json();
 
 			setLayerOpacity();
@@ -260,7 +260,12 @@
 	};
 </script>
 
-<div class="contents" bind:this={contentDiv} hidden={numberOfVisibleLayers === 0}>
+<div
+	class="contents"
+	bind:this={contentDiv}
+	hidden={numberOfVisibleLayers === 0}
+	style="width: {width}px;"
+>
 	<FloatingPanel title="Legend" showClose={false} bind:isExpanded>
 		{#if legend?.length > 1 && showInteractive}
 			<div class="is-flex is-align-items-center layer-header px-4 pt-2">
@@ -292,7 +297,7 @@
 			</div>
 		{/if}
 
-		<div class="legend-contents">
+		<div class="legend-contents" style="width: {width}px;">
 			{#if isLoading}
 				<div class="is-flex is-justify-content-center">
 					<Loader size="small" />
@@ -341,8 +346,6 @@
 </div>
 
 <style lang="scss">
-	$width: 300px;
-
 	button {
 		border: none;
 		outline: none;
@@ -352,7 +355,6 @@
 	.contents {
 		background-color: white;
 		z-index: 10;
-		width: $width;
 
 		.layer-header-buttons {
 			margin-left: auto;
@@ -363,8 +365,7 @@
 		}
 
 		.legend-contents {
-			width: $width;
-			max-height: $width;
+			max-height: 300px;
 			overflow-y: auto;
 			overflow-x: hidden;
 		}

--- a/packages/svelte-maplibre-storymap/src/lib/interfaces/StoryMapChapter.ts
+++ b/packages/svelte-maplibre-storymap/src/lib/interfaces/StoryMapChapter.ts
@@ -121,5 +121,5 @@ export interface StoryMapChapter {
 	/**
 	 * Visibility of Legend. Default is true. If true, show legend if style is geohub map.
 	 */
-	showLegend?: false;
+	showLegend?: boolean;
 }

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
@@ -391,20 +391,6 @@
 									/>
 								</div>
 							</FieldControl>
-							{#if $activeChapterStore.showLegend}
-								<FieldControl title="Select position" showHelp={false} showHelpPopup={false}>
-									<div slot="control" class="select is-fullwidth">
-										<select
-											bind:value={$activeChapterStore.legendPosition}
-											on:change={handleChange}
-										>
-											{#each mapControlPositions as item}
-												<option value={item.value}>{item.title}</option>
-											{/each}
-										</select>
-									</div>
-								</FieldControl>
-							{/if}
 						</div>
 						<div slot="buttons">
 							<Help>Settings to show or hide a legend for the slide.</Help>

--- a/sites/geohub/src/routes/(app)/storymaps/[[id]]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(app)/storymaps/[[id]]/edit/+page.svelte
@@ -233,6 +233,8 @@
 				mapInteractive: false,
 				mapNavigationPosition: data.config.StorymapChapterNavigationControlPosition,
 				spinGlobe: false,
+				showLegend: true,
+				legendPosition: 'bottom-left',
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				style_id: lastChapter?.style_id ?? style_id,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #3992

- show legend always at bottom-left
- set width as 384px for legend
- but I keep accordion for each layer. I believe collapse/expand legend is useful. 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
