### PR TITLE
fix: add try catch to handle error when titiler is down, so landing page can be shown all the time

### DIFF
--- a/.changeset/odd-jars-shake.md
+++ b/.changeset/odd-jars-shake.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add try catch to handle error when titiler is down, so landing page can be shown all the time

--- a/sites/geohub/src/routes/(app)/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/+page.server.ts
@@ -24,8 +24,13 @@ export const load: PageServerLoad = async ({ depends, fetch }) => {
 };
 
 const getAlgorithms = async (fetch) => {
-	const apiUrl = `${env.TITILER_ENDPOINT.replace('/cog', '')}/algorithms`;
-	const res = await fetch(apiUrl);
-	const algorithms: { [key: string]: RasterAlgorithm } = await res.json();
-	return algorithms;
+	try {
+		const apiUrl = `${env.TITILER_ENDPOINT.replace('/cog', '')}/algorithms`;
+		const res = await fetch(apiUrl);
+		const algorithms: { [key: string]: RasterAlgorithm } = await res.json();
+		return algorithms;
+	} catch (error) {
+		console.error('Error fetching algorithms:', error);
+		return {};
+	}
 };

--- a/sites/geohub/src/routes/(app)/tools/+page.server.ts
+++ b/sites/geohub/src/routes/(app)/tools/+page.server.ts
@@ -14,9 +14,16 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	let algoTags = tags[ALGORITHM_TAG_KEY] ?? [];
 	algoTags = algoTags.sort((a, b) => a.count - b.count);
 
-	const apiUrl = `${env.TITILER_ENDPOINT.replace('/cog', '')}/algorithms`;
-	const resAlgo = await fetch(apiUrl);
-	const algorithms: { [key: string]: RasterAlgorithm } = await resAlgo.json();
+	let algorithms: { [key: string]: RasterAlgorithm } = {};
+	try {
+		const apiUrl = `${env.TITILER_ENDPOINT.replace('/cog', '')}/algorithms`;
+		const resAlgo = await fetch(apiUrl);
+		algorithms = await resAlgo.json();
+	} catch (error) {
+		console.error('Error fetching algorithms:', error);
+		algorithms = {};
+	}
+
 	const filteredAlgos: { [key: string]: RasterAlgorithm } = {};
 
 	algoTags.forEach((tag) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Currently, titiler is down because something happened for SSL certificate. In landing page and tools page, +page.server.ts access titiler /algorithms api to fetch the list of tools, this fetch fails and bring the whole page down.

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
