### PR TITLE
fix: fixed bug of removing dataset from style.json if dataset access level is orgnaization and signed user is same organization domain

### DIFF
--- a/.changeset/fluffy-cheetahs-brake.md
+++ b/.changeset/fluffy-cheetahs-brake.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of removing dataset from style.json if dataset access level is orgnaization and signed user is same organization domain


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

If a public style includes organization level datasets, datasets will be removed from maps even if signed user is same organization domain of creator. I fixed this issue by checking signed in user domain and creator domain.

![image](https://github.com/user-attachments/assets/c9a58084-dc2a-4a82-8f0e-10bf41fcd7dc)


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
