### PR TITLE
fix: move sveltekit and svelte from dependencies to devDependencies.

### DIFF
--- a/.changeset/wet-apples-swim.md
+++ b/.changeset/wet-apples-swim.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-undp-components": patch
+"@undp-data/svelte-undp-design": patch
+---
+
+fix: move sveltekit and svelte from dependencies to devDependencies.

--- a/packages/svelte-undp-components/package.json
+++ b/packages/svelte-undp-components/package.json
@@ -40,7 +40,6 @@
 		"!dist/**/*.mdx.*"
 	],
 	"peerDependencies": {
-		"@sveltejs/kit": "^2.0.0",
 		"svelte": "^4.0.0 || ^5.0.0"
 	},
 	"devDependencies": {

--- a/packages/svelte-undp-design/package.json
+++ b/packages/svelte-undp-design/package.json
@@ -36,6 +36,7 @@
 		"@storybook/sveltekit": "^8.3.4",
 		"@storybook/test": "^8.3.4",
 		"@sveltejs/adapter-auto": "^3.2.5",
+		"@sveltejs/kit": "^2.6.1",
 		"@sveltejs/package": "^2.3.5",
 		"@sveltejs/vite-plugin-svelte": "^3.1.2",
 		"@testing-library/svelte": "^5.2.3",
@@ -54,6 +55,7 @@
 		"prettier-plugin-svelte": "^3.2.7",
 		"sass": "^1.79.4",
 		"storybook": "^8.3.4",
+		"svelte": "^4.2.19",
 		"svelte-check": "^4.0.4",
 		"svelte-htm": "^1.2.0",
 		"tslib": "^2.7.0",
@@ -64,10 +66,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/kit": "^2.6.1",
 		"filesize": "^10.1.6",
 		"marked": "^14.1.2",
-		"svelte": "^4.2.19",
 		"svelte-carousel": "^1.0.25",
 		"uuid": "^10.0.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,18 +493,12 @@ importers:
 
   packages/svelte-undp-design:
     dependencies:
-      '@sveltejs/kit':
-        specifier: ^2.6.1
-        version: 2.7.3(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4))
       filesize:
         specifier: ^10.1.6
         version: 10.1.6
       marked:
         specifier: ^14.1.2
         version: 14.1.3
-      svelte:
-        specifier: ^4.2.19
-        version: 4.2.19
       svelte-carousel:
         specifier: ^1.0.25
         version: 1.0.25
@@ -542,6 +536,9 @@ importers:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.5
         version: 3.3.1(@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4)))
+      '@sveltejs/kit':
+        specifier: ^2.6.1
+        version: 2.7.3(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4)))(svelte@4.2.19)(vite@5.4.10(@types/node@22.8.1)(sass@1.80.4))
       '@sveltejs/package':
         specifier: ^2.3.5
         version: 2.3.7(svelte@4.2.19)(typescript@5.6.3)
@@ -596,6 +593,9 @@ importers:
       storybook:
         specifier: ^8.3.4
         version: 8.3.6
+      svelte:
+        specifier: ^4.2.19
+        version: 4.2.19
       svelte-check:
         specifier: ^4.0.4
         version: 4.0.5(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

because there were sveltekit and svelte in dependencies at both packages, this seems blocking to upgrade svelte to v5 in geohub and static api.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
