### PR TITLE
fix: fixed microsoft-pc stac management page bug, and fixed bug of sh…

### DIFF
--- a/.changeset/gold-eagles-report.md
+++ b/.changeset/gold-eagles-report.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed microsoft-pc stac management page bug, and fixed bug of showing sentinel 1 asset

--- a/sites/geohub/src/components/pages/home/MapStyleCardList.svelte
+++ b/sites/geohub/src/components/pages/home/MapStyleCardList.svelte
@@ -16,8 +16,6 @@
 	export let mode: 'browse' | 'select' = 'browse';
 	export let selectedId = '';
 
-	console.log(mode);
-
 	const handlePaginationClicked = async (url: string) => {
 		const apiUrl = new URL(url);
 		dispatch('reload', { url: apiUrl });

--- a/sites/geohub/src/components/util/MiniMap.svelte
+++ b/sites/geohub/src/components/util/MiniMap.svelte
@@ -102,6 +102,7 @@
 					const stacType = feature.properties.tags?.find((tag) => tag.key === 'stacType');
 					if (stacType?.value === 'collection') return;
 					const rasterInfo: RasterTileMetadata = metadata;
+					if (!rasterInfo.band_metadata) return;
 					let bandIndex = rasterInfo.band_metadata.findIndex((b) => {
 						return b[0] === band;
 					});

--- a/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
+++ b/sites/geohub/src/lib/stac/MicrosoftPlanetaryStac.ts
@@ -212,6 +212,10 @@ export default class MicrosoftPlanetaryStac implements StacTemplate {
 		const assetItem = item.assets[assetName];
 		let url = assetItem?.href;
 
+		if (!url) {
+			return undefined as unknown as DatasetFeature;
+		}
+
 		const providers: Tag[] = this.stacCollection.providers?.map((p) => {
 			return { key: 'provider', value: p.name };
 		});

--- a/sites/geohub/src/routes/(app)/management/stac/api/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/management/stac/api/[id]/+page.svelte
@@ -31,7 +31,9 @@
 
 	let toolTags: Tag[] = [];
 	let isInitialising: Promise<void>;
-	let accessLevel: AccessLevel = data.dataset.properties.access_level ?? AccessLevel.PUBLIC;
+	let accessLevel: AccessLevel = isRegistered
+		? data.dataset.properties.access_level
+		: AccessLevel.PUBLIC;
 	let stacCollections: StacCollections;
 	let filteredCollection: StacCollection[] = [];
 	let geohubDatasets: DatasetFeatureCollection;


### PR DESCRIPTION
…owing sentinel 1 asset

Thank you for submitting a pull request!

## Description

fixes #4097

also fixed bug of showing sentinel 1 data

sentinel 1 of `Sentinel 1 Level-1 Ground Range Detected (GRD)` has `vh` and `vv` assets, but for `vh` asset is not available for all items, thus it causes an error in stac api explorer. I show the warning message if asset is not available for selected item.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
