### PR TITLE
fix: renamed header slot name from custom-button to customButton.

### DIFF
--- a/.changeset/tall-spoons-invent.md
+++ b/.changeset/tall-spoons-invent.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-undp-design": patch
+"geohub": patch
+---
+
+fix: renamed header slot name from custom-button to customButton.

--- a/packages/svelte-undp-design/src/lib/Header/Header.svelte
+++ b/packages/svelte-undp-design/src/lib/Header/Header.svelte
@@ -202,7 +202,7 @@
 						<span class="hamburger-line line-bottom" />
 						Nav toggle
 					</button>
-					<div class="custom-button"><slot name="custom-button" /></div>
+					<div class="custom-button"><slot name="customButton" /></div>
 				</div>
 				{#if links.length > 0}
 					<div class="mobile-nav {showMobileMenu ? 'show' : ''}">

--- a/sites/geohub/src/components/header/Header.svelte
+++ b/sites/geohub/src/components/header/Header.svelte
@@ -32,7 +32,7 @@
 		bind:links={headerLinks}
 		bind:showMobileMenu
 	>
-		<div slot="custom-button">
+		<div slot="customButton">
 			{#if browser && showSignin}
 				<UserAccount />
 			{/if}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I realized custom slot using name with `-` will have issue when use snippet of svelte 5

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
