### PR TITLE
fix: renew azure sas token for saved default style.

### DIFF
--- a/.changeset/strange-pears-sort.md
+++ b/.changeset/strange-pears-sort.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: renew azure sas token for saved default style.

--- a/sites/geohub/src/routes/api/datasets/[id]/style/[layer]/[type]/+server.ts
+++ b/sites/geohub/src/routes/api/datasets/[id]/style/[layer]/[type]/+server.ts
@@ -1,5 +1,5 @@
 import { AccessLevel, Permission } from '$lib/config/AppConfig';
-import { createAttributionFromTags, getDomainFromEmail } from '$lib/helper';
+import { createAttributionFromTags, getBase64EncodedUrl, getDomainFromEmail } from '$lib/helper';
 import {
 	createDatasetLinks,
 	getDatasetById,
@@ -80,6 +80,20 @@ export const GET: RequestHandler = async ({ params, locals, url, fetch }) => {
 			if (url.origin !== titilerUrl.origin) {
 				tiles[i] = tiles[i].replace(url.origin, titilerUrl.origin);
 			}
+			// renew sas token from dataset.properties.url
+			const tileUrlObj = new URL(tiles[i]);
+			tileUrlObj.searchParams.set(
+				'url',
+				encodeURIComponent(getBase64EncodedUrl(dataset.properties.url))
+			);
+			tiles[i] = decodeURI(tileUrlObj.href);
+		}
+	} else {
+		const vectorSource = data.source as VectorSourceSpecification;
+		const tileUrl = vectorSource.url;
+		// renew sas token from dataset.properties.url
+		if (tileUrl && tileUrl.startsWith('pmtiles://')) {
+			vectorSource.url = dataset.properties.url;
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

there was a bug not renewing sas token for saved default style, thus some datasets which default style was saved 1 year ago had 403 error for both pmtiles and cog.
In default style endpoint, now sas url is renewed

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
