### PR TITLE
fix: replace http to https for titiler tilejson api's tile url if it starts with http, but not localhost.

### DIFF
--- a/.changeset/itchy-ads-check.md
+++ b/.changeset/itchy-ads-check.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: replace http to https for titiler tilejson api's tile url if it starts with http, but not localhost. This is required because of our kubernetes has an issue of SSL certificate.

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -57,7 +57,12 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 				throw new Error(error.message ?? error.cause.message ?? res.statusText);
 			}
 			const tilejson = await res.json();
-			tileLinkUrl = tilejson.tiles[0];
+			tileLinkUrl = tilejson.tiles[0] as string;
+			const _url = new URL(tileLinkUrl);
+			if (_url.protocol === 'http:' && _url.hostname !== 'localhost') {
+				// hostname is not localhost, but its protocol is http, convert it to https
+				tileLinkUrl = tileLinkUrl.replace('http://', 'https://');
+			}
 		}
 		const tilesUrl = new URL(tileLinkUrl);
 		let params = tilesUrl.searchParams;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

this fix is actually related to https://github.com/UNDP-Data/geo-cogserver/issues/55

if tilejson was given for titiler, and protocol is http, force replacing it to https.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
