### PR TITLE
switched to cloudflare API key from token

### DIFF
--- a/backends/k8s/cert-manager/scripts/install.sh
+++ b/backends/k8s/cert-manager/scripts/install.sh
@@ -2,7 +2,7 @@
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
 . scripts/.env
-envsubst < yaml/cloudflare-apitoken-secret.yaml | kubectl apply -f -
+envsubst < yaml/cloudflare-apikey-secret.yaml | kubectl apply -f -
 envsubst < yaml/zerossl-hmac-secret.yaml | kubectl apply -f -
 unset CLOUDFLARE_API_TOKEN
 unset ZEROSSL_HMAC_KEY

--- a/backends/k8s/cert-manager/yaml/cloudflare-apikey-secret.yaml
+++ b/backends/k8s/cert-manager/yaml/cloudflare-apikey-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cloudflare-api-token-secret
+  name: cloudflare-api-key
   namespace: cert-manager
 type: Opaque
 stringData:
-  api-token: $CLOUDFLARE_API_TOKEN
+  api-key: $CLOUDFLARE_API_KEY

--- a/backends/k8s/cert-manager/yaml/le-cluster-issuer.yaml
+++ b/backends/k8s/cert-manager/yaml/le-cluster-issuer.yaml
@@ -12,10 +12,9 @@ spec:
       - dns01:
           cloudflare:
             email: ioan.ferencik@undp.org
-            apiTokenSecretRef:
-              name: cloudflare-api-token-secret
-              key: api-token
+            apiKeySecretRef:
+              name: cloudflare-api-key
+              key: api-key
         selector:
           dnsZones:
           - 'undpgeohub.org'
-          - '*.undpgeohub.org'

--- a/backends/k8s/cert-manager/yaml/zerossl-cluster-issuer.yaml
+++ b/backends/k8s/cert-manager/yaml/zerossl-cluster-issuer.yaml
@@ -20,7 +20,7 @@ spec:
         # Replace the section below with your DNS01 provider
         cloudflare:
           email: ioan.ferencik@undp.org
-          apiTokenSecretRef:
-            name: cloudflare-api-token-secret
-            key: api-token
+          apiKeySecretRef:
+            name: cloudflare-api-key
+            key: api-key
         


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Our Kube cluster's cert issuers used cloudflare API token to validate the undpgeohub domain. The token is valid cca 2 years and has just expired. As a result, we have switched to using Global Key instead of token  

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
