### PR TITLE
fix: bring duplicated layer to the top

### DIFF
--- a/.changeset/happy-feet-behave.md
+++ b/.changeset/happy-feet-behave.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: previously, the order of layers in sidebar is opposite from what maplibre renders. That makes some confusion and users do not realize the first layer is actually rendered the bottom of second layer. This will bring duplicated layer to the top, so it will be the same order of maplibre.

--- a/sites/geohub/src/routes/(app)/dashboards/ceei/utils/layerHelper.ts
+++ b/sites/geohub/src/routes/(app)/dashboards/ceei/utils/layerHelper.ts
@@ -96,7 +96,7 @@ const addLayer = (map: Map, layer: Layer) => {
 
 	const layers = get(layersStore);
 
-	layersStore.set([...layers, layer]);
+	layersStore.set([layer, ...layers]);
 
 	map.addSource(layer.sourceId, layer.source);
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4931 

fix: previously, the order of layers in sidebar is opposite from what maplibre renders. That makes some confusion and users do not realize the first layer is actually rendered the bottom of second layer. This will bring duplicated layer to the top, so it will be the same order of maplibre.

- previously, when duplicate layer, new layer is added to the bottom.

when users changed parameters in the first layer, it looks not being changed because it is behind the second layer. But the first layer is actually changed when the second layer is hidden.

This makes users confused because the order of layers maplibre renders is opposite.

![image](https://github.com/user-attachments/assets/98730639-1a1c-4ace-b83e-32c8ab598bb0)

- now, new layer is added to the top

Now the order of layers in sidebar and the order of maplibre rendered layers are the same. I believe this can solve the confusion for users at least.

![image](https://github.com/user-attachments/assets/44a1570f-9bc8-4d9a-9faf-12bd90d3c7b3)


### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
