### PR TITLE
fix: set debounce for textbox of NumberInput component to allow users manually change value correctly.

### DIFF
--- a/.changeset/wet-peas-grin.md
+++ b/.changeset/wet-peas-grin.md
@@ -1,0 +1,6 @@
+---
+"@undp-data/svelte-undp-components": patch
+"geohub": patch
+---
+
+fix: set debounce for textbox of NumberInput component to allow users manually change value correctly.

--- a/packages/svelte-undp-components/src/lib/components/ui/NumberInput.stories.ts
+++ b/packages/svelte-undp-components/src/lib/components/ui/NumberInput.stories.ts
@@ -37,6 +37,11 @@ const meta = {
 			type: 'boolean',
 			description: 'If true, become readonly mode.',
 			defaultValue: false
+		},
+		debounceTime: {
+			type: 'number',
+			description: 'decounce time in second. Default is 1000 msec (1sec)',
+			defaultValue: 1000
 		}
 	}
 } satisfies Meta<NumberInput>;

--- a/packages/svelte-undp-components/src/lib/components/ui/NumberInput.svelte
+++ b/packages/svelte-undp-components/src/lib/components/ui/NumberInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { isInt } from '$lib/util/isInt';
 	import BigNumber from 'bignumber.js';
+	import { debounce } from 'lodash-es';
 
 	interface Props {
 		value: number;
@@ -9,6 +10,7 @@
 		step?: number;
 		size?: 'small' | 'normal' | 'medium' | 'large';
 		readonly?: boolean;
+		debounceTime?: number;
 		onchange?: (value: number) => void;
 	}
 
@@ -19,6 +21,7 @@
 		step = $bindable(),
 		size = 'normal',
 		readonly = $bindable(),
+		debounceTime = 1000,
 		onchange = () => {}
 	}: Props = $props();
 
@@ -53,7 +56,7 @@
 		}
 	};
 
-	const handleValueChanged = (e) => {
+	const handleValueChanged = debounce((e) => {
 		let allowNegative = minValue < 0 || maxValue < 0;
 
 		if (isInt(step)) {
@@ -124,7 +127,7 @@
 		}
 		value = Number(round(value, countDecimals(step ?? 1)).toFixed(countDecimals(step ?? 1)));
 		if (onchange) onchange(value);
-	};
+	}, debounceTime);
 
 	// round number based on length of decimal places
 	const round = (val: number, exp: number) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #5000

I added debounce for NumberInput. Now it seems working good

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
