### PR TITLE
fix: previously user settings are remained even after user sign out. copied object is passed to Object.assign to prevent default value is changed.

### DIFF
--- a/.changeset/witty-knives-invite.md
+++ b/.changeset/witty-knives-invite.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: previously user settings are remained even after user sign out. It was occured by that Object.assign update DefaultUserConfig variable in nodejs side. Now copied object is passed to Object.assign to prevent default value is changed.

--- a/sites/geohub/src/routes/api/settings/+server.ts
+++ b/sites/geohub/src/routes/api/settings/+server.ts
@@ -26,6 +26,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 export const GET: RequestHandler = async ({ locals }) => {
 	const session = await locals.auth();
 	if (!session) {
+		console.log(DefaultUserConfig);
 		return new Response(JSON.stringify(DefaultUserConfig), {});
 	}
 	const user_email = session.user?.email;
@@ -37,7 +38,10 @@ export const GET: RequestHandler = async ({ locals }) => {
 		// no settings found for this user in the database
 		return new Response(JSON.stringify(DefaultUserConfig), {});
 	} else {
-		const data: UserConfig = Object.assign(DefaultUserConfig, settings.settings as UserConfig);
+		const data: UserConfig = Object.assign(
+			JSON.parse(JSON.stringify(DefaultUserConfig)),
+			settings.settings as UserConfig
+		);
 		if (typeof data.DataPageIngestingJoinVectorTiles === 'string') {
 			data.DataPageIngestingJoinVectorTiles =
 				data.DataPageIngestingJoinVectorTiles === 'true' ? true : false;


### PR DESCRIPTION


Thank you for submitting a pull request!

## Description

fixes #4280

fix: previously user settings are remained even after user sign out. It was occured by that Object.assign update DefaultUserConfig variable in nodejs side. Now copied object is passed to Object.assign to prevent default value is changed.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
