### PR TITLE
fix: search exclude chapters to improve storymap portal performance

### DIFF
--- a/.changeset/silver-cows-add.md
+++ b/.changeset/silver-cows-add.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: added 'exclude_chapter' to /api/storymaps endpoint to remove chapters from search result as default. so it can make the performance a bit faster since chapters may contain massive data and images.

--- a/sites/geohub/src/lib/server/StorymapManager.ts
+++ b/sites/geohub/src/lib/server/StorymapManager.ts
@@ -56,7 +56,8 @@ class StorymapManager {
 		is_superuser: boolean,
 		user_email: string,
 		isCount = false,
-		where?: SQL
+		where?: SQL,
+		excludeChapter = false
 	) => {
 		const sqlChunks: SQL[] = [];
 		sqlChunks.push(
@@ -99,6 +100,10 @@ class StorymapManager {
 			a.updatedat, 
 			a.updated_user,
 			CASE WHEN z.no_stars is not null THEN cast(z.no_stars as integer) ELSE 0 END as no_stars,
+			${
+				excludeChapter === true
+					? `'{}'::integer[] as chapters`
+					: `
 			${
 				user_email
 					? `
@@ -151,7 +156,9 @@ class StorymapManager {
 					c.updatedat, 
 					c.updated_user
 				) AS p
-			)) ORDER BY b.sequence)) AS chapters
+			)) ORDER BY b.sequence)) AS chapters	
+			`
+			}
 			`)
 			);
 		}
@@ -457,12 +464,13 @@ class StorymapManager {
 		sortOrder: 'asc' | 'desc',
 		is_superuser: boolean,
 		user_email: string,
-		mydataOnly: boolean
+		mydataOnly: boolean,
+		excludeChapter: boolean = false
 	) {
 		const where = this.getWhereSql(query, accessLevel, onlyStar, user_email, mydataOnly);
 
 		const sqlChunks: SQL[] = [];
-		const mainSql = this.getSelectSql(is_superuser, user_email, false, where);
+		const mainSql = this.getSelectSql(is_superuser, user_email, false, where, excludeChapter);
 		sqlChunks.push(mainSql);
 
 		sqlChunks.push(

--- a/sites/geohub/src/lib/server/StorymapManager.ts
+++ b/sites/geohub/src/lib/server/StorymapManager.ts
@@ -404,7 +404,7 @@ class StorymapManager {
 	) {
 		const where = this.getWhereSql(query, accessLevel, onlyStar, user_email, mydataOnly);
 
-		const sql = this.getSelectSql(is_superuser, user_email, true, where);
+		const sql = this.getSelectSql(is_superuser, user_email, true, where, true);
 
 		const res = await db.execute(sql);
 		if (res.length === 0) {
@@ -500,7 +500,7 @@ class StorymapManager {
 			a.id = UUID('${id}')
 		`);
 
-		const mainSql = this.getSelectSql(is_superuser, user_email as string, false, where);
+		const mainSql = this.getSelectSql(is_superuser, user_email as string, false, where, false);
 
 		const res = await db.execute(mainSql);
 

--- a/sites/geohub/src/lib/server/api/storymaps/GET.ts
+++ b/sites/geohub/src/lib/server/api/storymaps/GET.ts
@@ -46,7 +46,14 @@ export const Query = z.object({
 		.string()
 		.optional()
 		.default('false')
-		.describe(`If true, only search for signed user's storymaps. default is false`)
+		.describe(`If true, only search for signed user's storymaps. default is false`),
+	exclude_chapter: z
+		.enum(['true', 'false'])
+		.optional()
+		.default('true')
+		.describe(
+			'exclude chapters from the result if enabled. Default is true. If it is set to false, returning all chapters in the search result which may make the performance slow.'
+		)
 });
 
 export const Modifier: RouteModifier = (c) => {
@@ -127,6 +134,9 @@ export default new Endpoint({ Query, Output, Modifier }).handle(async (param, { 
 		}
 	}
 
+	const _excludeChapter = param.exclude_chapter ?? 'true';
+	const excludeChapter = _excludeChapter.toLowerCase() === 'true';
+
 	const sm = new StorymapManager();
 	const stories = await sm.search(
 		query,
@@ -138,7 +148,8 @@ export default new Endpoint({ Query, Output, Modifier }).handle(async (param, { 
 		sortOrder,
 		is_superuser,
 		user_email,
-		mydataOnly
+		mydataOnly,
+		excludeChapter
 	);
 
 	const nextUrl = new URL(url.toString());


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I realized chapters are not needed for search page of storymaps. chapters tend to have many contents and images which potentially make the api response slow down. removing chapters from search result can improve the page performance significantly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
