### PR TITLE
fix: fixed reactivity of MarkdownEditor component

### DIFF
--- a/.changeset/stale-rice-burn.md
+++ b/.changeset/stale-rice-burn.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed reactivity of MarkdownEditor component

--- a/sites/geohub/src/components/pages/storymap/MarkdownEditor.svelte
+++ b/sites/geohub/src/components/pages/storymap/MarkdownEditor.svelte
@@ -7,12 +7,14 @@
 		value?: string;
 		placeholder?: string;
 		maxHeight?: string;
+		onchange?: (value: string) => void;
 	}
 
 	let {
-		value = $bindable(''),
+		value = '',
 		placeholder = 'Input contents in markdown...',
-		maxHeight = '200px'
+		maxHeight = '200px',
+		onchange = () => {}
 	}: Props = $props();
 
 	let textareaElement: HTMLTextAreaElement | undefined = $state();
@@ -38,6 +40,7 @@
 			debounce(() => {
 				if (!easyMDE) return;
 				value = easyMDE.value().trim();
+				onchange(value);
 			}, 300)
 		);
 	});

--- a/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapChapterEdit.svelte
@@ -16,7 +16,7 @@
 		type Tab
 	} from '@undp-data/svelte-undp-components';
 	import { Switch } from '@undp-data/svelte-undp-design';
-	import { ControlPosition } from 'maplibre-gl';
+	import type { ControlPosition } from 'maplibre-gl';
 	import { getContext, onMount } from 'svelte';
 	import ImageUploader from './ImageUploader.svelte';
 	import MapLocationSelector from './MapLocationSelector.svelte';
@@ -219,9 +219,13 @@
 								<FieldControl title="Description" showHelp={false}>
 									{#snippet control()}
 										<div>
-											{#key activeTab}
-												<MarkdownEditor bind:value={$activeChapterStore.description} />
-											{/key}
+											<MarkdownEditor
+												value={($activeChapterStore as StoryMapChapter).description}
+												onchange={(value) => {
+													if (!$activeChapterStore) return;
+													$activeChapterStore.description = value;
+												}}
+											/>
 										</div>
 									{/snippet}
 								</FieldControl>
@@ -463,7 +467,10 @@
 												bind:selected={mapAnimation}
 												onchange={() => {
 													if (!$activeChapterStore) return;
-													$activeChapterStore.mapAnimation = mapAnimation;
+													($activeChapterStore as StoryMapChapter).mapAnimation = mapAnimation as
+														| 'flyTo'
+														| 'easeTo'
+														| 'jumpTo';
 													handleChange;
 												}}
 											/>

--- a/sites/geohub/src/components/pages/storymap/StorymapFooterEdit.svelte
+++ b/sites/geohub/src/components/pages/storymap/StorymapFooterEdit.svelte
@@ -38,7 +38,12 @@
 					<FieldControl title="description" showHelp={true} showHelpPopup={false}>
 						{#snippet control()}
 							<div>
-								<MarkdownEditor bind:value={$configStore.footer} />
+								<MarkdownEditor
+									value={$configStore.footer}
+									onchange={(value) => {
+										$configStore.footer = value;
+									}}
+								/>
 							</div>
 						{/snippet}
 						{#snippet help()}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4872

I think `key` statement made the bug of recreating markdown editor.

also fixed reactivity of MarkdownEditor to use onchange event.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
