### PR TITLE
fix: applying filtering labels showing all labels instead of only filtered ones

### DIFF
--- a/.changeset/funny-ads-serve.md
+++ b/.changeset/funny-ads-serve.md
@@ -1,0 +1,5 @@
+---
+"geohub": patch
+---
+
+fix: applying labels after filtering now shows labels for only the showing polygons

--- a/sites/geohub/src/components/pages/map/layers/vector/TextField.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/TextField.svelte
@@ -50,7 +50,7 @@
 
 	const setTextField = () => {
 		if (!style && !textFieldValue) return;
-		if (!style && layer.parentId) {
+		if (layer.parentId) {
 			const parentStyle = getLayerStyle($map, layer.parentId);
 
 			const childLayer: SymbolLayerSpecification = {
@@ -81,7 +81,6 @@
 			}
 			style = childLayer;
 		}
-
 		if (style.type !== 'symbol') return;
 		if (textFieldValue) {
 			// variable label placement settings: https://docs.mapbox.com/mapbox-gl-js/example/variable-label-placement/

--- a/sites/geohub/src/components/pages/map/layers/vector/TextField.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/TextField.svelte
@@ -52,6 +52,7 @@
 		if (!style && !textFieldValue) return;
 		if (!style && layer.parentId) {
 			const parentStyle = getLayerStyle($map, layer.parentId);
+
 			const childLayer: SymbolLayerSpecification = {
 				id: layerId,
 				type: 'symbol',
@@ -68,6 +69,10 @@
 					'text-halo-width': Number(config.LabelHaloWidth)
 				}
 			};
+
+			if (parentStyle.filter) {
+				childLayer.filter = parentStyle.filter;
+			}
 			if (parentStyle.minzoom) {
 				childLayer.minzoom = parentStyle.minzoom;
 			}

--- a/sites/geohub/src/components/pages/map/layers/vector/VectorLabelPanel.svelte
+++ b/sites/geohub/src/components/pages/map/layers/vector/VectorLabelPanel.svelte
@@ -56,6 +56,7 @@
 	let { layer = $bindable(), metadata = $bindable() }: Props = $props();
 
 	let parentLayerId = $state(layer.id);
+
 	let style: LayerSpecification = getLayerStyle($map, layer.id);
 	let textFieldValue = $state('');
 	let onlyNumberFields = $state(false);
@@ -85,6 +86,7 @@
 
 	onMount(() => {
 		targetLayer = style.type === 'symbol' ? layer : undefined;
+
 		let targetLayerId = targetLayer ? layer.id : `${parentLayerId}-label`;
 		if (!targetLayer) {
 			layer.children?.forEach((child) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description
In this PR.
[x] Fix bug of showing labels of polygons which have been filtered out

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [ ] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `develop` branch
- [x] No build errors after `pnpm build`
- [x] No lint errors after `pnpm lint`
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [x] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
