### PR TITLE
fix: fixed a bug of some old map style which has tileMatrixSetId in the URL param, but new titiler requires tileMatrixSetId as path param.

### DIFF
--- a/.changeset/proud-experts-bake.md
+++ b/.changeset/proud-experts-bake.md
@@ -1,0 +1,10 @@
+---
+"geohub": patch
+---
+
+fix: some old map style has tileMatrixSetId in the URL param, but new titiler requires tileMatrixSetId as path param.
+
+For example, new URL will be like below after replacing old saved URL.
+
+- Old URL: /cog/tiles/{z}/{x}/{y}.png?TileMatrixSetId=WebMercatorQuad
+- New URL: /cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fix: some old map style has tileMatrixSetId in the URL param, but new titiler requires tileMatrixSetId as path param.

For example, new URL will be like below after replacing old saved URL.

- Old URL: /cog/tiles/{z}/{x}/{y}.png?TileMatrixSetId=WebMercatorQuad
- New URL: /cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
