### PR TITLE
ci: put version for azure-blob-storage-upload instead of using main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: deploy storybook to Blob container
         if: ${{ (github.ref == 'refs/heads/develop') }}
-        uses: bacongobbler/azure-blob-storage-upload@main
+        uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
           source_dir: packages/svelte-undp-design/storybook-static
           container_name: $web
@@ -233,7 +233,7 @@ jobs:
 
       - name: deploy storybook to Blob container
         if: ${{ (github.ref == 'refs/heads/develop') }}
-        uses: bacongobbler/azure-blob-storage-upload@main
+        uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
           source_dir: packages/svelte-undp-components/storybook-static
           container_name: $web
@@ -289,7 +289,7 @@ jobs:
 
       - name: deploy userguide to Blob container Prod
         if: ${{ (github.ref == 'refs/heads/main') }}
-        uses: bacongobbler/azure-blob-storage-upload@main
+        uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
           source_dir: documentation/site
           container_name: $web
@@ -298,7 +298,7 @@ jobs:
           sync: "true"
       - name: deploy userguide to Blob container Dev
         if: ${{ github.ref == 'refs/heads/develop' }}
-        uses: bacongobbler/azure-blob-storage-upload@main
+        uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
           source_dir: documentation/site
           container_name: $web


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I found there are errors for azure-blob-storage-upload in our github actions

![image](https://github.com/user-attachments/assets/e525447a-99e7-4b75-8890-fd5eb6889e54)

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
