### PR TITLE
fix: downgrade maptiler geocoder to 1.4.1

### DIFF
--- a/.changeset/old-taxis-cover.md
+++ b/.changeset/old-taxis-cover.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: downgrade maptiler geocoder to 1.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,8 +710,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(maplibre-gl@4.7.1)
       '@maptiler/geocoding-control':
-        specifier: ^2.0.0
-        version: 2.0.1(maplibre-gl@4.7.1)(ol@10.2.1)(react@18.3.1)(svelte@4.2.19)
+        specifier: ^1.4.1
+        version: 1.4.1(maplibre-gl@4.7.1)(ol@10.2.1)(react@18.3.1)(svelte@4.2.19)
       '@neodrag/svelte':
         specifier: ^2.0.6
         version: 2.0.6
@@ -1950,12 +1950,12 @@ packages:
     resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
     hasBin: true
 
-  '@maptiler/geocoding-control@2.0.1':
-    resolution: {integrity: sha512-fHa6QgRfYGbviMdDY1QoDNs2yIQyc2LS8rTOwoj71dTAWwSiQfw6s+ohhiM9zEBmfwYVoELByAG8qwC9brafww==}
+  '@maptiler/geocoding-control@1.4.1':
+    resolution: {integrity: sha512-/NMM8oaKKAdF36KbJuucJc18RaY+VpwkJ2V098yoG7H+9K7Rkyen+XKuLDA8gmvrgTeX1m48Pb9RP+e5zCrRvA==}
     peerDependencies:
       '@maptiler/sdk': ^1 || ^2
       leaflet: ^1.7 || ^1.8 || ^1.9
-      maplibre-gl: ^2 || ^3 || ^4 || ^5
+      maplibre-gl: ^2 || ^3 || ^4
       ol: ^6 || ^7 || ^8 || ^9 || ^10
       react: ^17 || ^18
       svelte: ^4.2
@@ -7005,7 +7005,7 @@ snapshots:
       rw: 1.3.3
       tinyqueue: 3.0.0
 
-  '@maptiler/geocoding-control@2.0.1(maplibre-gl@4.7.1)(ol@10.2.1)(react@18.3.1)(svelte@4.2.19)':
+  '@maptiler/geocoding-control@1.4.1(maplibre-gl@4.7.1)(ol@10.2.1)(react@18.3.1)(svelte@4.2.19)':
     dependencies:
       '@turf/bbox': 7.1.0
       '@turf/clone': 7.1.0

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -44,7 +44,7 @@
 		"@azure/web-pubsub-client": "1.0.1",
 		"@carbon/charts-svelte": "^1.22.0",
 		"@maplibre/maplibre-gl-geocoder": "^1.7.0",
-		"@maptiler/geocoding-control": "^2.0.0",
+		"@maptiler/geocoding-control": "^1.4.1",
 		"@neodrag/svelte": "^2.0.6",
 		"@sveltejs/adapter-node": "^5.2.5",
 		"@sveltejs/kit": "^2.6.1",

--- a/sites/geohub/src/components/pages/map/Map.svelte
+++ b/sites/geohub/src/components/pages/map/Map.svelte
@@ -433,6 +433,7 @@
 				apiKey: apiKey,
 				marker: true,
 				showResultsWhileTyping: false,
+				showFullGeometry: false,
 				collapsed: false
 			});
 			$map.addControl(gc, 'top-left');


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

looks like v2 has issue in geohub. there is weird error in local

```
TypeError: Class extends value undefined is not a constructor or null
    at $r (/Users/j_igarashi/Documents/git/UNDP-Data/geohub/node_modules/.pnpm/@maptiler+geocoding-control@2.0.1_maplibre-gl@4.7.1_ol@10.2.1_react@18.3.1_svelte@4.2.19/node_modules/@maptiler/src/MapLibreBasedGeocodingControl.ts:242:47)
    at /Users/j_igarashi/Documents/git/UNDP-Data/geohub/node_modules/.pnpm/@maptiler+geocoding-control@2.0.1_maplibre-gl@4.7.1_ol@10.2.1_react@18.3.1_svelte@4.2.19/node_modules/@maptiler/src/maplibregl.ts:16:51
    at async instantiateModule (file:///Users/j_igarashi/Documents/git/UNDP-Data/geohub/sites/geohub/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52972:5)
```

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
