### PR TITLE
ci: add --shamefully-hoist to pnpm install for changeset release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,10 @@ jobs:
           cache: pnpm
 
       - name: install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --shamefully-hoist
 
       - name: build packages
-        run: |
-          pnpm build
+        run: pnpm build
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I believe this bug of changeset was caused by pnpm v10 upgrade. I could have reproduced same with local. I believe this can fix changeset CI

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
