### PR TITLE
fix: use  to fetch bounds info in LngLat coordinates since the latest titiler does not return LngLat bounds from /info and /statistics.

### DIFF
--- a/.changeset/witty-ears-shake.md
+++ b/.changeset/witty-ears-shake.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: use `/bounds?crs=EPSG:4326` to fetch bounds info in LngLat coordinates since the latest titiler does not return LngLat bounds from /info and /statistics.

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -22,11 +22,22 @@ export class RasterTileData {
 		this.feature = feature;
 	}
 
+	public getBounds = async () => {
+		const boundsUrl = this.feature.properties?.links?.find((l) => l.rel === 'bounds')?.href;
+		if (!boundsUrl) return;
+		const res = await fetch(boundsUrl);
+		if (!res.ok) return;
+		const json = await res.json();
+		const bounds = json.bounds as number[];
+		return bounds;
+	};
+
 	public getMetadata = async (algorithmId?: string, expression?: string, nodata?: string) => {
 		const metadataUrl = this.feature.properties?.links?.find((l) => l.rel === 'info')?.href;
 		const product = this.feature.properties.tags?.find((t) => t.key === 'product')?.value;
 
 		if (!metadataUrl) return;
+		const bounds = await this.getBounds();
 		const res = await fetch(metadataUrl);
 		if (product) {
 			const metadata_json = await res.json();
@@ -36,6 +47,9 @@ export class RasterTileData {
 			return metadata;
 		}
 		const metadata: RasterTileMetadata = await res.json();
+		if (bounds) {
+			metadata.bounds = bounds;
+		}
 		if (metadata && metadata.band_metadata && metadata.band_metadata.length > 0) {
 			const scales = metadata.scales;
 			let unscale = 'false';

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -199,6 +199,16 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 		return data;
 	};
 
+	public getBounds = async () => {
+		const boundsUrl = this.dataset.properties?.links?.find((l) => l.rel === 'bounds')?.href;
+		if (!boundsUrl) return;
+		const res = await fetch(boundsUrl);
+		if (!res.ok) return;
+		const json = await res.json();
+		const bounds = json.bounds as number[];
+		return bounds;
+	};
+
 	public getMetadata = async (algorithmId?: string) => {
 		const metadataUrl = this.dataset.properties?.links?.find((l) => l.rel === 'info').href;
 		const product = this.dataset.properties.tags?.find((t) => t.key === 'product')?.value;
@@ -207,6 +217,7 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 		if (!res.ok) {
 			error(res.status, res.statusText);
 		}
+		const bounds = await this.getBounds();
 		if (product) {
 			// FIXME: this is a hack to get the metadata for the product
 			const assetMeta = await res.json();
@@ -221,6 +232,9 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 			this.metadata.band_descriptions = [[this.metadata.active_band_no]];
 		} else {
 			this.metadata = await res.json();
+		}
+		if (bounds) {
+			this.metadata.bounds = bounds;
 		}
 		if (this.metadata && this.metadata.band_metadata && this.metadata.band_metadata.length > 0) {
 			const scales = this.metadata.scales;

--- a/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
+++ b/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
@@ -87,6 +87,11 @@ export const createDatasetLinks = async (
 					)}&asset_as_band=true&unscale=false&resampling=nearest&reproject=nearest&max_size=1024&categorical=false&histogram_bins=8`
 				});
 				feature.properties.links.push({
+					rel: 'bounds',
+					type: 'application/json',
+					href: `${titilerUrl}/bounds?url=${b64EncodedUrl}&crs=EPSG:4326`
+				});
+				feature.properties.links.push({
 					rel: 'tiles',
 					type: 'image/png',
 					href: `${titilerUrl}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${encodeURIComponent(
@@ -132,6 +137,11 @@ export const createDatasetLinks = async (
 					href: `${titilerUrl}/statistics?url=${b64EncodedUrl}`
 				});
 				feature.properties.links.push({
+					rel: 'bounds',
+					type: 'application/json',
+					href: `${titilerUrl}/bounds?url=${b64EncodedUrl}&crs=EPSG:4326`
+				});
+				feature.properties.links.push({
 					rel: 'tiles',
 					type: 'image/png',
 					href: `${titilerUrl}/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${encodeURIComponent(
@@ -166,6 +176,11 @@ export const createDatasetLinks = async (
 				rel: 'statistics',
 				type: 'application/json',
 				href: `${titilerUrl}/statistics?url=${b64EncodedUrl}`
+			});
+			feature.properties.links.push({
+				rel: 'bounds',
+				type: 'application/json',
+				href: `${titilerUrl}/bounds?url=${b64EncodedUrl}&crs=EPSG:4326`
 			});
 			feature.properties.links.push({
 				rel: 'tilejson',
@@ -234,6 +249,11 @@ export const createDatasetLinks = async (
 				rel: 'statistics',
 				type: 'application/json',
 				href: `${titilerUrl}/statistics?url=${b64EncodedUrl}${algorithmId ? `&algorithm=${algorithmId}` : '&bidx=1'}`
+			});
+			feature.properties.links.push({
+				rel: 'bounds',
+				type: 'application/json',
+				href: `${titilerUrl}/bounds?url=${b64EncodedUrl}&crs=EPSG:4326`
 			});
 			feature.properties.links.push({
 				rel: 'tiles',


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

In maplibre, coordinates to fitBounds have to be LngLat. However, the latest titiler stop providing bounds in LngLat system from /info and /statistics. Instead, `/bounds` endpoint now has `crs` option. I fixed to use `/bounds` endpoint to fetch lng lat bounds for metadata.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
