### PR TITLE
fix: fixed bug of creating too many webgl object in data tab.

### DIFF
--- a/.changeset/curly-kids-prove.md
+++ b/.changeset/curly-kids-prove.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of creating too many webgl object in data tab.

--- a/sites/geohub/src/components/pages/map/data/DataCard.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataCard.svelte
@@ -312,67 +312,73 @@
 				{/await}
 			</div>
 			<div slot="content" class="card-container px-1" bind:clientWidth>
-				{#if !is_raster && tilestatsLayers?.length > 1}
-					<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted} />
+				{#if isExpanded === true}
+					{#if !is_raster && tilestatsLayers?.length > 1}
+						<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted} />
 
-					{#each tilestatsLayers as layer}
-						<DataVectorCard
-							bind:layer
-							bind:feature
-							bind:isExpanded={expanded[`${feature.properties.id}-${layer.layer}`]}
-							bind:metadata
-							isShowInfo={false}
-						/>
-					{/each}
-				{:else}
-					<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted}>
-						{#if isRgbTile || selectedBand}
-							{#key selectedBand}
-								<div class="map">
-									<MiniMap
-										bind:feature
-										bind:width
-										height={'150px'}
-										bind:isLoadMap={isExpanded}
-										bind:metadata
-										band={isRgbTile ? undefined : selectedBand}
-										on:layerAdded={handleLayerAdded}
-									/>
+						{#each tilestatsLayers as layer}
+							<DataVectorCard
+								bind:layer
+								bind:feature
+								bind:isExpanded={expanded[`${feature.properties.id}-${layer.layer}`]}
+								bind:metadata
+								isShowInfo={false}
+							/>
+						{/each}
+					{:else}
+						<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted}>
+							{#if isRgbTile || selectedBand}
+								{#key selectedBand}
+									<div class="map">
+										<MiniMap
+											bind:feature
+											bind:width
+											height={'150px'}
+											bind:isLoadMap={isExpanded}
+											bind:metadata
+											band={isRgbTile ? undefined : selectedBand}
+											on:layerAdded={handleLayerAdded}
+										/>
+									</div>
+								{/key}
+							{/if}
+						</DataCardInfo>
+
+						{#if is_raster && !isCatalog && metadata && !isRgbTile && bands.length > 1}
+							<div class="field">
+								<!-- svelte-ignore a11y-label-has-associated-control -->
+								<label class="label">Please select a raster band</label>
+								<div class="control">
+									<RasterBandSelectbox bind:metadata bind:selectedBand />
 								</div>
-							{/key}
-						{/if}
-					</DataCardInfo>
-
-					{#if is_raster && !isCatalog && metadata && !isRgbTile && bands.length > 1}
-						<div class="field">
-							<!-- svelte-ignore a11y-label-has-associated-control -->
-							<label class="label">Please select a raster band</label>
-							<div class="control">
-								<RasterBandSelectbox bind:metadata bind:selectedBand />
 							</div>
-						</div>
-					{/if}
+						{/if}
 
-					{#if stacType}
-						<StacExplorerButton
-							bind:feature
-							isIconButton={false}
-							on:clicked={addStacLayer}
-							bind:showDialog={showSTACDialog}
-						/>
-					{:else if layerCreationInfo}
-						<AddLayerButton bind:isLoading={layerLoading} title="Add layer" on:clicked={addLayer} />
-					{/if}
-
-					{#if is_raster && !stacType && !isRgbTile}
-						<div class="mt-2">
-							<RasterAlgorithmExplorerButton
+						{#if stacType}
+							<StacExplorerButton
 								bind:feature
 								isIconButton={false}
-								on:added={addAlgoLayer}
-								bind:showDialog={showAlgoDialog}
+								on:clicked={addStacLayer}
+								bind:showDialog={showSTACDialog}
 							/>
-						</div>
+						{:else if layerCreationInfo}
+							<AddLayerButton
+								bind:isLoading={layerLoading}
+								title="Add layer"
+								on:clicked={addLayer}
+							/>
+						{/if}
+
+						{#if is_raster && !stacType && !isRgbTile}
+							<div class="mt-2">
+								<RasterAlgorithmExplorerButton
+									bind:feature
+									isIconButton={false}
+									on:added={addAlgoLayer}
+									bind:showDialog={showAlgoDialog}
+								/>
+							</div>
+						{/if}
 					{/if}
 				{/if}
 			</div>

--- a/sites/geohub/src/components/pages/map/data/DataVectorCard.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataVectorCard.svelte
@@ -125,13 +125,28 @@
 		{/if}
 	</div>
 	<div class="container pb-2" slot="content" bind:clientWidth>
-		{#if isShowInfo}
-			<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted}>
+		{#if isExpanded === true}
+			{#if isShowInfo}
+				<DataCardInfo bind:feature bind:metadata on:starDeleted={handleStarDeleted}>
+					<div class="map">
+						<MiniMap
+							bind:feature
+							bind:width
+							height={'200px'}
+							bind:isLoadMap={isExpanded}
+							bind:metadata
+							bind:layer
+							bind:layerType
+							on:layerAdded={handleLayerAdded}
+						/>
+					</div>
+				</DataCardInfo>
+			{:else}
 				<div class="map">
 					<MiniMap
 						bind:feature
 						bind:width
-						height={'150px'}
+						height={'200px'}
 						bind:isLoadMap={isExpanded}
 						bind:metadata
 						bind:layer
@@ -139,25 +154,12 @@
 						on:layerAdded={handleLayerAdded}
 					/>
 				</div>
-			</DataCardInfo>
-		{:else}
-			<div class="map">
-				<MiniMap
-					bind:feature
-					bind:width
-					height={'200px'}
-					bind:isLoadMap={isExpanded}
-					bind:metadata
-					bind:layer
-					bind:layerType
-					on:layerAdded={handleLayerAdded}
-				/>
-			</div>
-		{/if}
+			{/if}
 
-		<LayerTypeSwitch bind:layer bind:layerType size="small" />
-		{#if layerCreationInfo}
-			<AddLayerButton bind:isLoading={layerLoading} title="Add layer" on:clicked={addLayer} />
+			<LayerTypeSwitch bind:layer bind:layerType size="small" />
+			{#if layerCreationInfo}
+				<AddLayerButton bind:isLoading={layerLoading} title="Add layer" on:clicked={addLayer} />
+			{/if}
 		{/if}
 	</div>
 </Accordion>

--- a/sites/geohub/src/components/pages/map/data/DataView.svelte
+++ b/sites/geohub/src/components/pages/map/data/DataView.svelte
@@ -67,7 +67,7 @@
 			const res = await fetch(url);
 			const json: DatasetFeatureCollection = await res.json();
 			if (json.features.length > 0) {
-				json.features = [...DataItemFeatureCollection.features, ...json.features];
+				json.features = [...(DataItemFeatureCollection?.features ?? []), ...json.features];
 			}
 			DataItemFeatureCollection = json;
 		} finally {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

only create maplibre object when accordion is expanded. otherwise, browser delete oldest maplibre object including main map

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
