### PR TITLE
fix: upgarded base style to v2.4.4 to add terririum-hillshade source only for hillshade layer.

### DIFF
--- a/.changeset/lovely-words-roll.md
+++ b/.changeset/lovely-words-roll.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: upgarded base style to v2.4.4 to add terririum-hillshade source only for hillshade layer.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,7 +504,7 @@ importers:
         version: 1.2.0(svelte@5.34.3)
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.27.4)(postcss-load-config@5.1.0(postcss@8.5.6))(postcss@8.5.6)(sass@1.89.2)(svelte@5.34.3)(typescript@5.8.3)
+        version: 6.0.3(@babel/core@7.27.4)(postcss-load-config@5.1.0(postcss@8.5.5))(postcss@8.5.5)(sass@1.89.2)(svelte@5.34.3)(typescript@5.8.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -628,7 +628,7 @@ importers:
         version: 1.2.0(svelte@5.34.3)
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.27.4)(postcss-load-config@5.1.0(postcss@8.5.5))(postcss@8.5.5)(sass@1.89.2)(svelte@5.34.3)(typescript@5.8.3)
+        version: 6.0.3(@babel/core@7.27.4)(postcss-load-config@5.1.0(postcss@8.5.6))(postcss@8.5.6)(sass@1.89.2)(svelte@5.34.3)(typescript@5.8.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -682,8 +682,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
       '@undp-data/style':
-        specifier: ^2.4.3
-        version: 2.4.3
+        specifier: ^2.4.4
+        version: 2.4.4
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2811,8 +2811,8 @@ packages:
     peerDependencies:
       svelte: ^3.24.0 || ^4.0.0
 
-  '@undp-data/style@2.4.3':
-    resolution: {integrity: sha512-SCRUfraX9vrLMUAd5tmxl7zbMYyZahW3OlafMAXuG5+oT1r35mR0iKHb4f1Mtj7v0r0JXlvFD82KhxLfflb/Tg==}
+  '@undp-data/style@2.4.4':
+    resolution: {integrity: sha512-VugpXgBfJGMuaSshgsYD0Ul9VULylXiBaisja8qiQuvoXqcPfb5mwNBk5wao4JnmcEn59o2Tp+JvPvrzhOAFBw==}
     engines: {pnpm: ^10.0.0}
 
   '@undp-data/svelte-file-dropzone@2.0.3':
@@ -8555,7 +8555,7 @@ snapshots:
     dependencies:
       svelte: 5.34.3
 
-  '@undp-data/style@2.4.3': {}
+  '@undp-data/style@2.4.4': {}
 
   '@undp-data/svelte-file-dropzone@2.0.3(svelte@5.34.3)':
     dependencies:

--- a/sites/geohub/package.json
+++ b/sites/geohub/package.json
@@ -144,7 +144,7 @@
 		"@azure/web-pubsub": "^1.2.0",
 		"@mapbox/geo-viewport": "^0.5.0",
 		"@mapbox/vector-tile": "^2.0.4",
-		"@undp-data/style": "^2.4.3",
+		"@undp-data/style": "^2.4.4",
 		"crypto-js": "^4.2.0",
 		"drizzle-orm": "^0.44.2",
 		"flatgeobuf": "^4.0.2",


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

This PR upgrade the version of base map style package to add raster-dem source only for hillshade layer which can solve the issue raised by https://github.com/UNDP-Data/geohub/pull/5081

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [x] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
