### PR TITLE
added settings to ensure deleting scaled cron job after completion

### DIFF
--- a/backends/k8s/stac-pipeline/README.md
+++ b/backends/k8s/stac-pipeline/README.md
@@ -40,3 +40,39 @@ cd scripts
 For processing night time light data of 6 January 2024, it took around 12 minutes time with 20GB RAM allocated pod. `activeDeadlineSeconds` is set to 3600 seconds (1 hour). Thus, the container will automatically stop after 1 hour passes. If the job finished before 1 hour, the container will automatically stop and delete it.
 
 This scaled job is deployed to `manual` node pool which can autoscale up to 2 nodes. Currently, all pods for titiler and titiler-dev can run within a node. When a message is added into the queue, the resource is not enough to launch scaled job. Then k8s will scale up to 2 nodes. Once the pipeline job finished, the second node will be deleted automatically after some time (probably around 15 - 20 minutes).
+
+## Delete old jobs
+
+In some reason, old jobs are not deleted, and it maybe blocks to trigger new scaled job.
+
+```shell
+kubectl get all -n stac
+NAME                                   COMPLETIONS   DURATION   AGE
+job.batch/stac-scaled-cron-job-27db6   1/1           2m22s      50d
+job.batch/stac-scaled-cron-job-2jmn4   1/1           2m21s      29d
+job.batch/stac-scaled-cron-job-2p8l5   1/1           2m10s      62d
+job.batch/stac-scaled-cron-job-45b56   1/1           2m33s      9d
+job.batch/stac-scaled-cron-job-45gvv   1/1           2m14s      56d
+job.batch/stac-scaled-cron-job-4chfd   1/1           2m5s       84d
+job.batch/stac-scaled-cron-job-4dhxj   1/1           2m7s       6d7h
+```
+
+In this case, you may need to delete jobs manually by using the below command.
+
+```shell
+# delete all jobs in stac namespace
+kubectl delete jobs -n stac --all
+# delete all completed jobs in stac namespace
+kubectl delete jobs -n stac --field-selector=status.successful=1
+```
+
+To avoid this issue, I added the below setting for scaled cron job.
+
+```yaml
+spec:
+  jobTargetRef:
+    # delete job after 3600 seconds (1 hour) of completion
+    ttlSecondsAfterFinished: 3600
+  successfulJobsHistoryLimit: 0 # Don't keep successful jobs
+  failedJobsHistoryLimit: 10 # keep failed jobs for 10 attempts
+```

--- a/backends/k8s/stac-pipeline/yaml/deployment.yaml
+++ b/backends/k8s/stac-pipeline/yaml/deployment.yaml
@@ -65,6 +65,8 @@ spec:
     completions: 1
     activeDeadlineSeconds: 300
     backoffLimit: 5
+    # delete job after 3600 seconds (1 hour) of completion
+    ttlSecondsAfterFinished: 3600
     template:
       spec:
         nodeSelector:
@@ -96,6 +98,8 @@ spec:
         restartPolicy: Never
   pollingInterval: 600 # Optional. set 10 min for interval to ensure only a process is created
   envSourceContainerName: stac # Optional. Default: .spec.JobTargetRef.template.spec.containers[0]
+  successfulJobsHistoryLimit: 0 # Don't keep successful jobs
+  failedJobsHistoryLimit: 10 # keep failed jobs for 10 attempts
   scalingStrategy:
     strategy: default
   triggers:


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I added some settings to ensure deleting jobs after completion

https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#updating-ttl-for-finished-jobs
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
