### PR TITLE
fix: add UNDP to attribution

### DIFF
--- a/.changeset/smooth-ads-wave.md
+++ b/.changeset/smooth-ads-wave.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: add UNDP attribution to getAttribution so it can be used in storymaps"

--- a/sites/geohub/src/lib/config/AppConfig/attribution.ts
+++ b/sites/geohub/src/lib/config/AppConfig/attribution.ts
@@ -5,13 +5,11 @@ const disclaimerText = `
   of the Secretariat of the United Nations or UNDP concerning the legal status of any country, territory, city or area or its authorities,<br>
   or concerning the delimitation of its frontiers or boundaries.
 </span>
-
-
 `;
 
 export const attribution = `<span>${disclaimerText}</span>`;
 
 export const getAttribution = (isLink = false) => {
-	const label = `© ${new Date().getFullYear()}`;
-	return isLink ? ` ` : label;
+	const label = `© ${new Date().getFullYear()} United Nations Development Programme`;
+	return isLink ? `<a target="_top" rel="noopener" href="https://undp.org">${label}</a>` : label;
 };


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

In this PR:

I modified `getAttribution` function to add UNDP to the attribuiton as the storymaps are part of the UNDP's GeoHUB system.
UNDP is not attributed in any part of maps as there are no basemaps whose source is UNDP.

This PR will fix issue #5135 

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
