### PR TITLE
fix: add tilematrixid (WebMercatorQuad) for mosaicjson tilejson endpoint.

### DIFF
--- a/.changeset/weak-dancers-listen.md
+++ b/.changeset/weak-dancers-listen.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add tilematrixid (WebMercatorQuad) for mosaicjson tilejson endpoint.

--- a/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
+++ b/sites/geohub/src/lib/server/helpers/createDatasetLinks.ts
@@ -185,7 +185,7 @@ export const createDatasetLinks = async (
 			feature.properties.links.push({
 				rel: 'tilejson',
 				type: 'application/json',
-				href: `${titilerUrl.replace('cog', 'mosaicjson')}/tilejson.json?url=${encodeURIComponent(
+				href: `${titilerUrl.replace('cog', 'mosaicjson')}/WebMercatorQuad/tilejson.json?url=${encodeURIComponent(
 					feature.properties.url
 				)}`
 			});


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I found mosaicjson feature of Stac API and Catalog does not work because I missed to add tilematrixid to titiler mosaicjson endpoint when we upgrade titiler to v0.19 last time.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
