### PR TITLE
fix: previously simulation button on CEEI dashboard was disabled when the page is shown.

### DIFF
--- a/.changeset/little-news-film.md
+++ b/.changeset/little-news-film.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: previously simulation button on CEEI dashboard was disabled when the page is shown. Now the button is enabled on initial page shown. This bug was caused by svelte 5 migration which did not bind layer variable to the component correctly.

--- a/sites/geohub/src/routes/(app)/dashboards/ceei/+page@.svelte
+++ b/sites/geohub/src/routes/(app)/dashboards/ceei/+page@.svelte
@@ -316,7 +316,7 @@
 
 					{#each $layerStore as l, i (l.layerId)}
 						<div>
-							<LayerControl layerDetails={l} index={i} />
+							<LayerControl bind:layerDetails={$layerStore[i]} index={i} />
 						</div>
 					{/each}
 				{/if}

--- a/sites/geohub/src/routes/(app)/dashboards/ceei/components/DropdownSearch.svelte
+++ b/sites/geohub/src/routes/(app)/dashboards/ceei/components/DropdownSearch.svelte
@@ -23,7 +23,7 @@
 	let showResults = $state(false);
 	let inputValue = $state('');
 	let filteredItemResults = $derived(
-		items.filter((i) => i.label.toLowerCase().includes(inputValue.toLowerCase()))
+		items?.filter((i) => i.label.toLowerCase().includes(inputValue.toLowerCase()) ?? [])
 	);
 
 	const handleItemClick = (item: Item) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4937

fix: previously simulation button on CEEI dashboard was disabled when the page is shown. Now the button is enabled on initial page shown. This bug was caused by svelte 5 migration which did not bind layer variable to the component correctly.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
