### PR TITLE
fix: only register pubsub listener when status is not in progress

### DIFF
--- a/.changeset/lovely-turkeys-behave.md
+++ b/.changeset/lovely-turkeys-behave.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: only register pubsub listener when status is not in progress

--- a/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRow.svelte
+++ b/sites/geohub/src/components/pages/data/ingesting/IngestingDatasetRow.svelte
@@ -171,9 +171,11 @@
 	};
 
 	onMount(() => {
-		// register websocket callback if status is 'In progress'
-		if (wpsClient) {
-			wpsClient.on('group-message', onMessage);
+		if (!['Processed', 'Published', 'Failed'].includes(status)) {
+			// register websocket callback if status is 'In progress'
+			if (wpsClient) {
+				wpsClient.on('group-message', onMessage);
+			}
 		}
 	});
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I saw warning message that registered so many pubsub event listener. fixed to only register listener for in progress status

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
