### PR TITLE
fix: sometimes there might be same values in array. remove duplicated values from intervalList.

### DIFF
--- a/.changeset/thin-tigers-invite.md
+++ b/.changeset/thin-tigers-invite.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: sometimes there might be same values in array. remove duplicated values from intervalList.

--- a/packages/svelte-undp-components/src/lib/util/getIntervalList.ts
+++ b/packages/svelte-undp-components/src/lib/util/getIntervalList.ts
@@ -36,17 +36,6 @@ export const getIntervalList = (
 			intervalList = jenks(randomSample, numberOfClasses)?.map((element) => {
 				return isInteger ? Math.round(element) : Number(element.toFixed(2));
 			});
-			if (
-				intervalList.length > 2 &&
-				intervalList[intervalList.length - 1] === intervalList[intervalList.length - 2]
-			) {
-				// set layerMax to the last value of array if the last two values are same
-				if (intervalList[intervalList.length - 1] === layerMax) {
-					intervalList[intervalList.length - 1] = layerMax + 1;
-				} else {
-					intervalList[intervalList.length - 1] = layerMax;
-				}
-			}
 			if (intervalList) {
 				if (intervalList[0] > layerMin) {
 					intervalList[0] = layerMin;
@@ -81,5 +70,7 @@ export const getIntervalList = (
 				return isInteger ? Math.round(element) : Number(element.toFixed(2));
 			});
 	}
+	// sometimes there might be same values in array. remove duplicated values from intervalList
+	intervalList = [...new Set(intervalList)];
 	return intervalList;
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

In some cases, getIntervalList returns array with duplicated number, and maplibre complains about it. For instance, google/microsoft open building data's confidence field has quite tight range of values and chroma produces duplicated array for quantile and logarithmic (same for jenks of natural breaks). I decided to remove duplicated values from array in this function.
Because of this, sometimes only 2 or 3 classes can be produced even users want to make 5 classes. but I feel this can be better other than aligning user selected number of classes somehow.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
