### PR TITLE
fix: allow unsigned users to access stac product api to get information.

### DIFF
--- a/.changeset/strange-singers-pay.md
+++ b/.changeset/strange-singers-pay.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: allow unsigned users to access stac product api to get information.

--- a/sites/geohub/src/routes/api/stac/[id]/[collection]/products/+server.ts
+++ b/sites/geohub/src/routes/api/stac/[id]/[collection]/products/+server.ts
@@ -1,14 +1,9 @@
-import { error, type RequestHandler } from '@sveltejs/kit';
+import { type RequestHandler } from '@sveltejs/kit';
 import { db } from '$lib/server/db';
 import { sql } from 'drizzle-orm';
 import { stacCollectionProductInGeohub } from '$lib/server/schema';
 
-export const GET: RequestHandler = async ({ locals, params }) => {
-	const session = await locals.auth();
-	if (!session) {
-		error(403, { message: 'Permission error' });
-	}
-
+export const GET: RequestHandler = async ({ params }) => {
 	const products = await db
 		.select({
 			stac_id: stacCollectionProductInGeohub.stacId,

--- a/sites/geohub/src/routes/api/stac/[id]/[collection]/products/[product_id]/+server.ts
+++ b/sites/geohub/src/routes/api/stac/[id]/[collection]/products/[product_id]/+server.ts
@@ -4,17 +4,7 @@ import { db } from '$lib/server/db';
 import { productInGeohub, stacCollectionProductInGeohub } from '$lib/server/schema';
 import { eq, sql } from 'drizzle-orm';
 
-export const GET: RequestHandler = async ({ locals, params }) => {
-	// get product details
-	/**
-	 * get product details
-	 * Needs to be logged in to get product details
-	 */
-	const session = await locals.auth();
-	if (!session) {
-		error(403, { message: 'Permission error' });
-	}
-
+export const GET: RequestHandler = async ({ params }) => {
 	const productDetails = await db
 		.select({
 			stac_id: stacCollectionProductInGeohub.stacId,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

product get endpoints should be allowed to access from unsigned users

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
