### PR TITLE
refactor: break vector metadata api independently

### DIFF
--- a/sites/geohub/src/lib/server/api/vector/azstorage/metadata.json/GET.ts
+++ b/sites/geohub/src/lib/server/api/vector/azstorage/metadata.json/GET.ts
@@ -1,0 +1,36 @@
+import { Endpoint, error as apiError, type RouteModifier, z } from 'sveltekit-api';
+import type { VectorTileMetadata } from '@undp-data/svelte-undp-components';
+import { getStaticPbfMetadataJson } from '$lib/server/helpers/getStaticPbfMetadataJson';
+import { error } from '@sveltejs/kit';
+
+export const Output = z
+	.custom<VectorTileMetadata>()
+	.describe(
+		'return metadata.json v1.3.0 (https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md)'
+	);
+
+export const Query = z.object({
+	pmtiles_path: z
+		.string()
+		.optional()
+		.describe('Pmtiles path. The URL should start with `pmtiles://` prefix')
+});
+
+export const Error = {
+	400: apiError(400, 'Invalid parameter')
+};
+
+export const Modifier: RouteModifier = (c) => {
+	c.summary = 'Vector tile metadata.json API';
+	c.description = 'This api is to generate metadata.json for vector tiles. ';
+	c.tags = ['vector tile'];
+	return c;
+};
+
+export default new Endpoint({ Query, Output, Modifier }).handle(async (param, { url }) => {
+	const pmtiles_path = param.pmtiles_path;
+	if (!pmtiles_path) {
+		error(400, { message: `'pbfpath' is required.` });
+	}
+	return await getStaticPbfMetadataJson(url.origin, pmtiles_path);
+});

--- a/sites/geohub/src/lib/server/api/vector/pgtileserv/metadata.json/GET.ts
+++ b/sites/geohub/src/lib/server/api/vector/pgtileserv/metadata.json/GET.ts
@@ -1,0 +1,44 @@
+import { Endpoint, z, error as apiError, type RouteModifier } from 'sveltekit-api';
+import type { VectorTileMetadata } from '@undp-data/svelte-undp-components';
+import type { TileJson } from '$lib/types/TileJson';
+import { getPgtileservTileJson } from '$lib/server/helpers/getPgtileservTileJson';
+import { generateMetadataJson } from '$lib/server/helpers/generateMetadataJson';
+import { env } from '$env/dynamic/private';
+
+export const Output = z
+	.custom<VectorTileMetadata>()
+	.describe(
+		'return metadata.json v1.3.0 (https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md)'
+	);
+
+export const Query = z.object({
+	table: z.string().optional().describe('table name.').openapi({ example: 'zambia.poverty' }),
+	type: z
+		.enum(['table', 'function'])
+		.optional()
+		.describe('type name.')
+		.openapi({ example: 'table' })
+});
+
+export const Error = {
+	400: apiError(400, 'Invalid parameter')
+};
+
+export const Modifier: RouteModifier = (c) => {
+	c.summary = 'Vector tile metadata.json API';
+	c.description = 'This api is to generate metadata.json for vector tiles. ';
+	c.tags = ['vector tile'];
+	return c;
+};
+
+export default new Endpoint({ Query, Output, Modifier }).handle(async (param) => {
+	const table = param.table;
+	const type = param.type;
+	const tilejson: TileJson = await getPgtileservTileJson(
+		table as string,
+		type as string,
+		env.PGTILESERV_API_ENDPOINT
+	);
+	const metadatajson: VectorTileMetadata = await generateMetadataJson(tilejson);
+	return metadatajson;
+});

--- a/sites/geohub/src/lib/server/helpers/getPgtileservTileJson.ts
+++ b/sites/geohub/src/lib/server/helpers/getPgtileservTileJson.ts
@@ -6,8 +6,7 @@ import type { TileJson } from '$lib/types/TileJson';
 export const getPgtileservTileJson = async (table: string, type: string, pgtileservUrl: string) => {
 	const indexJson = await getIndexJson(table, pgtileservUrl);
 	const detailUrl: string = indexJson.detailurl;
-	const tilejson = await getTileJson(detailUrl);
-	return tilejson;
+	return await getTileJson(detailUrl);
 };
 
 const getIndexJson = async (table: string, pgtileservUrl: string) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Break up the metadata service

### Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Adding tests
- [x] Others ()
<!-- ignore-task-list-end -->

### Verify the followings

<!-- ignore-task-list-start -->

- [ ] Code is up-to-date with the `develop` branch
- [ ] No build errors after `pnpm build`
- [ ] No lint errors after `pnpm lint`
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Make sure all the existing features working well
<!-- ignore-task-list-end -->

### Changesets

- [ ] If your PR makes a change under `packages` folder that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Refer to [CONTRIBUTING.MD](https://github.com/UNDP-Data/geohub/blob/develop/CONTRIBUTING.md) for more information.
