### PR TITLE
fix: related to #4315, this fixes sampling method to classification for raster dataset. It samples data from histogram data distribution if histogram from titiler is available by considering rescaled values.

### DIFF
--- a/.changeset/mighty-tigers-approve.md
+++ b/.changeset/mighty-tigers-approve.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: related to #4315, this fixes sampling method to classification for raster dataset. It samples data from histogram data distribution if histogram from titiler is available by considering rescaled values.

--- a/.changeset/sharp-dogs-smoke.md
+++ b/.changeset/sharp-dogs-smoke.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: changed default classificaiton method from equidistant to natural break.

--- a/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
+++ b/sites/geohub/src/components/maplibre/raster/RasterClassifyLegend.svelte
@@ -12,7 +12,7 @@
 		updateIntervalValues,
 		updateParamsInURL
 	} from '$lib/helper';
-	import type { BandMetadata, ColorMapRow, RasterTileMetadata } from '$lib/types';
+	import type { BandMetadata, ColorMapRow, RasterLayerStats, RasterTileMetadata } from '$lib/types';
 	import {
 		CLASSIFICATION_METHOD_CONTEXT_KEY,
 		COLORMAP_NAME_CONTEXT_KEY,
@@ -51,11 +51,22 @@
 	let colorMapRows: Array<ColorMapRow> = [];
 	let layerMax: number;
 	let layerMin: number;
+	let histogram: { bins: number[]; count: number[] };
 
 	if ('stats' in metadata) {
 		const band = metadata.active_band_no;
-		layerMin = Number(metadata.stats[band].min);
-		layerMax = Number(metadata.stats[band].max);
+		if (band) {
+			const rasterLayerStats = metadata.stats as RasterLayerStats;
+			const bandStats = rasterLayerStats[band];
+			layerMin = Number(bandStats.min);
+			layerMax = Number(bandStats.max);
+			if (bandStats.histogram && bandStats.histogram.length === 2) {
+				histogram = {
+					bins: bandStats.histogram[1],
+					count: bandStats.histogram[0]
+				};
+			}
+		}
 	} else {
 		const bandIndex = getActiveBandIndex(metadata);
 		const bandMetaStats = metadata['band_metadata'][bandIndex][1] as BandMetadata;
@@ -141,7 +152,8 @@
 				$classificationMethodStore,
 				isClassificationMethodEdited,
 				percentile98,
-				$colorMapNameStore
+				$colorMapNameStore,
+				histogram
 			);
 		}
 	};

--- a/sites/geohub/src/lib/config/DefaultUserConfig/ClassificationMethod.ts
+++ b/sites/geohub/src/lib/config/DefaultUserConfig/ClassificationMethod.ts
@@ -1,4 +1,4 @@
 import { ClassificationMethodTypes } from '$lib/config/AppConfig';
 
 export const ClassificationMethod: ClassificationMethodTypes =
-	ClassificationMethodTypes.EQUIDISTANT;
+	ClassificationMethodTypes.NATURAL_BREAK;

--- a/sites/geohub/src/lib/helper/getSampleFromHistogram.test.ts
+++ b/sites/geohub/src/lib/helper/getSampleFromHistogram.test.ts
@@ -25,4 +25,21 @@ describe('getSampleFromHistogram', () => {
 		const samplesList = getSampleFromHistogram({ bins: histogram[1], count: histogram[0] }, 1000);
 		expect(samplesList.length).toEqual(1000);
 	});
+
+	it('titiler histogram) should have the length of the resulting array be equal to the numberOfSamples excluded specified min and max', () => {
+		const histogram = [
+			[21, 15, 28832, 326202, 140385, 71575, 13629, 991, 759, 347],
+			[100, 502.3, 904.6, 1306.9, 1709.2, 2111.5, 2513.8, 2916.1, 3318.4, 3720.7000000000003, 4123]
+		];
+
+		const samplesList = getSampleFromHistogram(
+			{ bins: histogram[1], count: histogram[0] },
+			1000,
+			100,
+			1300
+		);
+		expect(samplesList.length).toEqual(49);
+		expect(Math.min(...samplesList) >= 100).toBeTruthy();
+		expect(Math.max(...samplesList) <= 1300).toBeTruthy();
+	});
 });

--- a/sites/geohub/src/lib/helper/getSampleFromHistogram.ts
+++ b/sites/geohub/src/lib/helper/getSampleFromHistogram.ts
@@ -4,11 +4,15 @@ import { getSampleFromInterval } from './getSampleFromInterval';
  * get sampled values according to actual data distribution of histogram
  * @param histogram histogram data with count and bins
  * @param numberOfSamples the number of sampled items (eg., 1000)
+ * @param min Optional. To ensure samples to be less than or equal to min value
+ * @param max Optional. To ensure samples to be more than or equal to max value
  * @returns an array of sampled numbers based on data distribution of histogram.
  */
 export const getSampleFromHistogram = (
 	histogram: { bins: number[]; count: number[] },
-	numberOfSamples: number
+	numberOfSamples: number,
+	min?: number,
+	max?: number
 ) => {
 	const totalCount = histogram.count.reduce((acc, count) => acc + count, 0);
 	const probabilities = histogram.count.map((count) => count / totalCount);
@@ -17,17 +21,38 @@ export const getSampleFromHistogram = (
 	// make a list of min/max for each count
 	const ranges: number[][] = [];
 	for (let i = 0; i < histogram.bins.length - 1; i++) {
-		const min = histogram.bins[i];
-		const max = histogram.bins[i + 1];
-		ranges.push([min, max]);
+		const _min = histogram.bins[i];
+		const _max = histogram.bins[i + 1];
+		ranges.push([_min, _max]);
 	}
 
 	// get random sampled values from min/max for each count
 	const result: number[] = [];
 	ranges.forEach((range, index) => {
-		const values = getSampleFromInterval(range[0], range[1], sampleCount[index]);
+		let start = range[0];
+		let end = range[1];
+		if (min && max) {
+			// if min and max are passed, make sure returning samples within the range
+			if (!isBetween(start, min, max) && !isBetween(end, min, max)) {
+				// if both are out of ranges, skip to next.
+				return;
+			}
+			if (!isBetween(start, min, max)) {
+				// if start is out of ranges, use min instead
+				start = min;
+			}
+			if (!isBetween(end, min, max)) {
+				// if end is out of ranges, use max instead
+				end = max;
+			}
+		}
+		const values = getSampleFromInterval(start, end, sampleCount[index]);
 		result.push(...values);
 	});
 
 	return result;
+};
+
+const isBetween = (val: number, min: number, max: number) => {
+	return val >= min && val <= max;
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- fixes the same issue #4315 for raster classification. Adapt getSamplesFromHistogram to consider min and max values of rescaled.
- changed default classification method to Natural Break, so it can classify with same data distribution of histogram.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
