### PR TITLE
fix: removed max-height from storymap slide card content itself, but added max-height for storymap editor preview.

### DIFF
--- a/.changeset/fluffy-islands-draw.md
+++ b/.changeset/fluffy-islands-draw.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-maplibre-storymap": patch
+"geohub": patch
+---
+
+fix: removed max-height from storymap slide card content itself, but added max-height for storymap editor preview.

--- a/packages/svelte-maplibre-storymap/src/lib/css/dark/chapter.scss
+++ b/packages/svelte-maplibre-storymap/src/lib/css/dark/chapter.scss
@@ -17,7 +17,6 @@
 			border: solid 0.25px #d4d6d8;
 			background-color: rgba(14, 14, 14, 0.9);
 			height: fit-content;
-			max-height: 80%;
 			pointer-events: all;
 			font-family: ProximaNova, sans-serif;
 

--- a/packages/svelte-maplibre-storymap/src/lib/css/light/chapter.scss
+++ b/packages/svelte-maplibre-storymap/src/lib/css/light/chapter.scss
@@ -16,7 +16,6 @@
 			border: solid 0.25px #d4d6d8;
 			background-color: rgba(255, 255, 255, 0.9);
 			height: fit-content;
-			max-height: 80%;
 			pointer-events: all;
 			font-family: ProximaNova, sans-serif;
 

--- a/sites/geohub/src/components/pages/storymap/StorymapEditPreview.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapEditPreview.svelte
@@ -232,5 +232,10 @@
 			margin: 0 auto !important;
 			width: 85% !important;
 		}
+
+		:global(.card-content) {
+			max-height: 50vh !important;
+			overflow-y: auto !important;
+		}
 	}
 </style>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4212

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
