### PR TITLE
fix: hide EA raster layer when show AnalyzeBivariate component.

### DIFF
--- a/.changeset/wet-ants-wonder.md
+++ b/.changeset/wet-ants-wonder.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: hide EA raster layer when show AnalyzeBivariate component.

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/AnalyzeBivariate.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/AnalyzeBivariate.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { initTooltipTippy } from '@undp-data/svelte-undp-components';
 	import { onMount } from 'svelte';
+	import { map } from '../stores';
 	import { loadAdmin, reloadAdmin } from '../utils/adminLayer';
+	import { UNDP_DASHBOARD_RASTER_LAYER_ID } from './TimeSlider.svelte';
 	export let loadAdminLabels = true;
 	export let propertyA = `hrea_2020`;
 	export let propertyB = `hrea_2012`;
@@ -73,6 +75,13 @@
 	};
 
 	onMount(() => {
+		if ($map) {
+			const rasterLayer = $map.getLayer(UNDP_DASHBOARD_RASTER_LAYER_ID);
+			if (rasterLayer) {
+				$map.setLayoutProperty(UNDP_DASHBOARD_RASTER_LAYER_ID, 'visibility', 'none');
+			}
+		}
+
 		loadAdmin(true);
 		reloadAdmin(undefined, loadAdminLabels, colorExpression);
 	});

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/AnalyzeBivariate.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/AnalyzeBivariate.svelte
@@ -76,9 +76,11 @@
 
 	onMount(() => {
 		if ($map) {
-			const rasterLayer = $map.getLayer(UNDP_DASHBOARD_RASTER_LAYER_ID);
-			if (rasterLayer) {
-				$map.setLayoutProperty(UNDP_DASHBOARD_RASTER_LAYER_ID, 'visibility', 'none');
+			const style = $map.getStyle();
+			for (const layer of style.layers) {
+				if (layer.id.startsWith(UNDP_DASHBOARD_RASTER_LAYER_ID.replace('{year}', ''))) {
+					$map.setLayoutProperty(layer.id, 'visibility', 'none');
+				}
 			}
 		}
 

--- a/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
+++ b/sites/geohub/src/routes/(map)/dashboards/electricity/components/TimeSlider.svelte
@@ -1,3 +1,8 @@
+<script lang="ts" context="module">
+	export const UNDP_DASHBOARD_RASTER_LAYER_ID = 'dashboard-electricity-raster-layer';
+	export const UNDP_DASHBOARD_RASTER_SOURCE_ID = 'dashboard-electricity-raster-source';
+</script>
+
 <script lang="ts">
 	import { page } from '$app/stores';
 	import type { RasterLayerSpecification, SourceSpecification } from 'maplibre-gl';
@@ -21,8 +26,6 @@
 		ELECTRICITY_DATATYPE_CONTEXT_KEY,
 		type ElectricityDataTypeStore
 	} from '../stores/electricityDataType';
-	const UNDP_DASHBOARD_RASTER_LAYER_ID = 'dashboard-electricity-raster-layer';
-	const UNDP_DASHBOARD_RASTER_SOURCE_ID = 'dashboard-electricity-raster-source';
 
 	const titilerUrl = $page.data.titilerUrl;
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

previously, raster layer was still shown when users switch to the third menu. I just simply set visibility: none for raster layer. When second menu component is mounted, it will recreate new raster.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
