### PR TITLE
fix: fixed drizzle schema.ts to use customType for geometry columns.

### DIFF
--- a/.changeset/proud-pots-look.md
+++ b/.changeset/proud-pots-look.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed drizzle schema.ts to use customType for geometry columns.

--- a/sites/geohub/drizzle/meta/_journal.json
+++ b/sites/geohub/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1726151081473,
-      "tag": "0000_conscious_madelyne_pryor",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1726151081473,
+			"tag": "0000_conscious_madelyne_pryor",
+			"breakpoints": true
+		}
+	]
 }

--- a/sites/geohub/src/lib/server/schema.ts
+++ b/sites/geohub/src/lib/server/schema.ts
@@ -9,14 +9,16 @@ import {
 	serial,
 	timestamp,
 	boolean,
-	geometry,
+	// geometry,
 	uuid,
 	doublePrecision,
 	jsonb,
 	foreignKey,
 	primaryKey,
-	smallint
+	smallint,
+	customType
 } from 'drizzle-orm/pg-core';
+import type { Point, Polygon } from 'geojson';
 // import { sql } from 'drizzle-orm';
 
 export const geohub = pgSchema('geohub');
@@ -94,7 +96,13 @@ export const datasetInGeohub = geohub.table(
 		url: varchar('url').notNull(),
 		isRaster: boolean('is_raster').notNull(),
 		license: varchar('license'),
-		bounds: geometry('bounds', { type: 'polygon', srid: 4326 }).notNull(),
+		// to fix the bug of geometry, use customType for time-being
+		// https://github.com/drizzle-team/drizzle-orm/issues/3040#issuecomment-2451014133
+		bounds: customType<{ data: Polygon }>({
+			dataType() {
+				return 'geometry(Polygon,4326)';
+			}
+		})('bounds').notNull(),
 		createdat: timestamp('createdat', { withTimezone: true, mode: 'string' }).notNull(),
 		updatedat: timestamp('updatedat', { withTimezone: true, mode: 'string' }),
 		name: varchar('name'),
@@ -164,7 +172,13 @@ export const storymapChapterInGeohub = geohub.table('storymap_chapter', {
 	rotateAnimation: boolean('rotate_animation').default(false).notNull(),
 	spinglobe: boolean('spinglobe').default(false).notNull(),
 	hidden: boolean('hidden').default(false).notNull(),
-	center: geometry('center', { type: 'point', srid: 4326 }).notNull(),
+	// to fix the bug of geometry, use customType for time-being
+	// https://github.com/drizzle-team/drizzle-orm/issues/3040#issuecomment-2451014133
+	center: customType<{ data: Point }>({
+		dataType() {
+			return 'geometry(Point,4326)';
+		}
+	})('center').notNull(),
 	zoom: doublePrecision('zoom').notNull(),
 	bearing: doublePrecision('bearing').default(0).notNull(),
 	pitch: doublePrecision('pitch').default(0).notNull(),


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

because the bug of drizzle, `geometry('Polygon', 4136)` is turned into `geometry('Point')` and, srid will be dropped always. I changed to use custom data type to avoid this bug for time being until it will be fixed in drizzle

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
