### PR TITLE
feat: added maplibre globe mode to GeoHub

### DIFF
--- a/.changeset/chilled-fishes-attack.md
+++ b/.changeset/chilled-fishes-attack.md
@@ -1,0 +1,5 @@
+---
+"geohub": minor
+---
+
+feat: added maplibre globe mode to GeoHub. Sky layer was removed since it has issues with globe mode.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,9 +841,6 @@ importers:
       '@undp-data/undp-bulma':
         specifier: workspace:*
         version: link:../../packages/undp-bulma
-      '@watergis/maplibre-gl-sky':
-        specifier: ^0.0.9
-        version: 0.0.9
       '@watergis/svelte-splitter':
         specifier: ^2.0.0
         version: 2.0.0(svelte@5.19.9)
@@ -975,7 +972,7 @@ importers:
         version: 0.7.0
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.26.7)(postcss-load-config@5.1.0(postcss@8.5.3))(postcss@8.5.3)(sass@1.84.0)(svelte@5.19.9)(typescript@5.7.3)
+        version: 6.0.3(@babel/core@7.26.7)(postcss-load-config@5.1.0(postcss@8.5.1))(postcss@8.5.1)(sass@1.84.0)(svelte@5.19.9)(typescript@5.7.3)
       svelte-step-wizard:
         specifier: ^0.0.2
         version: 0.0.2
@@ -1923,10 +1920,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       maplibre-gl: '>=4.0.0'
-
-  '@maplibre/maplibre-gl-style-spec@20.4.0':
-    resolution: {integrity: sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==}
-    hasBin: true
 
   '@maplibre/maplibre-gl-style-spec@23.1.0':
     resolution: {integrity: sha512-R6/ihEuC5KRexmKIYkWqUv84Gm+/QwsOUgHyt1yy2XqCdGdLvlBWVWIIeTZWN4NGdwmY6xDzdSGU2R9oBLNg2w==}
@@ -3019,10 +3012,6 @@ packages:
 
   '@vitest/utils@3.0.5':
     resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
-
-  '@watergis/maplibre-gl-sky@0.0.9':
-    resolution: {integrity: sha512-UZuXxp+oBxsKcp3kHOHNQEQuX5H7Uy1QODWfErR4m5nLOoUOZ6sddrq+oIusVYOKWoOENgMFZZg7KWOyiYmaIA==}
-    engines: {pnpm: ^9.0.0}
 
   '@watergis/svelte-splitter@2.0.0':
     resolution: {integrity: sha512-EcHai7HdzvtOQ7EfTPscZ/cER4oSEiqORUVnYsOCfhOsu3a9Sh0fILc6sowXEa7MXJ7YkFYzDX6vKl+G+ybQpQ==}
@@ -4691,10 +4680,6 @@ packages:
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
-  maplibre-gl@4.7.1:
-    resolution: {integrity: sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==}
-    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
-
   maplibre-gl@5.1.0:
     resolution: {integrity: sha512-6lbf7qAnqAVm1T/vJBMmRtP+g8G/O/Z52IBtWX31SbFj7sEdlrk4YugxJen8IdV/pFjLFnDOw7HiHZl5nYdVjg==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
@@ -5251,9 +5236,6 @@ packages:
     resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
     engines: {node: '>=12'}
 
-  quickselect@2.0.0:
-    resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
-
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
@@ -5679,9 +5661,6 @@ packages:
 
   suggestions-list@0.0.2:
     resolution: {integrity: sha512-Yw0fdq14c6RQWQIfE1/8WEi9Dp8rjyCD6FhYA/Tit2/ADbE9Y4ADG4ezlvivsa8Civ5nz++pyVVBMjOMlgIUJw==}
-
-  suncalc@1.9.0:
-    resolution: {integrity: sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==}
 
   supercluster@8.0.1:
     resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
@@ -7248,16 +7227,6 @@ snapshots:
       suggestions-list: 0.0.2
       xtend: 4.0.2
 
-  '@maplibre/maplibre-gl-style-spec@20.4.0':
-    dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/unitbezier': 0.0.1
-      json-stringify-pretty-compact: 4.0.0
-      minimist: 1.2.8
-      quickselect: 2.0.0
-      rw: 1.3.3
-      tinyqueue: 3.0.0
-
   '@maplibre/maplibre-gl-style-spec@23.1.0':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
@@ -8526,11 +8495,6 @@ snapshots:
       '@vitest/pretty-format': 3.0.5
       loupe: 3.1.3
       tinyrainbow: 2.0.0
-
-  '@watergis/maplibre-gl-sky@0.0.9':
-    dependencies:
-      maplibre-gl: 4.7.1
-      suncalc: 1.9.0
 
   '@watergis/svelte-splitter@2.0.0(svelte@5.19.9)':
     dependencies:
@@ -10205,35 +10169,6 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
-  maplibre-gl@4.7.1:
-    dependencies:
-      '@mapbox/geojson-rewind': 0.5.2
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/point-geometry': 0.1.0
-      '@mapbox/tiny-sdf': 2.0.6
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 1.3.1
-      '@mapbox/whoots-js': 3.1.0
-      '@maplibre/maplibre-gl-style-spec': 20.4.0
-      '@types/geojson': 7946.0.16
-      '@types/geojson-vt': 3.2.5
-      '@types/mapbox__point-geometry': 0.1.4
-      '@types/mapbox__vector-tile': 1.3.4
-      '@types/pbf': 3.0.5
-      '@types/supercluster': 7.1.3
-      earcut: 3.0.1
-      geojson-vt: 4.0.2
-      gl-matrix: 3.4.3
-      global-prefix: 4.0.0
-      kdbush: 4.0.2
-      murmurhash-js: 1.0.0
-      pbf: 3.3.0
-      potpack: 2.0.0
-      quickselect: 3.0.0
-      supercluster: 8.0.1
-      tinyqueue: 3.0.0
-      vt-pbf: 3.1.3
-
   maplibre-gl@5.1.0:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
@@ -10822,6 +10757,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.1
 
+  postcss-load-config@5.1.0(postcss@8.5.1):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.7.0
+    optionalDependencies:
+      postcss: 8.5.1
+    optional: true
+
   postcss-load-config@5.1.0(postcss@8.5.3):
     dependencies:
       lilconfig: 3.1.3
@@ -10915,8 +10858,6 @@ snapshots:
 
   quick-lru@6.1.2:
     optional: true
-
-  quickselect@2.0.0: {}
 
   quickselect@3.0.0: {}
 
@@ -11377,8 +11318,6 @@ snapshots:
       fuzzy: 0.1.3
       xtend: 4.0.2
 
-  suncalc@1.9.0: {}
-
   supercluster@8.0.1:
     dependencies:
       kdbush: 4.0.2
@@ -11476,6 +11415,16 @@ snapshots:
       '@babel/core': 7.26.7
       postcss: 8.5.3
       postcss-load-config: 5.1.0(postcss@8.5.3)
+      sass: 1.84.0
+      typescript: 5.7.3
+
+  svelte-preprocess@6.0.3(@babel/core@7.26.7)(postcss-load-config@5.1.0(postcss@8.5.1))(postcss@8.5.1)(sass@1.84.0)(svelte@5.19.9)(typescript@5.7.3):
+    dependencies:
+      svelte: 5.19.9
+    optionalDependencies:
+      '@babel/core': 7.26.7
+      postcss: 8.5.1
+      postcss-load-config: 5.1.0(postcss@8.5.1)
       sass: 1.84.0
       typescript: 5.7.3
 

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -76,7 +76,6 @@
 		"@undp-data/svelte-undp-components": "workspace:*",
 		"@undp-data/svelte-undp-design": "workspace:*",
 		"@undp-data/undp-bulma": "workspace:*",
-		"@watergis/maplibre-gl-sky": "^0.0.9",
 		"@watergis/svelte-splitter": "^2.0.0",
 		"@zerodevx/svelte-toast": "^0.9.6",
 		"arraystat": "^1.7.81",

--- a/sites/geohub/src/routes/(app)/dashboards/ceei/+page@.svelte
+++ b/sites/geohub/src/routes/(app)/dashboards/ceei/+page@.svelte
@@ -11,7 +11,6 @@
 	import '@undp-data/style-switcher/dist/maplibre-style-switcher.css';
 	import { createMapStore, MAPSTORE_CONTEXT_KEY, Sidebar } from '@undp-data/svelte-undp-components';
 	import { Loader } from '@undp-data/svelte-undp-design';
-	import { SkyControl } from '@watergis/maplibre-gl-sky';
 	import { SvelteToast } from '@zerodevx/svelte-toast';
 	import type { FeatureCollection } from 'geojson';
 	import { uniq } from 'lodash-es';
@@ -192,7 +191,8 @@
 			zoom: 2.5,
 			hash: true,
 			attributionControl: false,
-			dragPan: false
+			dragPan: false,
+			maxPitch: 85
 		});
 
 		map.addControl(new NavigationControl({}), 'top-right');
@@ -234,9 +234,6 @@
 		popupStore.set(popup);
 
 		map.on('load', () => {
-			const sky = new SkyControl();
-			sky.addTo(map, { timeType: 'solarNoon' });
-
 			map.resize();
 
 			styleSwitcher.initialise();

--- a/sites/geohub/src/routes/(app)/dashboards/electricity/+page@.svelte
+++ b/sites/geohub/src/routes/(app)/dashboards/electricity/+page@.svelte
@@ -34,11 +34,11 @@
 	} from '@undp-data/svelte-geohub-static-image-controls';
 	import { initTooltipTippy, ModalTemplate, Sidebar } from '@undp-data/svelte-undp-components';
 	import { CtaLink } from '@undp-data/svelte-undp-design';
-	import { SkyControl } from '@watergis/maplibre-gl-sky';
 	import {
 		addProtocol,
 		AttributionControl,
 		GeolocateControl,
+		GlobeControl,
 		Map,
 		NavigationControl,
 		ScaleControl
@@ -125,7 +125,8 @@
 			center: [0, 0],
 			zoom: 2.5,
 			hash: true,
-			attributionControl: false
+			attributionControl: false,
+			maxPitch: 85
 		});
 
 		map.addControl(new NavigationControl({}), 'top-right');
@@ -136,6 +137,7 @@
 			}),
 			'top-right'
 		);
+		map.addControl(new GlobeControl(), 'top-right');
 		map.addControl(new ScaleControl({ maxWidth: 80, unit: 'metric' }), 'bottom-left');
 		map.addControl(
 			new AttributionControl({ compact: true, customAttribution: data.attribution }),
@@ -163,8 +165,6 @@
 		isInitialized = true;
 
 		map.on('load', () => {
-			const sky = new SkyControl();
-			sky.addTo(map, { timeType: 'solarNoon' });
 			map.resize();
 
 			styleSwitcher.initialise();

--- a/sites/geohub/src/routes/(app)/dashboards/zanzibar/+page@.svelte
+++ b/sites/geohub/src/routes/(app)/dashboards/zanzibar/+page@.svelte
@@ -31,7 +31,6 @@
 		type BreadcrumbPage
 	} from '@undp-data/svelte-undp-components';
 	import { Button, Footer } from '@undp-data/svelte-undp-design';
-	import { SkyControl } from '@watergis/maplibre-gl-sky';
 	import dayjs from 'dayjs';
 	import maplibregl, {
 		addProtocol,
@@ -131,8 +130,7 @@
 		if (!map) return;
 		map.resize();
 		await styleSwitcher.initialise();
-		const sky = new SkyControl();
-		sky.addTo(map, { timeType: 'solarNoon' });
+
 		const isTerrain = map.getTerrain();
 		if (isTerrain) {
 			map.setTerrain(null);

--- a/sites/geohub/src/routes/(app)/maps/[[id]]/edit/+page.svelte
+++ b/sites/geohub/src/routes/(app)/maps/[[id]]/edit/+page.svelte
@@ -31,10 +31,10 @@
 	import MaplibreCgazAdminControl from '@undp-data/cgaz-admin-tool';
 	import MaplibreStyleSwitcherControl from '@undp-data/style-switcher';
 	import { MAPSTORE_CONTEXT_KEY, type MapStore } from '@undp-data/svelte-undp-components';
-	import { SkyControl } from '@watergis/maplibre-gl-sky';
 	import {
 		AttributionControl,
 		GeolocateControl,
+		GlobeControl,
 		Map,
 		NavigationControl,
 		ScaleControl,
@@ -99,7 +99,8 @@
 		center: [0, 0],
 		zoom: 3,
 		hash: true,
-		attributionControl: false
+		attributionControl: false,
+		maxPitch: 85
 	};
 
 	let tourOptions: IntroJsOptions = $state({
@@ -417,6 +418,9 @@
 			}),
 			'bottom-right'
 		);
+
+		$map.addControl(new GlobeControl(), 'bottom-right');
+
 		$map.addControl(new TerrainControl(terrainOptions), 'bottom-right');
 
 		$map.addControl(new ScaleControl({ unit: 'metric' }), 'bottom-left');
@@ -450,8 +454,6 @@
 	const mapInitializeAfterLoading = async () => {
 		$map.resize();
 
-		const sky = new SkyControl();
-		sky.addTo($map, { timeType: 'solarNoon' });
 		const isTerrain = $map.getTerrain();
 		if (isTerrain) {
 			$map.setTerrain(null);
@@ -494,6 +496,10 @@
 		});
 		$map.on('styledata', async () => {
 			$showProgressBarStore = false;
+			let storageValue = $map.getStyle();
+			toLocalStorage(mapStyleStorageKey, storageValue);
+		});
+		$map.on('projectiontransition', () => {
 			let storageValue = $map.getStyle();
 			toLocalStorage(mapStyleStorageKey, storageValue);
 		});

--- a/sites/geohub/src/routes/(app)/maps/[id]/+page.svelte
+++ b/sites/geohub/src/routes/(app)/maps/[id]/+page.svelte
@@ -34,12 +34,12 @@
 		type BreadcrumbPage,
 		type Tab
 	} from '@undp-data/svelte-undp-components';
-	import { SkyControl } from '@watergis/maplibre-gl-sky';
 	import { toast } from '@zerodevx/svelte-toast';
 	import {
 		AttributionControl,
 		FullscreenControl,
 		GeolocateControl,
+		GlobeControl,
 		Map,
 		NavigationControl,
 		ScaleControl,
@@ -147,7 +147,8 @@
 		const map = new Map({
 			container: mapContainer,
 			style: style.style,
-			attributionControl: false
+			attributionControl: false,
+			maxPitch: 85
 		});
 
 		map.addControl(new FullscreenControl(), 'top-right');
@@ -171,7 +172,9 @@
 			}),
 			'bottom-right'
 		);
-		map.setMaxPitch(85);
+
+		map.addControl(new GlobeControl(), 'bottom-right');
+
 		map.addControl(
 			new TerrainControl({
 				source: 'terrarium',
@@ -188,9 +191,6 @@
 			defaultStyle: MapStyles[0].title
 		});
 		map.addControl(styleSwitcher, 'bottom-left');
-
-		const sky = new SkyControl();
-		sky.addTo(map, { timeType: 'solarNoon' });
 
 		map.once('load', async () => {
 			map.resize();


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4942

- added GlobeControl for map editor, map viewer and electricity dashboard
- deleted @watergis/maplibre-gl-sky
- save style when projection is changed at `projectiontransition` event.
- I confirmed static api works without error (it will print map as mercator map, and I think this is ok for static api)

We still need to add globe control functionality for storymap, but that can be done in another PR.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
