### PR TITLE
fix: downgraded @undp-data/date-picker-svelte to 2.12.1 since geohub is still svelte 4, and it has issue of using svelte 5 component

### DIFF
--- a/.changeset/proud-teachers-agree.md
+++ b/.changeset/proud-teachers-agree.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-undp-components": patch
+"geohub": patch
+---
+
+fix: downgraded @undp-data/date-picker-svelte to 2.12.1 since geohub is still svelte 4, and it has issue of using svelte 5 component

--- a/packages/svelte-undp-components/package.json
+++ b/packages/svelte-undp-components/package.json
@@ -87,7 +87,7 @@
 	"types": "./dist/index.d.ts",
 	"type": "module",
 	"dependencies": {
-		"@undp-data/date-picker-svelte": "^2.12.1",
+		"@undp-data/date-picker-svelte": "2.12.1",
 		"@undp-data/svelte-undp-design": "workspace:*",
 		"bignumber.js": "^9.1.2",
 		"chroma-js": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,8 +340,8 @@ importers:
   packages/svelte-undp-components:
     dependencies:
       '@undp-data/date-picker-svelte':
-        specifier: ^2.12.1
-        version: 2.14.1(svelte@4.2.19)
+        specifier: 2.12.1
+        version: 2.12.1(svelte@4.2.19)
       '@undp-data/svelte-undp-design':
         specifier: workspace:*
         version: link:../svelte-undp-design
@@ -2878,10 +2878,10 @@ packages:
     resolution: {integrity: sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@undp-data/date-picker-svelte@2.14.1':
-    resolution: {integrity: sha512-M+ji8ajLXGme0VI/IE2lENVsdFzylXO7WxcimlJ/qOZzXrLnMYl9LMbtf7/RNMU5v01UpzjWpKx8v1iag00OfA==}
+  '@undp-data/date-picker-svelte@2.12.1':
+    resolution: {integrity: sha512-p8Oo7O5glP0Y9B+TWrVdKNhtnH8S3hTWyB2evYjUNHApw6QVNBI9yssb94pctZZuxueS5c5Np5QpK586NO2b1A==}
     peerDependencies:
-      svelte: ^3.24.0 || ^4.0.0 || ^5.0.0
+      svelte: ^3.24.0 || ^4.0.0
 
   '@undp-data/style@2.3.3':
     resolution: {integrity: sha512-2qY/5aoK4JYIM21BZn8ucvk5HOtVPleLantvqbtVBuK8e2uszsvQTCciLv3rsRpBt8VMaj2sGhqfKE2QjmfLuA==}
@@ -8133,7 +8133,7 @@ snapshots:
       '@typescript-eslint/types': 8.15.0
       eslint-visitor-keys: 4.2.0
 
-  '@undp-data/date-picker-svelte@2.14.1(svelte@4.2.19)':
+  '@undp-data/date-picker-svelte@2.12.1(svelte@4.2.19)':
     dependencies:
       svelte: 4.2.19
 

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -132,7 +132,6 @@ export class RasterTileData {
 
 		if (!savedLayerStyle?.style) {
 			const data = new FormData();
-			console.log(this.feature);
 			data.append('feature', JSON.stringify(this.feature));
 			const params: { [key: string]: string } = {};
 			if (colormap_name) {

--- a/sites/geohub/vite.config.ts
+++ b/sites/geohub/vite.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
 			'maplibre-gl',
 			'@maptiler/geocoding-control',
 			'@maplibre/maplibre-gl-geocoder',
-			'@watergis/maplibre-gl-export',
-			'@undp-data/date-picker-svelte'
+			'@watergis/maplibre-gl-export'
 		]
 	},
 	resolve: {

--- a/sites/geohub/vite.config.ts
+++ b/sites/geohub/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
 			'maplibre-gl',
 			'@maptiler/geocoding-control',
 			'@maplibre/maplibre-gl-geocoder',
-			'@watergis/maplibre-gl-export'
+			'@watergis/maplibre-gl-export',
+			'@undp-data/date-picker-svelte'
 		]
 	},
 	resolve: {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

date-picker-svelte should be 2.12.1 with svelte 4. 2.14 is svelte 5 and cannot be used in geohub (svelte 4)

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
