### PR TITLE
fix: get only public storymap (max 4 items) for landing page

### DIFF
--- a/.changeset/smart-brooms-explain.md
+++ b/.changeset/smart-brooms-explain.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: get only public storymap (max 4 items) for landing page

--- a/sites/geohub/src/routes/(app)/+page.svelte
+++ b/sites/geohub/src/routes/(app)/+page.svelte
@@ -41,7 +41,9 @@
 	const loadStorymaps = async () => {
 		storiesData = undefined;
 
-		const res = await fetch(`/api/storymaps?limit=3&sortby=updatedat,desc&accesslevel=4`);
+		const res = await fetch(
+			`/api/storymaps?limit=4&sortby=updatedat,desc&accesslevel=${AccessLevel.PUBLIC}`
+		);
 		const stories: StorymapsData = await res.json();
 
 		storiesData = stories;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
