### PR TITLE
fix: fixed bug of changing symbol layer order when style is fetched.

### DIFF
--- a/.changeset/metal-rice-prove.md
+++ b/.changeset/metal-rice-prove.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of changing symbol layer order when style is saved.

--- a/sites/geohub/src/lib/server/helpers/getStyleById.ts
+++ b/sites/geohub/src/lib/server/helpers/getStyleById.ts
@@ -172,26 +172,29 @@ export const getStyleById = async (id: number, url: URL, email?: string, is_supe
 			// 	// skip if not geohub layer
 			if (baseStyle.layers.find((l) => l.id === savedLayer.id)) continue;
 			const currentIndex = style.style.layers.indexOf(savedLayer);
-
-			if (currentIndex > totalBaseLayerLength) {
-				// if it exists in the last part of layers
-				updatedLayers.push(savedLayer);
-			} else {
-				// if it exists in the middle of layers (for raster mostly)
-				const beforeOld = style.style.layers[currentIndex - 1];
-				const beforeNew = updatedLayers[currentIndex - 1];
-				if (beforeOld.id === beforeNew.id) {
-					// if layer IDs before this layer are the same, insert it at the same index
-					updatedLayers.splice(currentIndex, 0, savedLayer);
+			if (savedLayer.type === 'raster' || savedLayer.type === 'hillshade') {
+				if (currentIndex > totalBaseLayerLength) {
+					// if it exists in the last part of layers
+					updatedLayers.push(savedLayer);
 				} else {
-					// otherwise insert layer before first symbol layer (style structure might have been changed at all)
-					const firstSymbolLayerId = getFirstSymbolLayerId(updatedLayers);
-					let idx = updatedLayers.length - 1;
-					if (firstSymbolLayerId) {
-						idx = updatedLayers.findIndex((l) => l.id === firstSymbolLayerId);
+					// if it exists in the middle of layers (for raster mostly)
+					const beforeOld = style.style.layers[currentIndex - 1];
+					const beforeNew = updatedLayers[currentIndex - 1];
+					if (beforeOld.id === beforeNew.id) {
+						// if layer IDs before this layer are the same, insert it at the same index
+						updatedLayers.splice(currentIndex, 0, savedLayer);
+					} else {
+						// otherwise insert layer before first symbol layer (style structure might have been changed at all)
+						const firstSymbolLayerId = getFirstSymbolLayerId(updatedLayers);
+						let idx = updatedLayers.length - 1;
+						if (firstSymbolLayerId) {
+							idx = updatedLayers.findIndex((l) => l.id === firstSymbolLayerId);
+						}
+						updatedLayers.splice(idx, 0, savedLayer);
 					}
-					updatedLayers.splice(idx, 0, savedLayer);
 				}
+			} else {
+				updatedLayers.push(savedLayer);
 			}
 		}
 		style.style.layers = [...updatedLayers];


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I found when we fetch style, style GET endpoint changed vector layer position from original one.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
