### PR TITLE
fix: hide layer preview setting if only a line layer in a dataset.

### DIFF
--- a/.changeset/blue-dragons-grow.md
+++ b/.changeset/blue-dragons-grow.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: hide layer preview setting if only a line layer in a dataset.

--- a/sites/geohub/src/components/pages/data/datasets/DatasetPreview.svelte
+++ b/sites/geohub/src/components/pages/data/datasets/DatasetPreview.svelte
@@ -153,7 +153,11 @@
 <div class="preview">
 	{#if !is_raster}
 		{#if tilestatsLayers?.length > 0}
-			<div class="vector-config p-2">
+			<div
+				class="vector-config p-2"
+				hidden={tilestatsLayers?.length === 1 &&
+					selectedVectorLayer.geometry.toLowerCase() === 'linestring'}
+			>
 				{#if tilestatsLayers.length > 1}
 					<div class="field">
 						<!-- svelte-ignore a11y-label-has-associated-control -->


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
