### PR TITLE
fix: update bounds for mosaicjson if tilejson.bounds property is available

### DIFF
--- a/.changeset/five-suits-invent.md
+++ b/.changeset/five-suits-invent.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: update bounds for mosaicjson if tilejson.bounds property is available

--- a/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
+++ b/sites/geohub/src/lib/server/defaultStyle/RasterDefaultStyle.ts
@@ -63,6 +63,9 @@ export default class RasterDefaultStyle implements DefaultStyleTemplate {
 				// hostname is not localhost, but its protocol is http, convert it to https
 				tileLinkUrl = tileLinkUrl.replace('http://', 'https://');
 			}
+			if (tilejson.bounds) {
+				this.metadata['bounds'] = tilejson.bounds;
+			}
 		}
 		const tilesUrl = new URL(tileLinkUrl);
 		let params = tilesUrl.searchParams;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes mosaicjson layer to have incorrect bounds for raster source

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
