### PR TITLE
fix: fixed a bug not returning is_star and permission properties from /api/storymaps endpoint.

### DIFF
--- a/.changeset/four-cougars-hug.md
+++ b/.changeset/four-cougars-hug.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: fixed a bug not returning is_star and permission properties from /api/storymaps endpoint.

--- a/sites/geohub/src/lib/server/StorymapManager.ts
+++ b/sites/geohub/src/lib/server/StorymapManager.ts
@@ -102,10 +102,6 @@ class StorymapManager {
 			a.updated_user,
 			CASE WHEN z.no_stars is not null THEN cast(z.no_stars as integer) ELSE 0 END as no_stars,
 			${
-				excludeChapter === true
-					? `'{}'::integer[] as chapters`
-					: `
-			${
 				user_email
 					? `
 						CASE
@@ -118,11 +114,15 @@ class StorymapManager {
 						`
 					: 'false as is_star,'
 			}
-            ${
-							!is_superuser && user_email
-								? `CASE WHEN p.permission is not null THEN p.permission ELSE null END`
-								: `${is_superuser ? Permission.OWNER : 'null'}`
-						} as permission,
+			${
+				!is_superuser && user_email
+					? `CASE WHEN p.permission is not null THEN p.permission ELSE null END`
+					: `${is_superuser ? Permission.OWNER : 'null'}`
+			} as permission,
+			${
+				excludeChapter === true
+					? `'{}'::integer[] as chapters`
+					: `
 			array_to_json(array_agg(row_to_json((
 				SELECT p FROM (
 				SELECT


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #5018

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
