### PR TITLE
fix: fixed bug of not showing scaled raster tile correctly. always use unscale=true for titiler now.

### DIFF
--- a/.changeset/healthy-lemons-shop.md
+++ b/.changeset/healthy-lemons-shop.md
@@ -1,0 +1,5 @@
+---
+"@undp-data/svelte-undp-components": patch
+---
+
+fix: fixed too much reactivity caused by binding props in Slider and RasterRescale components.

--- a/.changeset/long-roses-eat.md
+++ b/.changeset/long-roses-eat.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed bug of not showing scaled raster tile correctly. always use unscale=true for titiler now.

--- a/packages/svelte-undp-components/src/lib/components/titiler/RasterRescale.svelte
+++ b/packages/svelte-undp-components/src/lib/components/titiler/RasterRescale.svelte
@@ -18,9 +18,9 @@
 	}
 
 	let {
-		layerId = $bindable(),
-		metadata = $bindable(),
-		unit = $bindable(''),
+		layerId,
+		metadata,
+		unit = '',
 		rescale = $bindable(),
 		onchange = () => {}
 	}: Props = $props();
@@ -77,7 +77,7 @@
 
 {#if rescale && rescale.length > 0}
 	<Slider
-		bind:values={rescale}
+		values={rescale}
 		min={layerMin}
 		max={layerMax}
 		{step}

--- a/packages/svelte-undp-components/src/lib/components/ui/Slider.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ui/Slider.svelte
@@ -82,31 +82,40 @@
 		{#if values.length === 1}
 			<div class="is-flex is-justify-content-center inputs">
 				<NumberInput
-					bind:minValue={min}
-					bind:maxValue={max}
-					bind:step
-					bind:value={values[0]}
+					minValue={min}
+					maxValue={max}
+					{step}
+					value={values[0]}
 					size="small"
-					onchange={handleNumberChanged}
+					onchange={(value: number) => {
+						values[0] = value;
+						handleNumberChanged();
+					}}
 				/>
 			</div>
 		{:else if values.length === 2}
 			<div class="is-flex is-justify-content-space-evenly inputs">
 				<NumberInput
-					bind:minValue={min}
-					bind:maxValue={values[1]}
+					minValue={min}
+					maxValue={values[1]}
 					bind:step
-					bind:value={values[0]}
+					value={values[0]}
 					size="small"
-					onchange={handleNumberChanged}
+					onchange={(value: number) => {
+						values[0] = value;
+						handleNumberChanged();
+					}}
 				/>
 				<NumberInput
-					bind:minValue={values[0]}
-					bind:maxValue={max}
-					bind:step
-					bind:value={values[1]}
+					minValue={values[0]}
+					maxValue={max}
+					{step}
+					value={values[1]}
 					size="small"
-					onchange={handleNumberChanged}
+					onchange={(value: number) => {
+						values[1] = value;
+						handleNumberChanged();
+					}}
 				/>
 			</div>
 		{/if}

--- a/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
+++ b/sites/geohub/src/components/pages/map/layers/LayerTemplate.svelte
@@ -410,13 +410,15 @@
 			delete mapStyle.sources[name];
 		}
 
+		const _layer: Layer = $state.snapshot(layer) as Layer;
+
 		const style: DashboardMapStyle = {
 			id: layer.id,
 			name: layer.name,
 			createdat: new Date().toString(),
 			updatedat: new Date().toString(),
 			style: mapStyle,
-			layers: [layer],
+			layers: [_layer],
 			access_level: AccessLevel.PRIVATE,
 			created_user: 'api',
 			updated_user: 'api',

--- a/sites/geohub/src/components/pages/map/layers/raster/RasterLegend.svelte
+++ b/sites/geohub/src/components/pages/map/layers/raster/RasterLegend.svelte
@@ -128,10 +128,10 @@
 		updateParamsInURL(layerStyle, layerURL, updatedParams, $map);
 	};
 
-	const handleRescaleChanged = debounce(() => {
+	const handleRescaleChanged = debounce((rescale: number[]) => {
 		if (layerHasUniqueValues) return;
-		if (!$rescaleStore) return;
 		if (algorithmId && !hasRescaleProperty()) return;
+		$rescaleStore = [...rescale];
 
 		const layerStyle = getLayerStyle($map, layerId);
 		const layerUrl = getLayerSourceUrl($map, layerId) as string;
@@ -405,9 +405,9 @@
 				{#snippet content()}
 					<div class="pb-2">
 						<RasterRescale
-							bind:layerId
-							bind:metadata
-							bind:unit
+							{layerId}
+							{metadata}
+							{unit}
 							bind:rescale={$rescaleStore}
 							onchange={handleRescaleChanged}
 						/>

--- a/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
+++ b/sites/geohub/src/components/pages/map/plugins/MapQueryInfoControl.svelte
@@ -305,13 +305,7 @@
 		// 	bandIndex + 1
 		// }`;
 
-		const scales = rasterInfo.scales;
-		let unscale = 'false';
-		if (scales?.length > 0 && scales[0] !== 1) {
-			unscale = 'true';
-		}
-
-		const baseUrl = new URL(`${cogUrl}/point/${lng},${lat}?unscale=${unscale}`);
+		const baseUrl = new URL(`${cogUrl}/point/${lng},${lat}?unscale=true`);
 		baseUrl.searchParams.set('url', blobUrl);
 
 		const bidx = getValueFromRasterTileUrl(map, layer.id, 'bidx') as string;
@@ -386,17 +380,11 @@
 
 		const mosaicjsonUrl = layer.dataset.properties.links.find((l) => l.rel === 'mosaicjson').href;
 
-		const scales = rasterInfo.scales;
-		let unscale = 'false';
-		if (scales?.length > 0 && scales[0] !== 1) {
-			unscale = 'true';
-		}
-
 		const baseUrl = `${mosaicjsonUrl}/point/${lng},${lat}?url=${getValueFromRasterTileUrl(
 			map,
 			layer.id,
 			'url'
-		)}&unscale=${unscale}`;
+		)}&unscale=true`;
 		const res = await fetch(baseUrl);
 		const data = await res.json();
 		if (

--- a/sites/geohub/src/lib/RasterTileData.ts
+++ b/sites/geohub/src/lib/RasterTileData.ts
@@ -53,16 +53,10 @@ export class RasterTileData {
 			metadata.bounds = bounds;
 		}
 		if (metadata && metadata.band_metadata && metadata.band_metadata.length > 0) {
-			const scales = metadata.scales;
-			let unscale = 'false';
-			if (scales?.length > 0 && scales[0] !== 1) {
-				unscale = 'true';
-			}
-
 			const statUrl = new URL(
-				this.feature.properties.links.find((l) => l.rel === 'statistics').href
+				this.feature.properties.links?.find((l) => l.rel === 'statistics')?.href as string
 			);
-			statUrl.searchParams.set('unscale', unscale);
+			statUrl.searchParams.set('unscale', 'true');
 
 			const apiUrl = new URL(statUrl.href);
 			apiUrl.searchParams.set('histogram_bins', '10');
@@ -83,14 +77,11 @@ export class RasterTileData {
 					const bandDetails = statistics[bandValue];
 					if (bandDetails) {
 						const meta = metadata.band_metadata[i][1];
-						// use values from statistics api if info does not contain them
-						meta['STATISTICS_MAXIMUM'] = meta['STATISTICS_MAXIMUM'] ?? bandDetails.max;
-						meta['STATISTICS_MEAN'] = meta['STATISTICS_MEAN'] ?? bandDetails.mean;
-						meta['STATISTICS_MINIMUM'] = meta['STATISTICS_MINIMUM'] ?? bandDetails.min;
-						meta['STATISTICS_STDDEV'] = meta['STATISTICS_STDDEV'] ?? bandDetails.std;
-						meta['STATISTICS_VALID_PERCENT'] =
-							meta['STATISTICS_VALID_PERCENT'] ?? bandDetails.STATISTICS_VALID_PERCENT;
-
+						meta['STATISTICS_MAXIMUM'] = bandDetails.max;
+						meta['STATISTICS_MEAN'] = bandDetails.mean;
+						meta['STATISTICS_MINIMUM'] = bandDetails.min;
+						meta['STATISTICS_STDDEV'] = bandDetails.std;
+						meta['STATISTICS_VALID_PERCENT'] = bandDetails.valid_percent;
 						// use median from statistics api which is not included in info api
 						meta['STATISTICS_MEDIAN'] = bandDetails.median;
 					}

--- a/sites/geohub/src/lib/server/SvgLegendCreator.ts
+++ b/sites/geohub/src/lib/server/SvgLegendCreator.ts
@@ -61,7 +61,6 @@ export class SvgLegendCreator {
 				options.min = parseFloat(options.min);
 			}
 			minDecimalPlaces = getDecimalPlaces(options.min);
-			console.log(minDecimalPlaces);
 			if (minDecimalPlaces > 2) minDecimalPlaces = 2;
 		}
 		let maxDecimalPlaces = 0;

--- a/sites/geohub/src/lib/server/SvgLegendCreator.ts
+++ b/sites/geohub/src/lib/server/SvgLegendCreator.ts
@@ -56,14 +56,19 @@ export class SvgLegendCreator {
 		options?: SvgLegendCreatorOptions
 	) {
 		let minDecimalPlaces = 0;
-		if (options?.min && typeof options.min === 'string') {
-			options.min = parseFloat(options.min);
+		if (options?.min) {
+			if (typeof options.min === 'string') {
+				options.min = parseFloat(options.min);
+			}
 			minDecimalPlaces = getDecimalPlaces(options.min);
+			console.log(minDecimalPlaces);
 			if (minDecimalPlaces > 2) minDecimalPlaces = 2;
 		}
 		let maxDecimalPlaces = 0;
-		if (options?.max && typeof options.max === 'string') {
-			options.max = parseFloat(options.max);
+		if (options?.max) {
+			if (typeof options.max === 'string') {
+				options.max = parseFloat(options.max);
+			}
 			maxDecimalPlaces = getDecimalPlaces(options.max);
 			if (maxDecimalPlaces > 2) maxDecimalPlaces = 2;
 		}

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -249,8 +249,6 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 				for (let i = 0; i < this.metadata.band_metadata.length; i++) {
 					const bandValue = this.metadata.band_metadata[i][0] as string;
 					const bandDetails = statistics[bandValue];
-					console.log(bandValue);
-					console.log(bandDetails);
 					if (bandDetails) {
 						const meta = this.metadata.band_metadata[i][1];
 						// use values from statistics api if info does not contain them

--- a/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
+++ b/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
@@ -84,7 +84,7 @@ export const createDatasetLinks = async (
 					type: 'application/json',
 					href: `${titilerUrl}/statistics?url=${b64EncodedUrl}&expression=${encodeURIComponent(
 						expression
-					)}&asset_as_band=true&unscale=false&resampling=nearest&reproject=nearest&max_size=1024&categorical=false&histogram_bins=8`
+					)}&asset_as_band=true&unscale=true&resampling=nearest&reproject=nearest&max_size=1024&categorical=false&histogram_bins=8`
 				});
 				feature.properties.links.push({
 					rel: 'bounds',


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- fix: fixed bug of not showing scaled raster tile correctly. always use unscale=true for titiler now.
- fix: fixed too much reactivity caused by binding props in Slider and RasterRescale components.

for titiler, we can always enable `unscale=true`. this can work for both scaled and unscaled dataset. that is what I fixed for titiler. but stats from `info` is always unscaled stats, that means we must use min/max from `statistics` endpoint with `unscale=true`

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
