### PR TITLE
fix: added fill-extrusion layer type for default style endpoint.

### DIFF
--- a/.changeset/hip-toys-itch.md
+++ b/.changeset/hip-toys-itch.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: added fill-extrusion layer type for default style endpoint.

--- a/sites/geohub/src/lib/VectorTileData.ts
+++ b/sites/geohub/src/lib/VectorTileData.ts
@@ -80,9 +80,12 @@ export class VectorTileData {
 
 				body: data
 			});
+			if (!res.ok) {
+				const message = await res.json();
+				throw new Error(`Failed to fetch saved layer style. ${res.statusText}: ${message.message}`);
+			}
 			savedLayerStyle = await res.json();
 		}
-
 		const layerSpec = JSON.parse(
 			JSON.stringify(savedLayerStyle.style)
 				.replace('{source_id}', tileSourceId)

--- a/sites/geohub/src/lib/server/api/datasets/[id]/preview/style.json/GET.ts
+++ b/sites/geohub/src/lib/server/api/datasets/[id]/preview/style.json/GET.ts
@@ -20,7 +20,7 @@ export const Query = z.object({
 	type: z
 		.enum(['fill', 'line', 'symbol', 'circle', 'heatmap', 'fill-extrusion', 'raster'])
 		.optional()
-		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster)')
+		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster, fill-extrusion)')
 });
 
 const description = `

--- a/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/DELETE.ts
+++ b/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/DELETE.ts
@@ -14,8 +14,8 @@ export const Param = z.object({
 	id: z.string().describe('Dataset ID'),
 	layer: z.string().describe('Band name if it is raster, layer ID if it is vector.'),
 	type: z
-		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap'])
-		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster)')
+		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap', 'fill-extrusion'])
+		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster, fill-extrusion)')
 });
 
 const description = `

--- a/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/GET.ts
+++ b/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/GET.ts
@@ -29,8 +29,8 @@ export const Param = z.object({
 		.describe('Band name if it is raster, layer ID if it is vector.')
 		.openapi({ example: 'drr.dynamic_subnational_hhr' }),
 	type: z
-		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap'])
-		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster)')
+		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap', 'fill-extrusion'])
+		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster, fill-extrusion)')
 		.openapi({ example: 'fill' })
 });
 

--- a/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/POST.ts
+++ b/sites/geohub/src/lib/server/api/datasets/[id]/style/[layer]/[type]/POST.ts
@@ -21,8 +21,8 @@ export const Param = z.object({
 		.describe('Band name if it is raster, layer ID if it is vector.')
 		.openapi({ example: 'drr.dynamic_subnational_hhr' }),
 	type: z
-		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap'])
-		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster)')
+		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap', 'fill-extrusion'])
+		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster, fill-extrusion)')
 		.openapi({ example: 'fill' })
 });
 

--- a/sites/geohub/src/lib/server/api/datasets/style/[layer]/[type]/POST.ts
+++ b/sites/geohub/src/lib/server/api/datasets/style/[layer]/[type]/POST.ts
@@ -16,8 +16,8 @@ export const Output = z.custom<DatasetDefaultLayerStyle>().describe('default lay
 export const Param = z.object({
 	layer: z.string().describe('Band name if it is raster, layer ID if it is vector.'),
 	type: z
-		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap'])
-		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster)')
+		.enum(['raster', 'fill', 'symbol', 'line', 'circle', 'heatmap', 'fill-extrusion'])
+		.describe('Maplibre layer type (fill, line, symbol, circle, heatmap, raster, fill-extrusion)')
 });
 
 export const Query = z.object({


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #4987

This bug was caused by migration to sveltekit-api.

https://github.com/UNDP-Data/geohub/blob/54d39073bec29ce3595425d0aedc633410a58629/sites/geohub/src/lib/server/api/datasets/style/%5Blayer%5D/%5Btype%5D/POST.ts#L16-L21

I forgot to add `fill-extrusion` for layer type, and svektelit-api throw error 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
