### PR TITLE
fix: improved logic to update saved map's base style from the latest if any different is presented

### DIFF
--- a/.changeset/tough-poems-give.md
+++ b/.changeset/tough-poems-give.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: improved logic to update saved map's base style from the latest if any different is presented


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

improved logic of updating style from latest base map. Previously it always changes layer style even no changes. Now only changes if layers are different from latest base style

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
